### PR TITLE
ステージ敵タイプ制限でエラー修正

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -196,7 +196,9 @@ const getCurrentEnemy = (enemyIndex: number) => {
   if (enemyIndex >= 0 && enemyIndex < ENEMY_LIST.length) {
     return ENEMY_LIST[enemyIndex];
   }
-  return ENEMY_LIST[0]; // フォールバック
+  // フォールバック：インデックスが範囲外の場合は配列の長さで余りを取る
+  const safeIndex = ((enemyIndex % ENEMY_LIST.length) + ENEMY_LIST.length) % ENEMY_LIST.length;
+  return ENEMY_LIST[safeIndex];
 };
 
 // ===== メインコンポーネント =====
@@ -226,7 +228,7 @@ export const useFantasyGameEngine = ({
     currentEnemyIndex: 0,
     currentEnemyHits: 0,
     enemiesDefeated: 0,
-    totalEnemies: 5,
+    totalEnemies: 1, // 初期値、実際の値はinitializeGameで設定
     // 敵のHP管理を追加
     currentEnemyHp: 5,
     maxEnemyHp: 5
@@ -277,7 +279,7 @@ export const useFantasyGameEngine = ({
       currentEnemyIndex: 0,
       currentEnemyHits: 0,
       enemiesDefeated: 0,
-      totalEnemies: 5,
+      totalEnemies: Math.ceil(stage.questionCount / 5), // 5問ごとに1体の敵
       // 敵のHP管理を追加
       currentEnemyHp: 5,
       maxEnemyHp: 5

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -282,15 +282,19 @@ export class FantasyPIXIInstance {
       
       if (texture) {
         // 既存のスプライトのテクスチャを更新（スプライト自体は破棄しない）
-        this.monsterSprite.texture = texture;
+        if (this.monsterSprite && texture) {
+          this.monsterSprite.texture = texture;
+        }
         
-        // ビジュアル状態をリセット
+        // ビジュアル状態をリセット（safe defaults）
         this.monsterVisualState = {
-          ...this.monsterVisualState,
-          alpha: 1.0,
-          visible: true,
+          x: this.app.screen.width / 2,
+          y: this.app.screen.height / 2 - 20,
+          scale: 1.0,
+          rotation: 0,
           tint: 0xFFFFFF,
-          scale: 1.0
+          alpha: 1.0,
+          visible: true
         };
         
         // ゲーム状態もリセット
@@ -333,15 +337,19 @@ export class FantasyPIXIInstance {
       graphics.destroy();
       
       // 既存のスプライトのテクスチャを更新
-      this.monsterSprite.texture = texture;
+      if (this.monsterSprite && texture) {
+        this.monsterSprite.texture = texture;
+      }
       
-      // ビジュアル状態をリセット
+      // ビジュアル状態をリセット（safe defaults）
       this.monsterVisualState = {
-        ...this.monsterVisualState,
-        alpha: 1.0,
-        visible: true,
+        x: this.app.screen.width / 2,
+        y: this.app.screen.height / 2 - 20,
+        scale: 1.0,
+        rotation: 0,
         tint: 0xFFFFFF,
-        scale: 1.0
+        alpha: 1.0,
+        visible: true
       };
       
       // スプライトの属性を更新
@@ -355,16 +363,25 @@ export class FantasyPIXIInstance {
 
   // モンスタースプライトの属性を安全に更新
   private updateMonsterSprite(): void {
-    if (this.isDestroyed || !this.monsterSprite) return;
+    if (this.isDestroyed || !this.monsterSprite || !this.monsterVisualState) return;
     
-    // ビジュアル状態を適用（絶対にnullにならない）
-    this.monsterSprite.x = this.monsterVisualState.x;
-    this.monsterSprite.y = this.monsterVisualState.y;
-    this.monsterSprite.scale.set(this.monsterVisualState.scale);
-    this.monsterSprite.rotation = this.monsterVisualState.rotation;
-    this.monsterSprite.tint = this.monsterVisualState.tint;
-    this.monsterSprite.alpha = this.monsterVisualState.alpha;
-    this.monsterSprite.visible = this.monsterVisualState.visible;
+    // ビジュアル状態の値を安全にチェック
+    const safeX = typeof this.monsterVisualState.x === 'number' ? this.monsterVisualState.x : this.app.screen.width / 2;
+    const safeY = typeof this.monsterVisualState.y === 'number' ? this.monsterVisualState.y : this.app.screen.height / 2;
+    const safeScale = typeof this.monsterVisualState.scale === 'number' ? this.monsterVisualState.scale : 1.0;
+    const safeRotation = typeof this.monsterVisualState.rotation === 'number' ? this.monsterVisualState.rotation : 0;
+    const safeTint = typeof this.monsterVisualState.tint === 'number' ? this.monsterVisualState.tint : 0xFFFFFF;
+    const safeAlpha = typeof this.monsterVisualState.alpha === 'number' ? this.monsterVisualState.alpha : 1.0;
+    const safeVisible = typeof this.monsterVisualState.visible === 'boolean' ? this.monsterVisualState.visible : true;
+    
+    // ビジュアル状態を適用（安全な値のみ使用）
+    this.monsterSprite.x = safeX;
+    this.monsterSprite.y = safeY;
+    this.monsterSprite.scale.set(safeScale);
+    this.monsterSprite.rotation = safeRotation;
+    this.monsterSprite.tint = safeTint;
+    this.monsterSprite.alpha = safeAlpha;
+    this.monsterSprite.visible = safeVisible;
   }
 
   // 攻撃成功エフェクト


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix "Cannot set properties of null (setting 'x')" error in Fantasy Mode by improving enemy index management and adding robust null checks for monster visual states.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error occurred when transitioning to a new enemy, primarily due to the `currentEnemyIndex` potentially exceeding the `ENEMY_LIST` bounds and `monsterVisualState` properties (like `x`, `y`) being null or undefined during sprite updates. This PR ensures the enemy index always cycles correctly and all visual state properties are safely initialized and accessed with default fallbacks.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a1d89cb0-6d6a-4afb-9281-082fa01467f1) · [Cursor](https://cursor.com/background-agent?bcId=bc-a1d89cb0-6d6a-4afb-9281-082fa01467f1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)