### PR TITLE
敵モンスターの色とアイコンを修正

### DIFF
--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -27,7 +27,10 @@ import {
   faDog,
   faBiohazard,
   faBug,
-  faPaw
+  faPaw,
+  faHatWizard,
+  faCrow,
+  faEye
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 
@@ -59,13 +62,13 @@ const MONSTER_ICONS: Record<string, any> = {
   'fire': faFire,
   'ice': faSnowflake,
   'lightning': faBolt,
-  // ファンタジーモード用の敵アイコンマッピング - 適切なアイコンに変更
-  'vampire': faGhost,
-  'monster': faSpider,
-  'reaper': faSkull,
-  'kraken': faFish,
-  'werewolf': faDog,
-  'demon': faKhanda
+  // ファンタジーモード用の敵アイコンマッピング - より適切なアイコンに変更
+  'vampire': faSkull, // バンパイア：頭蓋骨で威圧感を演出
+  'monster': faSpider, // モンスター：蜘蛛のまま
+  'reaper': faHatWizard, // 死神：魔法使いの帽子で神秘的に
+  'kraken': faEye, // クラーケン：目玉で不気味さを演出
+  'werewolf': faCrow, // 人狼：カラスで野生感を演出
+  'demon': faFire // 悪魔：炎で地獄感を演出
 };
 
 // モンスターサイズ設定
@@ -90,31 +93,31 @@ const SIZE_CONFIGS = {
   }
 };
 
-// モンスター特性（アイコンごとの特殊効果）- 単色設定
+// モンスター特性（アイコンごとの特殊効果）- 明るい色に変更
 const MONSTER_TRAITS: Record<string, { color: string; glowColor: string; specialEffect?: string }> = {
-  'ghost': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
-  'tree': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'sway' },
-  'seedling': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'droplet': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'bounce' },
-  'sun': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
-  'rock': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'sparkles': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'sparkle' },
-  'gem': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'shine' },
-  'wind_face': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
-  'zap': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'shake' },
-  'star2': { color: 'text-gray-300', glowColor: 'drop-shadow-md', specialEffect: 'twinkle' },
-  'dragon': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'skull': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'fire': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'ice': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  'lightning': { color: 'text-gray-300', glowColor: 'drop-shadow-md' },
-  // ファンタジーモード用の敵特性
-  'vampire': { color: 'text-white', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
-  'monster': { color: 'text-purple-400', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
-  'reaper': { color: 'text-gray-200', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
-  'kraken': { color: 'text-blue-400', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
-  'werewolf': { color: 'text-amber-400', glowColor: 'drop-shadow-lg', specialEffect: 'shake' },
-  'demon': { color: 'text-red-400', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' }
+  'ghost': { color: 'text-blue-200', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'tree': { color: 'text-green-400', glowColor: 'drop-shadow-md', specialEffect: 'sway' },
+  'seedling': { color: 'text-green-300', glowColor: 'drop-shadow-md' },
+  'droplet': { color: 'text-blue-400', glowColor: 'drop-shadow-md', specialEffect: 'bounce' },
+  'sun': { color: 'text-yellow-400', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
+  'rock': { color: 'text-stone-400', glowColor: 'drop-shadow-md' },
+  'sparkles': { color: 'text-yellow-300', glowColor: 'drop-shadow-md', specialEffect: 'sparkle' },
+  'gem': { color: 'text-cyan-400', glowColor: 'drop-shadow-md', specialEffect: 'shine' },
+  'wind_face': { color: 'text-sky-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
+  'zap': { color: 'text-yellow-400', glowColor: 'drop-shadow-md', specialEffect: 'shake' },
+  'star2': { color: 'text-yellow-300', glowColor: 'drop-shadow-md', specialEffect: 'twinkle' },
+  'dragon': { color: 'text-red-500', glowColor: 'drop-shadow-md' },
+  'skull': { color: 'text-red-400', glowColor: 'drop-shadow-md' },
+  'fire': { color: 'text-orange-400', glowColor: 'drop-shadow-md' },
+  'ice': { color: 'text-cyan-300', glowColor: 'drop-shadow-md' },
+  'lightning': { color: 'text-yellow-400', glowColor: 'drop-shadow-md' },
+  // ファンタジーモード用の敵特性 - 明るく見やすい色に変更
+  'vampire': { color: 'text-red-300', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
+  'monster': { color: 'text-purple-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
+  'reaper': { color: 'text-cyan-300', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
+  'kraken': { color: 'text-blue-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
+  'werewolf': { color: 'text-amber-300', glowColor: 'drop-shadow-lg', specialEffect: 'shake' },
+  'demon': { color: 'text-orange-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' }
 };
 
 const FantasyMonster: React.FC<FantasyMonsterProps> = ({

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -110,12 +110,12 @@ const MAGIC_TYPES: Record<string, MagicType> = {
 
 // ===== モンスターシンボルマッピング（フラットデザイン） =====
 const MONSTER_EMOJI: Record<string, string> = {
-  'vampire': '👻', // ゴースト（バンパイア）
-  'monster': '◈', // ダイヤ形（モンスター）
-  'reaper': '☠', // 骸骨マーク（死神）
-  'kraken': '◉', // 大きな円（クラーケン）
-  'werewolf': '▲', // 三角形（狼男）
-  'demon': '♦'  // ダイヤモンド（魔王）
+  'vampire': '☠', // 頭蓋骨（バンパイア）
+  'monster': '🕷', // 蜘蛛（モンスター）
+  'reaper': '🎩', // シルクハット（死神）
+  'kraken': '👁', // 目玉（クラーケン）
+  'werewolf': '🐦', // 鳥（人狼）
+  'demon': '🔥'  // 火（悪魔）
 };
 
 // ===== PIXI インスタンスクラス =====
@@ -179,7 +179,7 @@ export class FantasyPIXIInstance {
       isAttacking: false,
       isHit: false,
       hitColor: 0xFF6B6B,
-      originalColor: 0x666666, // モノクロ色合い
+      originalColor: 0xFFFFFF, // 明るい色合い
       staggerOffset: { x: 0, y: 0 },
       scale: 1.0,
       rotation: 0
@@ -233,7 +233,7 @@ export class FantasyPIXIInstance {
   // フォールバック用テクスチャ作成
   private createFallbackTextures(): void {
     const graphics = new PIXI.Graphics();
-    graphics.beginFill(0x666666);
+    graphics.beginFill(0xDDDDDD);
     graphics.drawCircle(0, 0, 50);
     graphics.endFill();
     
@@ -276,7 +276,7 @@ export class FantasyPIXIInstance {
         this.monsterSprite.anchor.set(0.5);
         this.monsterSprite.x = this.monsterState.x;
         this.monsterSprite.y = this.monsterState.y;
-        this.monsterSprite.tint = 0x666666; // モノクロ色合いを強制設定
+        this.monsterSprite.tint = 0xFFFFFF; // 明るい色合いに変更
         
         // インタラクティブ設定
         this.monsterSprite.interactive = true;
@@ -316,7 +316,7 @@ export class FantasyPIXIInstance {
 
       // グラフィックスからテクスチャを生成
       const graphics = new PIXI.Graphics();
-      graphics.beginFill(0x666666);
+      graphics.beginFill(0xDDDDDD);
       graphics.drawCircle(64, 64, 64);
       graphics.endFill();
       
@@ -337,7 +337,7 @@ export class FantasyPIXIInstance {
       this.monsterSprite.anchor.set(0.5);
       this.monsterSprite.x = this.monsterState.x;
       this.monsterSprite.y = this.monsterState.y;
-      this.monsterSprite.tint = 0x666666;
+      this.monsterSprite.tint = 0xFFFFFF;
       
       // インタラクティブ設定
       this.monsterSprite.interactive = true;

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -21,7 +21,11 @@ import {
   faSpider,
   faFish,
   faDog,
-  faKhanda
+  faKhanda,
+  faHatWizard,
+  faCrow,
+  faEye,
+  faFire
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
@@ -87,13 +91,13 @@ const MONSTER_ICONS: Record<string, any> = {
   'wind_face': faWind,
   'zap': faBolt,
   'star2': faStar,
-  // ファンタジーモード用の敵アイコンマッピング - 適切なアイコンに変更
-  'vampire': faGhost,
-  'monster': faSpider,
-  'reaper': faSkull,
-  'kraken': faFish,
-  'werewolf': faDog,
-  'demon': faKhanda
+  // ファンタジーモード用の敵アイコンマッピング - より適切なアイコンに変更
+  'vampire': faSkull, // バンパイア：頭蓋骨で威圧感を演出
+  'monster': faSpider, // モンスター：蜘蛛のまま
+  'reaper': faHatWizard, // 死神：魔法使いの帽子で神秘的に
+  'kraken': faEye, // クラーケン：目玉で不気味さを演出
+  'werewolf': faCrow, // 人狼：カラスで野生感を演出
+  'demon': faFire // 悪魔：炎で地獄感を演出
 };
 
 // ===== ランク背景色 =====


### PR DESCRIPTION
Brighten fantasy mode monster colors and update icons for better visibility and thematic representation.

Previously, monsters appeared dark due to gray text colors and PIXI tint settings. Additionally, monster icons, including the vampire, were generic or simple emojis, not aligning with user expectations for distinct monster representations.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-18d206ec-f152-4ae8-b8ac-fe7040d2522b) · [Cursor](https://cursor.com/background-agent?bcId=bc-18d206ec-f152-4ae8-b8ac-fe7040d2522b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)