### PR TITLE
敵アイコンをFont Awesomeに更新

### DIFF
--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -20,12 +20,7 @@ import {
   faSkull,
   faFire,
   faSnowflake,
-  faSpider,
-  faKhanda,
-  faMask,
-  faEye,
-  faHatWizard,
-  faBug
+  faKhanda
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 
@@ -58,12 +53,12 @@ const MONSTER_ICONS: Record<string, any> = {
   'ice': faSnowflake,
   'lightning': faBolt,
   // ファンタジーモード用の敵アイコンマッピング
-  'vampire': faEye,
-  'monster': faBug,
+  'vampire': faGhost,
+  'monster': faGhost,
   'reaper': faSkull,
-  'kraken': faSpider,
-  'werewolf': faMask,
-  'demon': faHatWizard
+  'kraken': faGhost,
+  'werewolf': faGhost,
+  'demon': faGhost
 };
 
 // モンスターサイズ設定

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -16,12 +16,7 @@ import {
   faGem,
   faWind,
   faBolt,
-  faSpider,
-  faSkull,
-  faEye,
-  faBug,
-  faMask,
-  faHatWizard
+  faSkull
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
@@ -88,12 +83,12 @@ const MONSTER_ICONS: Record<string, any> = {
   'zap': faBolt,
   'star2': faStar,
   // ファンタジーモード用の敵アイコンマッピング
-  'vampire': faEye,
-  'monster': faBug,
+  'vampire': faGhost,
+  'monster': faGhost,
   'reaper': faSkull,
-  'kraken': faSpider,
-  'werewolf': faMask,
-  'demon': faHatWizard
+  'kraken': faGhost,
+  'werewolf': faGhost,
+  'demon': faGhost
 };
 
 // ===== ランク背景色 =====


### PR DESCRIPTION
Standardize fantasy enemy icons to `fa-ghost` for a consistent flat design.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-fbdc0e79-fc3c-404f-a16d-a02c158eae45) · [Cursor](https://cursor.com/background-agent?bcId=bc-fbdc0e79-fc3c-404f-a16d-a02c158eae45)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)