### PR TITLE
Add mission page and ranking features

### DIFF
--- a/src/LegacyApp.tsx
+++ b/src/LegacyApp.tsx
@@ -210,6 +210,12 @@ const App: React.FC = () => {
     case '#ranking':
       MainContent = <LevelRanking />;
       break;
+    case '#missions':
+      MainContent = <MissionPage />;
+      break;
+    case '#mission-ranking':
+      MainContent = <MissionRanking />;
+      break;
     case '#information':
       MainContent = <InformationPage />;
       break;

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -32,7 +32,7 @@ const Dashboard: React.FC = () => {
   const [latestAnnouncement, setLatestAnnouncement] = useState<Announcement | null>(null);
   const [loading, setLoading] = useState(true);
   const { profile, isGuest } = useAuthStore();
-  const { weekly: challenges, monthly: missions, fetchAll: loadMissions } = useMissionStore();
+  const { monthly: missions, fetchAll: loadMissions } = useMissionStore();
   const toast = useToast();
 
   useEffect(() => {
@@ -226,24 +226,26 @@ const Dashboard: React.FC = () => {
 
               {/* クイックアクション */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {/* 今日のチャレンジ */}
+                {/* 今日のミッション */}
                 <button
                   onClick={() => { window.location.hash = '#missions'; }}
                   className="bg-slate-800 rounded-lg p-6 border border-slate-700 hover:border-primary-500 transition-colors text-left"
                 >
                   <div className="flex items-center space-x-3 mb-3">
                     <FaBullseye className="w-6 h-6 text-orange-400" />
-                    <h3 className="text-lg font-semibold">今日のチャレンジ</h3>
+                    <h3 className="text-lg font-semibold">今日のミッション</h3>
                   </div>
                   
-                  {challenges.length > 0 ? (
+                  {missions.length > 0 ? (
                     <div className="space-y-2">
-                      <p className="text-sm text-gray-300">{challenges[0].title}</p>
+                      <p className="text-sm text-gray-300">{missions[0].title}</p>
                       <div className="flex items-center space-x-2 text-xs text-gray-400">
-                        <span>{challenges[0].reward_multiplier}x ボーナス</span>
+                        <span>{missions[0].reward_multiplier}x ボーナス</span>
                       </div>
                     </div>
                   ) : (
+                    <p className="text-sm text-gray-400">ミッションを確認</p>
+                  )}
                     <p className="text-sm text-gray-400">チャレンジを確認</p>
                   )}
                 </button>

--- a/src/components/mission/ChallengeBoard.tsx
+++ b/src/components/mission/ChallengeBoard.tsx
@@ -3,19 +3,13 @@ import { useMissionStore } from '@/stores/missionStore';
 import ChallengeCard from './ChallengeCard';
 
 const ChallengeBoard: React.FC = () => {
-  const { weekly, monthly, progress, loading, fetchAll } = useMissionStore();
+  const { monthly, progress, loading, fetchAll } = useMissionStore();
   useEffect(()=>{ void fetchAll(); },[]);
 
   if (loading) return <p className="text-center text-gray-400">Loading...</p>;
 
   return (
     <div className="space-y-6">
-      <section>
-        <h3 className="font-bold mb-2 text-lg">Weekly Challenge</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {weekly.map(m => <ChallengeCard key={m.id} mission={m} progress={progress[m.id]} />)}
-        </div>
-      </section>
       <section>
         <h3 className="font-bold mb-2 text-lg">Monthly Mission</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -25,4 +19,4 @@ const ChallengeBoard: React.FC = () => {
     </div>
   );
 };
-export default ChallengeBoard; 
+export default ChallengeBoard;

--- a/src/components/mission/ChallengeCard.tsx
+++ b/src/components/mission/ChallengeCard.tsx
@@ -78,6 +78,13 @@ const ChallengeCard: React.FC<Props> = ({ mission, progress }) => {
         </div>
       )}
 
+        {mission.songs && mission.songs.length > 0 && (
+          <ul className="text-xs text-gray-300 list-disc pl-4 space-y-1">
+            {mission.songs.map(s => (
+              <li key={s.song_id}>{s.songs?.title || s.song_id}</li>
+            ))}
+          </ul>
+        )}
       {/* 詳細進捗バー */}
       <div className="space-y-2">
         <div className="flex justify-between items-center">

--- a/src/components/mission/ChallengeProgressWidget.tsx
+++ b/src/components/mission/ChallengeProgressWidget.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useMissionStore } from '@/stores/missionStore';
 
 const ChallengeProgressWidget: React.FC = () => {
-  const { weekly, monthly, progress, loading, fetchAll, claim } = useMissionStore();
+  const { monthly, progress, loading, fetchAll, claim } = useMissionStore();
 
   useEffect(() => {
     fetchAll();
@@ -12,38 +12,6 @@ const ChallengeProgressWidget: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      {weekly.length > 0 && (
-        <section>
-          <h3 className="font-bold mb-2 text-lg">ウィークリーチャレンジ</h3>
-          <ul className="space-y-3">
-            {weekly.map(ch => {
-              const prog = progress[ch.id];
-              const max = ch.min_clear_count ?? ch.diary_count ?? 1;
-              const current = prog?.clear_count ?? 0;
-              const ratio = Math.min(1, current / max);
-              return (
-                <li key={ch.id} className="p-3 rounded bg-slate-800/50">
-                  <div className="flex justify-between items-center mb-1">
-                    <span className="text-sm font-medium">{ch.title}</span>
-                    <span className="text-xs">{current}/{max}</span>
-                  </div>
-                  <div className="w-full bg-slate-700 rounded h-2 overflow-hidden mb-2">
-                    <div style={{ width: `${ratio*100}%` }} className="h-full bg-teal-400" />
-                  </div>
-                  {prog?.completed ? (
-                    <span className="badge badge-success badge-sm">達成済み</span>
-                  ) : (
-                    current >= max ? (
-                      <button className="btn btn-xs btn-primary" onClick={()=>claim(ch.id)}>報酬を受け取る</button>
-                    ) : null
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-      )}
-
       {monthly.length > 0 && (
         <section>
           <h3 className="font-bold mb-2 text-lg">マンスリーミッション</h3>
@@ -79,4 +47,4 @@ const ChallengeProgressWidget: React.FC = () => {
   );
 };
 
-export default ChallengeProgressWidget; 
+export default ChallengeProgressWidget;

--- a/src/components/mission/MissionPage.tsx
+++ b/src/components/mission/MissionPage.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import GameHeader from '@/components/ui/GameHeader';
+import ChallengeBoard from './ChallengeBoard';
+import { useMissionStore } from '@/stores/missionStore';
+
+const MissionPage: React.FC = () => {
+  const [open, setOpen] = useState(window.location.hash === '#missions');
+  const { fetchAll } = useMissionStore();
+
+  useEffect(() => {
+    const handler = () => setOpen(window.location.hash === '#missions');
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
+  useEffect(() => {
+    if (open) void fetchAll();
+  }, [open, fetchAll]);
+
+  if (!open) return null;
+
+  return (
+    <div className="w-full h-full flex flex-col bg-gradient-game text-white">
+      <GameHeader />
+      <div className="flex-1 overflow-y-auto p-4">
+        <ChallengeBoard />
+      </div>
+    </div>
+  );
+};
+
+export default MissionPage;

--- a/src/components/ranking/MissionRanking.tsx
+++ b/src/components/ranking/MissionRanking.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { fetchMissionRanking, MissionRankingEntry } from '@/platform/supabaseRanking';
+import { useMissionStore } from '@/stores/missionStore';
+import GameHeader from '@/components/ui/GameHeader';
+import { DEFAULT_AVATAR_URL } from '@/utils/constants';
+
+const MissionRanking: React.FC = () => {
+  const [open, setOpen] = useState(window.location.hash === '#mission-ranking');
+  const [entries, setEntries] = useState<MissionRankingEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { monthly } = useMissionStore();
+  const [missionId, setMissionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = () => setOpen(window.location.hash === '#mission-ranking');
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
+  useEffect(() => {
+    if (open && monthly.length > 0 && !missionId) {
+      setMissionId(monthly[0].id);
+    }
+  }, [open, monthly, missionId]);
+
+  useEffect(() => {
+    if (open && missionId) {
+      (async () => {
+        setLoading(true);
+        try {
+          const data = await fetchMissionRanking(missionId);
+          setEntries(data);
+        } finally {
+          setLoading(false);
+        }
+      })();
+    }
+  }, [open, missionId]);
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    window.location.href = '/main#dashboard';
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col bg-gradient-game text-white">
+      <GameHeader />
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {monthly.length > 1 && (
+          <select
+            className="select select-bordered text-white"
+            value={missionId ?? ''}
+            onChange={(e)=>setMissionId(e.target.value)}
+          >
+            {monthly.map(m => (
+              <option key={m.id} value={m.id}>{m.title}</option>
+            ))}
+          </select>
+        )}
+        {loading ? (
+          <p className="text-center text-gray-400">Loading...</p>
+        ) : entries.length === 0 ? (
+          <p className="text-center text-gray-400">ランキングデータがありません</p>
+        ) : (
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-slate-700 text-left">
+                <th className="py-2 px-2">#</th>
+                <th className="py-2 px-2">ユーザー</th>
+                <th className="py-2 px-2">回数</th>
+                <th className="py-2 px-2">レベル</th>
+                <th className="py-2 px-2">ランク</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e, idx) => (
+                <tr key={e.user_id} className="border-b border-slate-800 hover:bg-slate-800/50">
+                  <td className="py-1 px-2">{idx + 1}</td>
+                  <td className="py-1 px-2 flex items-center gap-2">
+                    <img src={e.avatar_url || DEFAULT_AVATAR_URL} className="w-6 h-6 rounded-full" />
+                    <span>{e.nickname}</span>
+                  </td>
+                  <td className="py-1 px-2">{e.clear_count}</td>
+                  <td className="py-1 px-2">{e.level}</td>
+                  <td className="py-1 px-2">{e.rank}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <button className="btn btn-sm btn-outline mt-4" onClick={handleClose}>ダッシュボードに戻る</button>
+      </div>
+    </div>
+  );
+};
+
+export default MissionRanking;

--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -37,6 +37,8 @@ const GameHeader: React.FC = () => {
 
           <HashButton hash="#lessons">レッスン</HashButton>
           <HashButton hash="#ranking">ランキング</HashButton>
+          <HashButton hash="#mission-ranking">ミッションランキング</HashButton>
+          <HashButton hash="#missions">ミッション</HashButton>
           <HashButton hash="#diary">日記</HashButton>
           <HashButton hash="#information">お知らせ</HashButton>
         </div>

--- a/src/platform/supabaseMissions.ts
+++ b/src/platform/supabaseMissions.ts
@@ -1,5 +1,15 @@
 import { getSupabaseClient, fetchWithCache, clearSupabaseCache } from '@/platform/supabaseClient';
 
+export interface MissionSong {
+  song_id: string;
+  key_offset: number;
+  min_speed: number;
+  min_rank: string;
+  min_clear_count: number;
+  notation_setting: string;
+  songs?: { id: string; title: string; artist?: string };
+}
+
 export interface Mission {
   id: string;
   type: 'weekly' | 'monthly';
@@ -10,6 +20,7 @@ export interface Mission {
   end_date: string;
   min_clear_count?: number | null;
   reward_multiplier: number;
+  songs?: MissionSong[];
 }
 
 export interface UserMissionProgress {
@@ -24,7 +35,7 @@ export async function fetchActiveMonthlyMissions(): Promise<Mission[]> {
   const { data, error } = await fetchWithCache(key, async () =>
     await getSupabaseClient()
       .from('challenges')
-      .select('*')
+      .select('*, challenge_songs(*, songs(id,title,artist))')
       .eq('type','monthly')
       .lte('start_date', today)
       .gte('end_date', today),
@@ -34,28 +45,21 @@ export async function fetchActiveMonthlyMissions(): Promise<Mission[]> {
   return data as Mission[];
 }
 
+export async function fetchMissionSongs(missionId: string): Promise<MissionSong[]> {
+  const { data, error } = await getSupabaseClient()
+    .from('challenge_songs')
+    .select('*, songs(id,title,artist)')
+    .eq('challenge_id', missionId);
+  if (error) throw error;
+  return data as MissionSong[];
+}
+
 export async function incrementDiaryProgress(missionId: string) {
   const supabase = getSupabaseClient();
   const { data:{ user } } = await supabase.auth.getUser();
   if (!user) return;
   await supabase.rpc('increment_diary_progress',{ _user_id:user.id, _mission_id:missionId });
   clearSupabaseCache();
-}
-
-export async function fetchWeeklyChallenges() {
-  const today = new Date().toISOString().substring(0,10);
-  const key = `missions:weekly:${today}`;
-  const { data, error } = await fetchWithCache(key, async () =>
-    await getSupabaseClient()
-      .from('challenges')
-      .select('*')
-      .eq('type','weekly')
-      .lte('start_date', today)
-      .gte('end_date', today),
-    1000*30,
-  );
-  if (error) throw error;
-  return data as Mission[];
 }
 
 export async function fetchUserMissionProgress(): Promise<UserMissionProgress[]> {
@@ -75,16 +79,14 @@ export async function claimReward(missionId: string) {
   const supabase = getSupabaseClient();
   const { data:{ user } } = await supabase.auth.getUser();
   if (!user) return;
-  // mark completed true (if not) and maybe set multiplier; simplified here
   await supabase.from('user_challenge_progress')
     .update({ completed: true })
     .eq('user_id', user.id)
     .eq('challenge_id', missionId);
 
-  // update profile multiplier
   const { data: prof } = await supabase.from('profiles').select('next_season_xp_multiplier').eq('id', user.id).single();
   const current = prof?.next_season_xp_multiplier ?? 1;
   const updated = Math.max(current, 1.3);
   await supabase.from('profiles').update({ next_season_xp_multiplier: updated }).eq('id', user.id);
   clearSupabaseCache();
-} 
+}

--- a/src/platform/supabaseRanking.ts
+++ b/src/platform/supabaseRanking.ts
@@ -35,3 +35,31 @@ export async function fetchLevelRanking(limit = 100): Promise<RankingEntry[]> {
   
   return filteredData as RankingEntry[];
 } 
+export interface MissionRankingEntry {
+  user_id: string;
+  clear_count: number;
+  nickname: string;
+  avatar_url?: string;
+  level: number;
+  rank: string;
+}
+
+export async function fetchMissionRanking(missionId: string, limit = 100): Promise<MissionRankingEntry[]> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from('user_challenge_progress')
+    .select('user_id, clear_count, profiles(nickname, avatar_url, level, rank)')
+    .eq('challenge_id', missionId)
+    .eq('completed', true)
+    .order('clear_count', { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []).map((d: any) => ({
+    user_id: d.user_id,
+    clear_count: d.clear_count,
+    nickname: d.profiles.nickname,
+    avatar_url: d.profiles.avatar_url,
+    level: d.profiles.level,
+    rank: d.profiles.rank,
+  }));
+}

--- a/src/stores/missionStore.ts
+++ b/src/stores/missionStore.ts
@@ -1,9 +1,8 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { Mission, UserMissionProgress, fetchWeeklyChallenges, fetchActiveMonthlyMissions, fetchUserMissionProgress, claimReward } from '@/platform/supabaseMissions';
+import { Mission, UserMissionProgress, fetchActiveMonthlyMissions, fetchUserMissionProgress, claimReward } from '@/platform/supabaseMissions';
 
 interface State {
-  weekly: Mission[];
   monthly: Mission[];
   progress: Record<string, UserMissionProgress>;
   loading: boolean;
@@ -15,21 +14,19 @@ interface Actions {
 
 export const useMissionStore = create<State & Actions>()(
   immer((set, get) => ({
-    weekly: [],
     monthly: [],
     progress: {},
     loading: false,
 
     fetchAll: async () => {
       set(s=>{s.loading=true;});
-      const [w,m,p] = await Promise.all([
-        fetchWeeklyChallenges(),
+      const [missions, progress] = await Promise.all([
         fetchActiveMonthlyMissions(),
         fetchUserMissionProgress(),
       ]);
       const progMap:Record<string,UserMissionProgress> = {};
-      p.forEach(pr=>{progMap[pr.challenge_id]=pr;});
-      set(s=>{s.weekly=w; s.monthly=m; s.progress=progMap; s.loading=false;});
+      progress.forEach(pr=>{progMap[pr.challenge_id]=pr;});
+      set(s=>{s.monthly=missions; s.progress=progMap; s.loading=false;});
     },
 
     claim: async(id:string)=>{
@@ -37,4 +34,4 @@ export const useMissionStore = create<State & Actions>()(
       await get().fetchAll();
     }
   }))
-); 
+);


### PR DESCRIPTION
## Summary
- integrate challenge songs with missions
- remove weekly challenge UI and state
- add mission page and mission ranking
- link missions in GameHeader and dashboard

## Testing
- `npm run lint` *(fails: node unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68772eb3ccc48328b84b0b5b552711ce