### PR TITLE
Font Awesomeの敵アイコン表示を修正

### DIFF
--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -19,7 +19,13 @@ import {
   faDragon,
   faSkull,
   faFire,
-  faSnowflake
+  faSnowflake,
+  faSpider,
+  faKhanda,
+  faMask,
+  faEye,
+  faHatWizard,
+  faBug
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 
@@ -50,7 +56,14 @@ const MONSTER_ICONS: Record<string, any> = {
   'skull': faSkull,
   'fire': faFire,
   'ice': faSnowflake,
-  'lightning': faBolt
+  'lightning': faBolt,
+  // ファンタジーモード用の敵アイコンマッピング
+  'vampire': faEye,
+  'monster': faBug,
+  'reaper': faSkull,
+  'kraken': faSpider,
+  'werewolf': faMask,
+  'demon': faHatWizard
 };
 
 // モンスターサイズ設定
@@ -92,7 +105,14 @@ const MONSTER_TRAITS: Record<string, { color: string; glowColor: string; special
   'skull': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
   'fire': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
   'ice': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'lightning': { color: 'text-gray-300', glowColor: 'drop-shadow-md' }
+  'lightning': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
+  // ファンタジーモード用の敵特性
+  'vampire': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'monster': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
+  'reaper': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'kraken': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
+  'werewolf': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'shake' },
+  'demon': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'pulse' }
 };
 
 const FantasyMonster: React.FC<FantasyMonsterProps> = ({

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -307,7 +307,14 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         
         {/* モンスターアイコン */}
         <div className="text-4xl text-center mb-2">
-          {unlocked ? MONSTER_ICONS[stage.monsterIcon] || '👻' : '🔒'}
+          {unlocked ? (
+            <FontAwesomeIcon 
+              icon={MONSTER_ICONS[stage.monsterIcon] || faGhost} 
+              className="text-gray-300 drop-shadow-md"
+            />
+          ) : (
+            <span>🔒</span>
+          )}
         </div>
         
         {/* ステージ名 */}

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -4,6 +4,25 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { 
+  faGhost,
+  faTree, 
+  faSeedling,
+  faTint,
+  faSun,
+  faCube,
+  faStar,
+  faGem,
+  faWind,
+  faBolt,
+  faSpider,
+  faSkull,
+  faEye,
+  faBug,
+  faMask,
+  faHatWizard
+} from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
 import { devLog } from '@/utils/logger';
@@ -56,18 +75,25 @@ const groupStagesByRank = (stages: FantasyStage[]): Record<string, FantasyStage[
 };
 
 // ===== モンスターアイコンマッピング =====
-const MONSTER_ICONS: Record<string, string> = {
-  'ghost': '👻',
-  'tree': '🌳',
-  'seedling': '🌱',
-  'droplet': '💧',
-  'sun': '☀️',
-  'rock': '🪨',
-  'sparkles': '✨',
-  'gem': '💎',
-  'wind_face': '🌬️',
-  'zap': '⚡',
-  'star2': '⭐'
+const MONSTER_ICONS: Record<string, any> = {
+  'ghost': faGhost,
+  'tree': faTree,
+  'seedling': faSeedling,
+  'droplet': faTint,
+  'sun': faSun,
+  'rock': faCube,
+  'sparkles': faStar,
+  'gem': faGem,
+  'wind_face': faWind,
+  'zap': faBolt,
+  'star2': faStar,
+  // ファンタジーモード用の敵アイコンマッピング
+  'vampire': faEye,
+  'monster': faBug,
+  'reaper': faSkull,
+  'kraken': faSpider,
+  'werewolf': faMask,
+  'demon': faHatWizard
 };
 
 // ===== ランク背景色 =====


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replace emoji-based monster icons with FontAwesome icons in fantasy mode components to correctly display flat, single-color icons.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-6f185aa7-1998-4038-a876-d7e5f53f35b0) · [Cursor](https://cursor.com/background-agent?bcId=bc-6f185aa7-1998-4038-a876-d7e5f53f35b0)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)