### PR TITLE
Fix monster centering and audio handling

### DIFF
--- a/src/components/fantasy/FantasySettingsModal.tsx
+++ b/src/components/fantasy/FantasySettingsModal.tsx
@@ -87,8 +87,14 @@ const FantasySettingsModal: React.FC<FantasySettingsModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 overflow-y-auto"
+      onClick={onClose}
+    >
+      <div
+        className="bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-bold text-white">ファンタジーモード設定</h2>
           <button


### PR DESCRIPTION
## Summary
- center monster renderer and piano canvas using container size
- update enemy HP via PIXI renderer callback
- use ColorMatrixFilter to grayscale monster sprite
- stop piano notes on key release
- allow scrolling and outside click for settings modal

## Testing
- `npm run lint` *(fails: 406 errors)*
- `npm run type-check` *(fails: TS2322 in FantasyStageSelect)*

------
https://chatgpt.com/codex/tasks/task_e_687eef17c5c88328805385ba716ce077