### PR TITLE
ファンタジーモードスプライトnullエラー根本解決

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -355,9 +355,18 @@ export class FantasyPIXIInstance {
 
   // モンスタースプライトの属性を安全に更新
   private updateMonsterSprite(): void {
-    if (this.isDestroyed || !this.monsterSprite) return;
+    // 追加の安全チェックを実装
+    if (
+      this.isDestroyed ||
+      !this.monsterSprite ||
+      this.monsterSprite.destroyed ||
+      // transform が null になると PIXI 内部で x 代入時にエラーになるため
+      !(this.monsterSprite as any).transform
+    ) {
+      return; // 破棄済みまたは異常状態の場合は更新しない
+    }
     
-    // ビジュアル状態を適用（絶対にnullにならない）
+    // ビジュアル状態を適用
     this.monsterSprite.x = this.monsterVisualState.x;
     this.monsterSprite.y = this.monsterVisualState.y;
     this.monsterSprite.scale.set(this.monsterVisualState.scale);


### PR DESCRIPTION
<!-- Add null and destroyed checks to `updateMonsterSprite` to prevent 'Cannot set properties of null' errors when a PIXI sprite is destroyed. -->

<!-- This addresses the 'Cannot set properties of null (setting 'x')' error that occurred when a PIXI sprite was already destroyed (e.g., after defeating an enemy in fantasy mode) but its update function was still attempting to modify its properties, leading to a null `transform` object. -->

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-83d6a113-96be-4a2f-a71d-b978902d3332) · [Cursor](https://cursor.com/background-agent?bcId=bc-83d6a113-96be-4a2f-a71d-b978902d3332)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)