### PR TITLE
敵撃破時のnullエラーを根本解決

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -264,10 +264,25 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // 敵が変更された時にモンスタースプライトを更新
   useEffect(() => {
     if (fantasyPixiInstance && currentEnemy) {
-      fantasyPixiInstance.createMonsterSprite(currentEnemy.icon);
-      devLog.debug('🔄 モンスタースプライト更新:', { monster: currentEnemy.icon });
+      // 敵が倒された後の場合は、少し遅延を入れて新しいモンスターを生成
+      // これにより、前の敵のフェードアウトが完了してから新しい敵が出現する
+      const isEnemyDefeated = gameState.currentEnemyHits === 0 && gameState.currentEnemyIndex > 0;
+      const delay = isEnemyDefeated ? 1000 : 0; // 1秒の遅延
+      
+      const timeoutId = setTimeout(() => {
+        if (fantasyPixiInstance && currentEnemy) {
+          fantasyPixiInstance.createMonsterSprite(currentEnemy.icon);
+          devLog.debug('🔄 モンスタースプライト更新:', { 
+            monster: currentEnemy.icon,
+            enemyIndex: gameState.currentEnemyIndex,
+            delay: delay
+          });
+        }
+      }, delay);
+      
+      return () => clearTimeout(timeoutId);
     }
-  }, [fantasyPixiInstance, currentEnemy]);
+  }, [fantasyPixiInstance, currentEnemy, gameState.currentEnemyIndex, gameState.currentEnemyHits]);
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）
   const renderHearts = useCallback((hp: number, maxHp: number, isPlayer: boolean = true) => {

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -252,16 +252,19 @@ export class FantasyPIXIInstance {
       // 既存のスプライトを安全に破棄
       if (this.monsterSprite) {
         try {
-          if (this.monsterSprite.parent) {
-            this.monsterSprite.parent.removeChild(this.monsterSprite);
+          // モンスタースプライトの参照を一時的にnullにして、アニメーションループが参照しないようにする
+          const spriteToDestroy = this.monsterSprite;
+          this.monsterSprite = null;
+          
+          if (spriteToDestroy.parent) {
+            spriteToDestroy.parent.removeChild(spriteToDestroy);
           }
-          if (!this.monsterSprite.destroyed) {
-            this.monsterSprite.destroy();
+          if (!spriteToDestroy.destroyed) {
+            spriteToDestroy.destroy();
           }
         } catch (error) {
           devLog.debug('⚠️ 既存モンスタースプライトの破棄エラー:', error);
         }
-        this.monsterSprite = null;
       }
 
       // 絵文字テクスチャを取得
@@ -302,16 +305,19 @@ export class FantasyPIXIInstance {
       // 既存のスプライトを安全に破棄
       if (this.monsterSprite) {
         try {
-          if (this.monsterSprite.parent) {
-            this.monsterSprite.parent.removeChild(this.monsterSprite);
+          // モンスタースプライトの参照を一時的にnullにして、アニメーションループが参照しないようにする
+          const spriteToDestroy = this.monsterSprite;
+          this.monsterSprite = null;
+          
+          if (spriteToDestroy.parent) {
+            spriteToDestroy.parent.removeChild(spriteToDestroy);
           }
-          if (!this.monsterSprite.destroyed) {
-            this.monsterSprite.destroy();
+          if (!spriteToDestroy.destroyed) {
+            spriteToDestroy.destroy();
           }
         } catch (error) {
           devLog.debug('⚠️ 既存モンスタースプライトの破棄エラー:', error);
         }
-        this.monsterSprite = null;
       }
 
       // グラフィックスからテクスチャを生成
@@ -391,11 +397,27 @@ export class FantasyPIXIInstance {
       // 画面震動エフェクト
       this.createScreenShake(5, 200);
       
-      // 5発で次のモンスターに交代
+      // 5発で敵を倒す（ただし、switchToNextMonsterは呼ばない）
+      // 新しいモンスターの生成は外部（FantasyGameScreen）から制御される
       if (this.enemyHitCount >= 5) {
-        setTimeout(() => {
-          this.switchToNextMonster();
-        }, 1500);
+        devLog.debug('💀 敵を倒した！外部からの新モンスター設定を待機中...');
+        // ヒットカウントをリセット（外部から新しいモンスターが設定された時のため）
+        this.enemyHitCount = 0;
+        this.monsterState.health = this.monsterState.maxHealth;
+        
+        // 倒れるエフェクトのみ実行
+        if (this.monsterSprite && !this.monsterSprite.destroyed) {
+          // フェードアウトエフェクト
+          const fadeOut = () => {
+            if (this.isDestroyed) return;
+            
+            if (this.monsterSprite && !this.monsterSprite.destroyed && this.monsterSprite.alpha > 0) {
+              this.monsterSprite.alpha -= 0.05;
+              requestAnimationFrame(fadeOut);
+            }
+          };
+          fadeOut();
+        }
       }
       
       // 色とよろけ効果をリセット
@@ -495,32 +517,6 @@ export class FantasyPIXIInstance {
     };
     
     shake();
-  }
-
-  // 次のモンスターに交代
-  private switchToNextMonster(): void {
-    if (!this.monsterSprite) return;
-    
-    // フェードアウトエフェクト
-    const fadeOut = () => {
-      if (this.monsterSprite && this.monsterSprite.alpha > 0) {
-        this.monsterSprite.alpha -= 0.05;
-        requestAnimationFrame(fadeOut);
-      } else if (this.monsterSprite) {
-        // 新しいモンスター生成
-        this.enemyHitCount = 0;
-        this.monsterState.health = this.monsterState.maxHealth;
-        this.monsterSprite.alpha = 1;
-        
-        // ランダムな新しいモンスターを選択
-        const monsterKeys = Object.keys(MONSTER_EMOJI);
-        const randomKey = monsterKeys[Math.floor(Math.random() * monsterKeys.length)];
-        this.createMonsterSprite(randomKey);
-      }
-    };
-    fadeOut();
-    
-    devLog.debug('🔄 次のモンスターに交代');
   }
 
   // ダメージ数値作成
@@ -628,7 +624,10 @@ export class FantasyPIXIInstance {
   updateMonsterAttacking(isAttacking: boolean): void {
     this.monsterState.isAttacking = isAttacking;
     
-    if (this.monsterSprite && isAttacking) {
+    // モンスタースプライトがnullの場合は早期リターン
+    if (!this.monsterSprite || this.monsterSprite.destroyed) return;
+    
+    if (isAttacking) {
       this.monsterSprite.tint = 0xFF6B6B;
       this.monsterSprite.scale.set(1.3);
       
@@ -636,7 +635,7 @@ export class FantasyPIXIInstance {
       // this.createMagicCircle(this.monsterState.x, this.monsterState.y, 'failure');
       
       setTimeout(() => {
-        if (this.monsterSprite) {
+        if (this.monsterSprite && !this.monsterSprite.destroyed) {
           this.monsterSprite.tint = 0xFFFFFF;
           this.monsterSprite.scale.set(1.0);
         }
@@ -662,15 +661,15 @@ export class FantasyPIXIInstance {
 
   // モンスターアニメーション更新
   private updateMonsterAnimation(): void {
+    // this.monsterSpriteがnullの場合は早期リターン
+    if (!this.monsterSprite || this.isDestroyed) {
+      return;
+    }
+    
     // ローカル参照を取得して、更新途中に this.monsterSprite が破棄されても
     // 例外にならないようにする
     const sprite = this.monsterSprite;
-    if (
-      !sprite || 
-      this.isDestroyed || 
-      sprite.destroyed ||
-      !sprite.transform  // transform が生きているかまでチェック
-    ) {
+    if (!sprite || sprite.destroyed || !sprite.transform) {
       return;
     }
 
@@ -813,7 +812,8 @@ export class FantasyPIXIInstance {
       this.monsterState.x = width / 2;
       this.monsterState.y = height / 2;
       
-      if (this.monsterSprite && !this.monsterSprite.destroyed) {
+      // モンスタースプライトの位置更新時もnullチェックを強化
+      if (this.monsterSprite && !this.monsterSprite.destroyed && this.monsterSprite.transform) {
         this.monsterSprite.x = this.monsterState.x;
         this.monsterSprite.y = this.monsterState.y;
       }
@@ -836,6 +836,23 @@ export class FantasyPIXIInstance {
     if (this.animationFrameId) {
       cancelAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;
+    }
+    
+    // モンスタースプライトを安全に破棄
+    if (this.monsterSprite) {
+      try {
+        const spriteToDestroy = this.monsterSprite;
+        this.monsterSprite = null;
+        
+        if (spriteToDestroy.parent) {
+          spriteToDestroy.parent.removeChild(spriteToDestroy);
+        }
+        if (!spriteToDestroy.destroyed) {
+          spriteToDestroy.destroy();
+        }
+      } catch (error) {
+        devLog.debug('⚠️ モンスタースプライト破棄エラー:', error);
+      }
     }
     
     // テクスチャクリーンアップ


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes Null error when defeating enemies in Fantasy Mode by improving monster sprite lifecycle management and decoupling enemy switching.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `Cannot set properties of null (setting 'x')` error occurred due to a race condition. When an enemy was defeated, `FantasyPIXIRenderer` would attempt to access properties of the monster sprite (e.g., `x`) while it was being destroyed or before a new sprite was fully initialized by `FantasyGameScreen`. This PR addresses this by strengthening null checks, ensuring safe sprite destruction, and introducing a delay in `FantasyGameScreen` to allow the previous monster's fade-out to complete before a new one is created.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-3b92a4fb-184e-485e-bebc-3b6c29d94f56) · [Cursor](https://cursor.com/background-agent?bcId=bc-3b92a4fb-184e-485e-bebc-3b6c29d94f56)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)