### PR TITLE
Fix build error in user types

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -61,8 +61,20 @@ export const MemberRankConfig: Record<MemberRank, MemberRankInfo> = {
   },
 }
 
+export function getRankByExp(exp: number): MemberRank {
+  if (exp >= MemberRankConfig[MemberRank.PLATINUM].minExp) {
+    return MemberRank.PLATINUM
+  }
+  if (exp >= MemberRankConfig[MemberRank.PREMIUM].minExp) {
+    return MemberRank.PREMIUM
+  }
+  if (exp >= MemberRankConfig[MemberRank.STANDARD].minExp) {
+    return MemberRank.STANDARD
+  }
+  return MemberRank.FREE
+}
+
 export interface UserPreferences {
-＝
   theme: 'light' | 'dark' | 'system'
   language: 'ja' | 'en'
   notifications: {
@@ -75,5 +87,4 @@ export interface UserPreferences {
     showProfile: boolean
     showRank: boolean
     showProgress: boolean
-  }
-}
+  }}


### PR DESCRIPTION
## Summary
- remove stray full-width character in `UserPreferences` definition
- add `getRankByExp` helper to compute rank from experience

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d631ba7288328a512d120e3866aa5