### PR TITLE
Improve sheet controls

### DIFF
--- a/src/components/game/ControlBar.tsx
+++ b/src/components/game/ControlBar.tsx
@@ -138,13 +138,10 @@ const ControlBar: React.FC = () => {
     transpose(1);
   }, [transpose]);
 
-  // シークバーとヘッダー表示/非表示の切り替え
-  const toggleSeekbarAndHeader = useCallback(() => {
-    updateSettings({ 
-      showSeekbar: !settings.showSeekbar,
-      showHeader: !settings.showHeader 
-    });
-  }, [updateSettings, settings.showSeekbar, settings.showHeader]);
+  // シークバー表示/非表示の切り替え
+  const toggleSeekbar = useCallback(() => {
+    updateSettings({ showSeekbar: !settings.showSeekbar });
+  }, [updateSettings, settings.showSeekbar]);
 
   // 楽譜表示の切り替え
   const toggleSheetMusic = useCallback(() => {
@@ -155,7 +152,7 @@ const ControlBar: React.FC = () => {
     <div className="w-full">
       {/* シークバー - showSeekbarフラグで制御 */}
       {settings.showSeekbar && (
-        <div className="px-3 py-2 bg-gray-900">
+        <div className="px-3 py-1 bg-gray-900">
           <div className="flex items-center space-x-3">
             <div className="relative flex-1">
               <input
@@ -166,7 +163,7 @@ const ControlBar: React.FC = () => {
                 step="0.1"
                 onChange={handleSeek}
                 disabled={!canInteract}
-                className={`w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer 
+                className={`w-full h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer
                   ${canInteract ? 'hover:bg-gray-600' : 'opacity-50 cursor-not-allowed'}
                   [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 
                   [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-500 
@@ -231,7 +228,7 @@ const ControlBar: React.FC = () => {
             <>
               <button
                 onClick={handleSkipBackward}
-                className="control-btn control-btn-secondary"
+                className="control-btn control-btn-sm control-btn-secondary"
                 title="5秒戻る"
               >
                 <FaBackward />
@@ -239,7 +236,7 @@ const ControlBar: React.FC = () => {
 
               <button
                 onClick={() => isPlaying ? pauseAction() : play()}
-                className="control-btn control-btn-primary"
+                className="control-btn control-btn-sm control-btn-primary"
                 disabled={!currentSong}
                 title={isPlaying ? '一時停止' : '再生'}
               >
@@ -248,7 +245,7 @@ const ControlBar: React.FC = () => {
 
               <button
                 onClick={handleSkipForward}
-                className="control-btn control-btn-secondary"
+                className="control-btn control-btn-sm control-btn-secondary"
                 title="5秒進む"
               >
                 <FaForward />
@@ -338,7 +335,7 @@ const ControlBar: React.FC = () => {
             <>
               <button
                 onClick={handlePlayOrRestart}
-                className="control-btn control-btn-primary"
+                className="control-btn control-btn-sm control-btn-primary"
                 disabled={!currentSong}
                 title={
                   currentTime > 0 
@@ -351,7 +348,7 @@ const ControlBar: React.FC = () => {
 
               <button
                 onClick={() => stop()}
-                className="control-btn control-btn-secondary"
+                className="control-btn control-btn-sm control-btn-secondary"
                 disabled={!currentSong}
                 title="停止"
               >
@@ -383,13 +380,13 @@ const ControlBar: React.FC = () => {
             <FaMusic />
           </button>
           
-          {/* シークバーとヘッダー表示/非表示ボタン */}
+          {/* シークバー表示/非表示ボタン */}
           <button
-            onClick={toggleSeekbarAndHeader}
+            onClick={toggleSeekbar}
             className="control-btn control-btn-xs control-btn-secondary"
-            title={settings.showSeekbar && settings.showHeader ? '全画面表示' : '全画面表示'}
+            title={settings.showSeekbar ? 'シークバーを隠す' : 'シークバーを表示'}
           >
-            {settings.showSeekbar && settings.showHeader ? <FaCompressAlt /> : <FaExpandAlt />}
+            {settings.showSeekbar ? <FaCompressAlt /> : <FaExpandAlt />}
           </button>
         </div>
       </div>
@@ -397,4 +394,4 @@ const ControlBar: React.FC = () => {
   );
 };
 
-export default ControlBar; 
+export default ControlBar;

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -783,6 +783,41 @@ const SettingsPanel: React.FC = () => {
               </div>
             </div>
 
+            {/* 楽譜表示モード */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                楽譜表示
+              </label>
+              <div className="flex items-center space-x-4 mt-1">
+                <label className="flex items-center space-x-1 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="sheet-music-mode"
+                    value="full"
+                    checked={!settings.sheetMusicChordsOnly}
+                    onChange={() =>
+                      gameActions.updateSettings({ sheetMusicChordsOnly: false })
+                    }
+                    className="radio radio-sm"
+                  />
+                  <span className="text-sm text-gray-300">ノート+コード</span>
+                </label>
+                <label className="flex items-center space-x-1 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="sheet-music-mode"
+                    value="chords-only"
+                    checked={settings.sheetMusicChordsOnly}
+                    onChange={() =>
+                      gameActions.updateSettings({ sheetMusicChordsOnly: true })
+                    }
+                    className="radio radio-sm"
+                  />
+                  <span className="text-sm text-gray-300">コードのみ</span>
+                </label>
+              </div>
+            </div>
+
             {/* 練習モードガイド設定 - 練習モード時のみ表示 */}
             {mode === 'practice' && (
               <div>
@@ -810,4 +845,4 @@ const SettingsPanel: React.FC = () => {
   );
 };
 
-export default GameScreen; 
+export default GameScreen;

--- a/src/components/game/SheetMusicDisplay.tsx
+++ b/src/components/game/SheetMusicDisplay.tsx
@@ -97,6 +97,13 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
       // 前処理されたMusicXMLを使用
       await osmdRef.current.load(processedMusicXml);
       osmdRef.current.render();
+
+      if (settings.sheetMusicChordsOnly) {
+        const noteEls = containerRef.current.querySelectorAll('[class*=notehead], [class*=rest], [class*=stem]');
+        noteEls.forEach(el => {
+          (el as HTMLElement).style.display = 'none';
+        });
+      }
       
       // レンダリング後に正確なスケールファクターを計算
       const svgElement = containerRef.current.querySelector('svg');
@@ -124,7 +131,13 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
     } finally {
       setIsLoading(false);
     }
-  }, [musicXml, notes, settings.simpleDisplayMode, settings.noteNameStyle]); // 簡易表示設定を依存関係に追加
+  }, [
+    musicXml,
+    notes,
+    settings.simpleDisplayMode,
+    settings.noteNameStyle,
+    settings.sheetMusicChordsOnly
+  ]); // 簡易表示設定を依存関係に追加
 
   // musicXmlが変更されたら楽譜を再読み込み・再レンダリング
   useEffect(() => {
@@ -274,8 +287,10 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
         targetX = prevEntry.xPosition + (nextEntry.xPosition - prevEntry.xPosition) * progress;
       }
       
-      const playheadPosition = 100; // プレイヘッドの画面上のX座標 (px)
-      const scrollX = Math.max(0, targetX - playheadPosition);
+      const playheadPosition = 120; // プレイヘッドの画面上のX座標 (px)
+      const scrollX = isPlaying
+        ? Math.max(0, targetX - playheadPosition)
+        : targetX - playheadPosition;
       
       // 再生中は滑らかなアニメーション、停止時は即座に移動
       if (isPlaying) {
@@ -355,7 +370,7 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
       {/* プレイヘッド（赤い縦線） */}
       <div 
         className="absolute top-0 bottom-0 w-0.5 bg-red-500 z-10 pointer-events-none"
-        style={{ left: '100px' }}
+        style={{ left: '120px' }}
       />
       
       {/* 楽譜コンテナ - 上部に余白を追加 */}

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -117,6 +117,7 @@ const defaultSettings: GameSettings = {
   noteNameStyle: 'abc',
   simpleDisplayMode: false,  // 新しい簡易表示モード設定を追加
   showSheetMusic: true,  // 楽譜表示のオン/オフ設定を追加
+  sheetMusicChordsOnly: false,
   
   showFPS: false,
   showSeekbar: true,  // デフォルトでシークバーを表示

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,8 @@ export interface GameSettings {
   simpleDisplayMode: boolean;
   /** 楽譜表示のオン/オフ設定 */
   showSheetMusic: boolean;
+  /** 楽譜をコードネームのみ表示 */
+  sheetMusicChordsOnly: boolean;
   showFPS: boolean;
   /** シークバーの表示/非表示 */
   showSeekbar: boolean;


### PR DESCRIPTION
## Summary
- tweak seekbar and control sizes
- add chords-only mode for sheet music
- let sheet scroll freely when paused
- move playhead slightly right
- add toggle for seekbar only

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b8e0f34688328bf994da2f7a75ebd