### PR TITLE
ファンタジーモードの改善とバグ修正

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -626,8 +626,8 @@ export const useFantasyGameEngine = ({
       // 入力バッファをクリア
       setInputBuffer([]);
       
-      // 次の問題へ（敵切り替えの遅延を追加）
-      setTimeout(proceedToNextQuestion, 500);
+      // 次の問題へ（待機時間を 0 に変更）
+      setTimeout(proceedToNextQuestion, 0);
       
     } else {
       devLog.debug('🎵 まだ構成音が足りません', { 

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -121,6 +121,18 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // MIDI/音声入力のハンドリング
   const handleNoteInputBridge = useCallback(async (note: number) => {
+    // キーボードハイライト & ヒットエフェクト
+    if (pixiRenderer) {
+      pixiRenderer.highlightKey(note, true);
+      pixiRenderer.triggerKeyPressEffect(note);
+      // 少し遅れてハイライトを解除
+      setTimeout(() => {
+        if (pixiRenderer) {
+          pixiRenderer.highlightKey(note, false);
+        }
+      }, 150);
+    }
+
     // 音声システムの初期化（初回のみ）
     try {
       await initializeAudioSystem();
@@ -134,7 +146,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     // ファンタジーゲームエンジンにも送信
     engineHandleNoteInput(note);
-  }, [handleNoteInput, engineHandleNoteInput]);
+  }, [handleNoteInput, engineHandleNoteInput, pixiRenderer]);
   
   // PIXI.jsレンダラーの準備完了ハンドラー
   const handlePixiReady = useCallback((renderer: PIXINotesRendererInstance | null) => {

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -526,7 +526,7 @@ export class FantasyPIXIInstance {
     
     // 新しい魔法名テキスト作成
     this.magicNameText = new PIXI.Text(magicName, {
-      fontFamily: 'Gothic16, Arial, sans-serif', // Gothic16を追加
+      fontFamily: 'DotGothic16, "DotGothic16", Gothic16, Arial, sans-serif', // Pixel style font
       fontSize: 36,
       fontWeight: 'bold',
       fill: 0xFFFFFF,
@@ -626,40 +626,38 @@ export class FantasyPIXIInstance {
 
   // モンスターアニメーション更新
   private updateMonsterAnimation(): void {
-    // nullチェックを強化
-    if (!this.monsterSprite || this.isDestroyed || this.monsterSprite.destroyed) {
+    // ローカル参照を取得して、更新途中に this.monsterSprite が破棄されても
+    // 例外にならないようにする
+    const sprite = this.monsterSprite;
+    if (!sprite || this.isDestroyed || sprite.destroyed) {
       return;
     }
-    
+
     try {
-      // 追加のnullチェック - プロパティアクセス前に確認
-      if (!this.monsterSprite || typeof this.monsterSprite.x === 'undefined') {
-        devLog.debug('⚠️ モンスタースプライトが無効な状態です');
+      // プロパティ存在チェック
+      if (typeof sprite.x === 'undefined') {
+        devLog.debug('⚠️ モンスタースプライトが無効な状態です (prop undefined)');
         return;
       }
-      
+
       // よろけ効果の適用
-      this.monsterSprite.x = this.monsterState.x + this.monsterState.staggerOffset.x;
-      this.monsterSprite.y = this.monsterState.y + this.monsterState.staggerOffset.y;
-      
+      sprite.x = this.monsterState.x + this.monsterState.staggerOffset.x;
+      sprite.y = this.monsterState.y + this.monsterState.staggerOffset.y;
+
       // 色変化の適用
-      if (this.monsterState.isHit) {
-        this.monsterSprite.tint = this.monsterState.hitColor;
-      } else {
-        this.monsterSprite.tint = this.monsterState.originalColor;
-      }
-      
+      sprite.tint = this.monsterState.isHit ? this.monsterState.hitColor : this.monsterState.originalColor;
+
       // よろけ効果の減衰
       this.monsterState.staggerOffset.x *= 0.9;
       this.monsterState.staggerOffset.y *= 0.9;
-      
+
       // アイドル時の軽い浮遊効果
       if (!this.monsterState.isAttacking && !this.monsterState.isHit) {
-        this.monsterSprite.y += Math.sin(Date.now() * 0.002) * 0.5;
+        sprite.y += Math.sin(Date.now() * 0.002) * 0.5;
       }
     } catch (error) {
       devLog.debug('⚠️ モンスターアニメーション更新エラー:', error);
-      // エラー時はmonsterSpriteをnullにして以降の処理をスキップ
+      // エラー時は次フレーム以降の更新を防止
       this.monsterSprite = null;
     }
   }

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -318,7 +318,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
   // ローディング画面
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center fantasy-game-screen">
         <div className="text-white text-center">
           <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-white mx-auto mb-4"></div>
           <h2 className="text-2xl font-bold">ファンタジーモード読み込み中...</h2>
@@ -330,7 +330,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
   // エラー画面
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center fantasy-game-screen">
         <div className="text-white text-center max-w-md">
           <div className="text-6xl mb-4">😵</div>
           <h2 className="text-2xl font-bold mb-4">エラーが発生しました</h2>
@@ -360,7 +360,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
   const totalCleared = userProgress ? userProgress.totalClearedStages : 0;
   
   return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 overflow-y-auto">
+    <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 overflow-y-auto fantasy-game-screen">
       {/* ヘッダー */}
       <div className="relative z-10 p-6 text-white">
         <div className="flex justify-between items-center">


### PR DESCRIPTION
Fix fantasy mode monster animation null error, adjust game flow timing, apply consistent fonts, and enable keyboard highlights.

The `Global Error: Cannot set properties of null (setting 'x')` in `updateMonsterAnimation` was due to `this.monsterSprite` potentially becoming null mid-frame after an initial null check, leading to a crash. This PR addresses it by using a local sprite reference to ensure consistent access. Additionally, keyboard highlights were missing for external inputs in fantasy mode, which is now resolved by explicitly calling `highlightKey` and `triggerKeyPressEffect` on note input.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e6213d0e-b96f-48d9-8be4-8117bb32889f) · [Cursor](https://cursor.com/background-agent?bcId=bc-e6213d0e-b96f-48d9-8be4-8117bb32889f)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)