### PR TITLE
コンポーネントの無限ループと設定を修正

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -3,7 +3,7 @@
  * UI/UX要件に従ったゲーム画面の実装
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { cn } from '@/utils/cn';
 import { useFantasyGameEngine, ChordDefinition, FantasyStage, FantasyGameState } from './FantasyGameEngine';
 import { PIXINotesRenderer, PIXINotesRendererInstance } from '../game/PIXINotesRenderer';
@@ -37,6 +37,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 設定状態を管理（初期値はstageから取得）
   const [showGuide, setShowGuide] = useState(stage.showGuide);
+  
+  // stage.showGuide の変更をコンポーネントの状態に同期させる
+  useEffect(() => {
+    setShowGuide(stage.showGuide);
+  }, [stage.showGuide]);
   
   // PIXI.js レンダラー
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
@@ -101,6 +106,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     onGameComplete(result, finalState.score, finalState.correctAnswers, finalState.totalQuestions);
   }, [onGameComplete]);
   
+  // useMemoを使って、stageオブジェクトをメモ化（安定化）させる
+  const memoizedStage = useMemo(() => ({
+    ...stage,
+    showGuide,
+  }), [stage, showGuide]);
+  
   // ゲームエンジンの初期化
   const {
     gameState,
@@ -111,10 +122,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     getCurrentEnemy,
     ENEMY_LIST
   } = useFantasyGameEngine({
-    stage: {
-      ...stage,
-      showGuide
-    },
+    stage: memoizedStage, // メモ化したstageを渡す
     onGameStateChange: handleGameStateChange,
     onChordCorrect: handleChordCorrect,
     onChordIncorrect: handleChordIncorrect,


### PR DESCRIPTION
Stabilize `stage` prop and synchronize `showGuide` state to resolve infinite re-renders and ensure database settings are reflected.

The `FantasyGameScreen` component experienced two issues:
1.  The `stage` object passed to `useFantasyGameEngine` was recreated on every render, causing the game engine to re-initialize unnecessarily and change the problem code ("roulette" effect).
2.  The `showGuide` state was not updating when `stage.showGuide` changed from the database, leading to outdated settings on screen.
This PR uses `useMemo` to stabilize the `stage` object and `useEffect` to synchronize the `showGuide` state, resolving both issues.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-0054c54c-8d30-4013-8ff2-423e88f37c78) · [Cursor](https://cursor.com/background-agent?bcId=bc-0054c54c-8d30-4013-8ff2-423e88f37c78)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)