### PR TITLE
Implement chord overlay and cleanup PIXI renderer

### DIFF
--- a/src/components/game/ChordOverlay.tsx
+++ b/src/components/game/ChordOverlay.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { useChords, useGameStore } from '@/stores/gameStore';
+
+const ChordOverlay: React.FC = () => {
+  const chords = useChords();
+  const [currentChord, setCurrentChord] = useState('');
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const time = useGameStore.getState().currentTime;
+      const chord = chords.find(
+        (c) => time >= c.startTime && (c.endTime === undefined || time < c.endTime)
+      );
+      setCurrentChord(chord ? chord.symbol.displayText : '');
+    }, 100);
+    return () => clearInterval(interval);
+  }, [chords]);
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 flex items-start justify-center"
+      style={{ top: '40%' }}
+    >
+      <div className="text-white text-4xl font-bold bg-black bg-opacity-40 px-4 rounded">
+        {currentChord}
+      </div>
+    </div>
+  );
+};
+
+export default ChordOverlay;

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useCallback, useState, useRef } from 'react';
 import { useGameStore } from '@/stores/gameStore';
 import { cn } from '@/utils/cn';
 import { PIXINotesRenderer, PIXINotesRendererInstance } from './PIXINotesRenderer';
+import ChordOverlay from './ChordOverlay';
 import * as Tone from 'tone';
 import { devLog, log, perfLog } from '@/utils/logger';
 
@@ -31,7 +32,6 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     isPlaying,
     currentSong,
     currentTime,
-    chords,
     settings,
     score,
     mode,
@@ -1013,13 +1013,13 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
                 
                 <PIXINotesRenderer
                   activeNotes={engineActiveNotes}
-                  chords={chords}
                   width={idealWidth}
                   height={gameAreaSize.height}
                   currentTime={currentTime}
                   onReady={handlePixiReady}
                   className="w-full h-full"
                 />
+                <ChordOverlay />
               </div>
             </div>
           );

--- a/src/utils/gameEngine.ts
+++ b/src/utils/gameEngine.ts
@@ -790,6 +790,7 @@ export class GameEngine {
   
   private startGameLoop(): void {
     this.isGameLoopRunning = true;
+    // PIXI.Ticker.shared を使用し、unifiedFrameController と同期
     const ticker = PIXI.Ticker.shared;
 
     const gameLoop = () => {


### PR DESCRIPTION
## Summary
- add `ChordOverlay` component for HTML overlay display
- remove chord drawing logic from `PIXINotesRenderer`
- integrate overlay in `GameEngine` and adjust imports
- add comments clarifying unified frame control usage

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run type-check` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686b80120c4c8328b84dd43389160486