### PR TITLE
Fix JSX syntax error in Dashboard

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -246,8 +246,6 @@ const Dashboard: React.FC = () => {
                   ) : (
                     <p className="text-sm text-gray-400">ミッションを確認</p>
                   )}
-                    <p className="text-sm text-gray-400">チャレンジを確認</p>
-                  )}
                 </button>
 
                 {/* 曲練習 */}


### PR DESCRIPTION
## Summary
- remove stray closing braces in `Dashboard.tsx` that broke JSX

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877360b982c83288e4d63c923ce2099