### PR TITLE
Add diary feature

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -18,6 +18,7 @@ export const MainLayout: React.FC = () => {
     { path: '/dashboard', label: 'ホーム', icon: '🏠' },
     { path: '/game', label: 'ゲーム', icon: '🎵' },
     { path: '/ranking', label: 'ランキング', icon: '🏆' },
+    { path: '/diary', label: '日記', icon: '✏️' },
     { path: '/lessons', label: 'レッスン', icon: '📚' },
     { path: '/profile', label: 'プロフィール', icon: '👤' },
     { path: '/settings', label: '設定', icon: '⚙️' },

--- a/src/lib/diary.ts
+++ b/src/lib/diary.ts
@@ -1,0 +1,34 @@
+import { supabase } from './supabase'
+import { Diary } from '@/types/diary'
+
+export const fetchDiaries = async (userId?: string): Promise<Diary[]> => {
+  const { data, error } = await supabase
+    .from('diaries')
+    .select('id, user_id, content, created_at, diary_likes(count), profiles(display_name)')
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return data.map((row: any) => ({
+    id: row.id,
+    userId: row.user_id,
+    content: row.content,
+    createdAt: row.created_at,
+    likes: row.diary_likes[0]?.count ?? 0,
+    likedByUser: row.diary_likes.some((l: any) => l.user_id === userId),
+    displayName: row.profiles?.display_name ?? null,
+  }))
+}
+
+export const createDiary = async (content: string): Promise<void> => {
+  const { error } = await supabase.from('diaries').insert({ content })
+  if (error) throw error
+}
+
+export const toggleLike = async (diaryId: string, liked: boolean): Promise<void> => {
+  if (liked) {
+    const { error } = await supabase.from('diary_likes').delete().match({ diary_id: diaryId })
+    if (error) throw error
+  } else {
+    const { error } = await supabase.from('diary_likes').insert({ diary_id: diaryId })
+    if (error) throw error
+  }
+}

--- a/src/pages/DiaryPage.tsx
+++ b/src/pages/DiaryPage.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { fetchDiaries, createDiary, toggleLike } from '@/lib/diary'
+import { Diary } from '@/types/diary'
+
+export const DiaryPage: React.FC = () => {
+  const { state } = useAuth()
+  const [diaries, setDiaries] = useState<Diary[]>([])
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  const load = async () => {
+    setLoading(true)
+    const data = await fetchDiaries(state.user?.id)
+    setDiaries(data)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    load()
+  }, [state.user])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!content.trim()) return
+    await createDiary(content.trim())
+    setContent('')
+    load()
+  }
+
+  const handleLike = async (diary: Diary) => {
+    await toggleLike(diary.id, diary.likedByUser ?? false)
+    load()
+  }
+
+  if (!state.user) return <div>読み込み中...</div>
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">日記</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="w-full p-2 border rounded"
+          rows={3}
+          maxLength={280}
+          placeholder="今日の練習内容を記録しよう"
+        />
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          投稿
+        </button>
+      </form>
+      {loading ? (
+        <div>読み込み中...</div>
+      ) : (
+        <ul className="space-y-4">
+          {diaries.map((d) => (
+            <li key={d.id} className="bg-white p-4 rounded shadow">
+              <div className="text-sm text-gray-500 mb-1">
+                {d.displayName || '名無し'} / {new Date(d.createdAt).toLocaleDateString('ja-JP')}
+              </div>
+              <p className="whitespace-pre-wrap mb-2">{d.content}</p>
+              <button
+                onClick={() => handleLike(d)}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                {d.likedByUser ? 'いいね解除' : 'いいね'} ({d.likes})
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default DiaryPage

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -11,6 +11,7 @@ import { LessonsPage } from '../pages/LessonsPage'
 import { GamePage } from '../pages/GamePage'
 import { ProfilePage } from '../pages/ProfilePage'
 import { SettingsPage } from '../pages/SettingsPage'
+import { DiaryPage } from '../pages/DiaryPage'
 
 const router = createBrowserRouter([
   {
@@ -44,6 +45,14 @@ const router = createBrowserRouter([
       {
         path: 'ranking',
         element: <RankingPage />,
+      },
+      {
+        path: 'diary',
+        element: (
+          <ProtectedRoute>
+            <DiaryPage />
+          </ProtectedRoute>
+        ),
       },
       {
         path: 'lessons',

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -1,0 +1,9 @@
+export interface Diary {
+  id: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  likes: number;
+  likedByUser?: boolean;
+  displayName?: string | null;
+}

--- a/supabase/migrations/20250709150000_create_diaries_tables.sql
+++ b/supabase/migrations/20250709150000_create_diaries_tables.sql
@@ -1,0 +1,32 @@
+-- Create diaries table
+CREATE TABLE IF NOT EXISTS public.diaries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc', now()) NOT NULL
+);
+
+-- Enable RLS
+ALTER TABLE public.diaries ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Public diaries are viewable" ON public.diaries
+  FOR SELECT USING (true);
+CREATE POLICY "Users can insert their own diary" ON public.diaries
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can delete their own diary" ON public.diaries
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Likes table
+CREATE TABLE IF NOT EXISTS public.diary_likes (
+  diary_id UUID REFERENCES public.diaries(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  PRIMARY KEY (diary_id, user_id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc', now()) NOT NULL
+);
+
+ALTER TABLE public.diary_likes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can like diaries" ON public.diary_likes
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can unlike their like" ON public.diary_likes
+  FOR DELETE USING (auth.uid() = user_id);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -56,5 +56,15 @@ INSERT INTO public.profiles (
 ON CONFLICT (id) DO NOTHING;
 
 -- Note: In a real environment, these users would need to be created
--- through Supabase Auth first, then the trigger would automatically
--- create their profiles. This seed data is for development/testing only.
+-- through Supabase Auth first, then the trigger would automatically-- create their profiles. This seed data is for development/testing only.
+-- Sample diary entries
+INSERT INTO public.diaries (user_id, content)
+VALUES
+  ('b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', '初めての練習記録です！'),
+  ('c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', '今日はスケール練習をしました。');
+
+-- Sample likes
+INSERT INTO public.diary_likes (diary_id, user_id)
+SELECT d.id, 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44'
+FROM public.diaries d
+LIMIT 1;


### PR DESCRIPTION
## Summary
- implement diaries table and seed data
- add diary types and supabase client functions
- create DiaryPage with posting and like support
- add diary route and navigation

## Testing
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_686d080df4348328a6d897c1c6d40a8a