### PR TITLE
Fix realtime init loop

### DIFF
--- a/src/components/diary/DiaryFeed.tsx
+++ b/src/components/diary/DiaryFeed.tsx
@@ -22,6 +22,8 @@ const DiaryFeed: React.FC = () => {
   const [editingId, setEditingId] = useState<string|null>(null);
   const [editText, setEditText] = useState<string>('');
   const toast = useToast();
+  // Initialize realtime channels when the feed mounts
+  useEffect(() => { useDiaryStore.getState().initRealtime(); }, []);
   useEffect(() => { void fetchAll(); }, []);
   useEffect(() => {
     diaries.forEach(d => {

--- a/src/stores/diaryStore.ts
+++ b/src/stores/diaryStore.ts
@@ -133,5 +133,6 @@ export const useDiaryStore = create<DiaryState & DiaryActions>()(
   }))
 );
 
-// 自動でリアルタイム初期化
-useDiaryStore.getState().initRealtime(); 
+// NOTE: Realtime initialization is now triggered from the UI to avoid
+// creating multiple channels inadvertently during hot reloads or when the
+// store is imported in different contexts.


### PR DESCRIPTION
## Summary
- remove automatic realtime initialization from store
- init realtime on DiaryFeed mount instead

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails: TS2349 in ProfileWizard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68772056960083289d16c337e6d5c8fe