### PR TITLE
Delay heavy module load until login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import LandingPage from '@/components/LandingPage';
 import AuthLanding from '@/components/auth/AuthLanding';
-import LegacyApp from './LegacyApp';
 import { useAuthStore } from '@/stores/authStore';
+
+// LegacyApp はバンドルサイズが大きいため遅延読み込みする
+const LegacyApp = React.lazy(() => import('./LegacyApp'));
 
 const App: React.FC = () => {
   const { user, isGuest } = useAuthStore();
@@ -14,12 +16,20 @@ const App: React.FC = () => {
   }
 
   return (
-    <Routes>
-      <Route path="/" element={<LandingPage />} />
-      <Route path="/auth" element={<AuthLanding />} />
-      <Route path="/main" element={<LegacyApp />} />
-      <Route path="/*" element={<LegacyApp />} />
-    </Routes>
+    <Suspense
+      fallback={
+        <div className="w-full h-screen flex items-center justify-center text-white">
+          Loading...
+        </div>
+      }
+    >
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/auth" element={<AuthLanding />} />
+        <Route path="/main" element={<LegacyApp />} />
+        <Route path="/*" element={<LegacyApp />} />
+      </Routes>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
## Summary
- lazy-load LegacyApp so heavy game assets load after login

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68765360d7808328bcd842466de70a7f