### PR TITLE
鍵盤ハイライトon/off機能修正

### DIFF
--- a/src/components/fantasy/FantasySettingsModal.tsx
+++ b/src/components/fantasy/FantasySettingsModal.tsx
@@ -13,6 +13,7 @@ interface FantasySettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSettingsChange?: (settings: FantasySettings) => void;
+  initialSettings?: Partial<FantasySettings>;
 }
 
 interface FantasySettings {
@@ -24,13 +25,21 @@ interface FantasySettings {
 const FantasySettingsModal: React.FC<FantasySettingsModalProps> = ({
   isOpen,
   onClose,
-  onSettingsChange
+  onSettingsChange,
+  initialSettings
 }) => {
   const [settings, setSettings] = useState<FantasySettings>({
     midiDeviceId: null,
     volume: 0.8,
-    showGuide: false
+    showGuide: false,
+    ...initialSettings
   });
+  
+  useEffect(() => {
+    if (initialSettings) {
+      setSettings(prev => ({ ...prev, ...initialSettings }));
+    }
+  }, [initialSettings]);
   
   const [midiController, setMidiController] = useState<MIDIController | null>(null);
   const [isConnected, setIsConnected] = useState(false);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement dynamic keyboard highlight ON/OFF in Fantasy Mode to reflect real-time setting changes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the keyboard highlight (guide) setting was not dynamically applied from the settings modal to the game screen, failing to reflect real-time changes or update highlights based on the current chord. This PR introduces dynamic state management and ensures immediate application of `showGuide` settings to the PIXI renderer, including highlighting current chord notes.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5a3fcd62-99f8-444c-8945-1b5abde0c154) · [Cursor](https://cursor.com/background-agent?bcId=bc-5a3fcd62-99f8-444c-8945-1b5abde0c154)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)