### PR TITLE
Fix context switching bug

### DIFF
--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -135,6 +135,9 @@ const GameScreen: React.FC = () => {
             }
           }
           
+          // 事前にミッションコンテキストをクリア
+          gameActions.clearMissionContext();
+
           // レッスンコンテキストを設定
           if (lessonId) {
             gameActions.setLessonContext(lessonId, {
@@ -326,6 +329,9 @@ const GameScreen: React.FC = () => {
             }
           }
           
+          // 事前にレッスンコンテキストをクリア
+          gameActions.clearLessonContext();
+
           // ミッションコンテキストを設定
           gameActions.setMissionContext(missionId, songId, {
             key: challengeSong.key_offset,

--- a/src/components/game/ResultModal.tsx
+++ b/src/components/game/ResultModal.tsx
@@ -16,7 +16,14 @@ const ResultModal: React.FC = () => {
     settings: s.settings,
     resultModalOpen: s.resultModalOpen
   }));
-  const { closeResultModal, resetScore, seek, setCurrentTab } = useGameActions();
+  const {
+    closeResultModal,
+    resetScore,
+    seek,
+    setCurrentTab,
+    clearLessonContext,
+    clearMissionContext
+  } = useGameActions();
 
   const { profile, fetchProfile } = useAuthStore();
   const lessonContext = useLessonContext();
@@ -334,6 +341,9 @@ const ResultModal: React.FC = () => {
     resetScore();
     seek(0);
     closeResultModal();
+    // 曲選択に戻る際はレッスン・ミッションコンテキストをクリア
+    clearLessonContext();
+    clearMissionContext();
     setCurrentTab('songs');
     setXpProcessed(false);
   };


### PR DESCRIPTION
## Summary
- clear mission context before starting a lesson
- clear lesson context before starting a mission
- when returning to song selection, clear both contexts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e658e488328a9d714dd99a7f94c