### PR TITLE
敵アイコンのawesome font表示を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "jazz-learning-game",
       "version": "1.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@stripe/stripe-js": "^2.4.0",
         "@supabase/supabase-js": "^2.39.5",
         "class-variance-authority": "^0.7.1",
@@ -872,6 +875,52 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@gar/promisify": {
@@ -7337,7 +7386,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7501,7 +7549,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "clean": "rm -rf dist node_modules/.vite"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@stripe/stripe-js": "^2.4.0",
     "@supabase/supabase-js": "^2.39.5",
     "class-variance-authority": "^0.7.1",

--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -4,22 +4,23 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { 
-  FaGhost,
-  FaTree, 
-  FaSeedling,
-  FaTint,
-  FaSun,
-  FaCube,
-  FaStar,
-  FaGem,
-  FaWind,
-  FaBolt,
-  FaDragon,
-  FaSkull,
-  FaFire,
-  FaSnowflake
-} from 'react-icons/fa';
+  faGhost,
+  faTree, 
+  faSeedling,
+  faTint,
+  faSun,
+  faCube,
+  faStar,
+  faGem,
+  faWind,
+  faBolt,
+  faDragon,
+  faSkull,
+  faFire,
+  faSnowflake
+} from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 
 interface FantasyMonsterProps {
@@ -33,23 +34,23 @@ interface FantasyMonsterProps {
 }
 
 // モンスターアイコンマッピング（FontAwesome）
-const MONSTER_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
-  'ghost': FaGhost,
-  'tree': FaTree,
-  'seedling': FaSeedling, 
-  'droplet': FaTint,
-  'sun': FaSun,
-  'rock': FaCube,
-  'sparkles': FaStar,
-  'gem': FaGem,
-  'wind_face': FaWind,
-  'zap': FaBolt,
-  'star2': FaStar,
-  'dragon': FaDragon,
-  'skull': FaSkull,
-  'fire': FaFire,
-  'ice': FaSnowflake,
-  'lightning': FaBolt
+const MONSTER_ICONS: Record<string, any> = {
+  'ghost': faGhost,
+  'tree': faTree,
+  'seedling': faSeedling, 
+  'droplet': faTint,
+  'sun': faSun,
+  'rock': faCube,
+  'sparkles': faStar,
+  'gem': faGem,
+  'wind_face': faWind,
+  'zap': faBolt,
+  'star2': faStar,
+  'dragon': faDragon,
+  'skull': faSkull,
+  'fire': faFire,
+  'ice': faSnowflake,
+  'lightning': faBolt
 };
 
 // モンスターサイズ設定
@@ -74,19 +75,24 @@ const SIZE_CONFIGS = {
   }
 };
 
-// モンスター特性（アイコンごとの特殊効果）
+// モンスター特性（アイコンごとの特殊効果）- 単色設定
 const MONSTER_TRAITS: Record<string, { color: string; glowColor: string; specialEffect?: string }> = {
-  'ghost': { color: 'text-purple-300', glowColor: 'shadow-purple-500', specialEffect: 'float' },
-  'tree': { color: 'text-green-400', glowColor: 'shadow-green-500', specialEffect: 'sway' },
-  'seedling': { color: 'text-green-300', glowColor: 'shadow-green-400' },
-  'droplet': { color: 'text-blue-400', glowColor: 'shadow-blue-500', specialEffect: 'bounce' },
-  'sun': { color: 'text-yellow-400', glowColor: 'shadow-yellow-500', specialEffect: 'pulse' },
-  'rock': { color: 'text-gray-400', glowColor: 'shadow-gray-500' },
-  'sparkles': { color: 'text-yellow-300', glowColor: 'shadow-yellow-400', specialEffect: 'sparkle' },
-  'gem': { color: 'text-pink-400', glowColor: 'shadow-pink-500', specialEffect: 'shine' },
-  'wind_face': { color: 'text-cyan-300', glowColor: 'shadow-cyan-500', specialEffect: 'float' },
-  'zap': { color: 'text-yellow-500', glowColor: 'shadow-yellow-600', specialEffect: 'shake' },
-  'star2': { color: 'text-yellow-200', glowColor: 'shadow-yellow-300', specialEffect: 'twinkle' }
+  'ghost': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'tree': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'sway' },
+  'seedling': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'droplet': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'bounce' },
+  'sun': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
+  'rock': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'sparkles': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'sparkle' },
+  'gem': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'shine' },
+  'wind_face': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'zap': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'shake' },
+  'star2': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'twinkle' },
+  'dragon': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'skull': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'fire': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'ice': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  'lightning': { color: 'text-gray-300', glowColor: 'drop-shadow-md' }
 };
 
 const FantasyMonster: React.FC<FantasyMonsterProps> = ({
@@ -102,7 +108,7 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
   const [showRageEffect, setShowRageEffect] = useState(false);
   
   const sizeConfig = SIZE_CONFIGS[size];
-  const MonsterIcon = MONSTER_ICONS[monsterIcon] || FaGhost;
+  const iconDef = MONSTER_ICONS[monsterIcon] || faGhost;
   const traits = MONSTER_TRAITS[monsterIcon] || MONSTER_TRAITS['ghost'];
   
   // 攻撃時のエフェクト
@@ -193,10 +199,11 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
           style={{
             filter: isAttacking 
               ? 'drop-shadow(0 0 20px rgba(239, 68, 68, 0.8))' 
-              : `drop-shadow(0 0 10px ${traits.color.includes('purple') ? 'rgba(147, 51, 234, 0.5)' : 'rgba(255, 255, 255, 0.2)'})`
+              : 'drop-shadow(0 0 10px rgba(255, 255, 255, 0.2))'
           }}
         >
-          <MonsterIcon
+          <FontAwesomeIcon
+            icon={iconDef}
             className={cn(
               "transition-all duration-300 select-none",
               sizeConfig.monster,
@@ -213,7 +220,7 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
               // 攻撃時のエフェクト
               isAttacking && "transform scale-125 text-red-500",
               // グロー効果
-              !isAttacking && `drop-shadow-lg`
+              !isAttacking && traits.glowColor
             )}
           />
         </div>


### PR DESCRIPTION
Change Fantasy Mode monster icons to official FontAwesome for flat, single-color display.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-dbc1ee0f-e360-4d3a-8dbc-1bdbb2b9dd64) · [Cursor](https://cursor.com/background-agent?bcId=bc-dbc1ee0f-e360-4d3a-8dbc-1bdbb2b9dd64)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)