### PR TITLE
Update music game feedback and hints

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -200,7 +200,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         noteWidth: dynamicNoteWidth,
         transpose: 0,
         transposingInstrument: 'concert_pitch',
-        practiceGuide: showGuide ? 'key' : 'off', // ガイド表示設定に基づく
+        practiceGuide: 'off', // 鍵盤ハイライトは常にOFF
         showHitLine: false, // ヒットラインを非表示
         viewportHeight: 120, // pianoHeightと同じ値に設定してノーツ下降部分を完全に非表示
         timingAdjustment: 0,
@@ -297,13 +297,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   useEffect(() => {
     if (pixiRenderer) {
       pixiRenderer.updateSettings({
-        practiceGuide: showGuide ? 'key' : 'off'
+        practiceGuide: 'off' // 鍵盤ハイライトは常にOFF
       });
       devLog.debug('🎮 PIXIレンダラー設定更新:', { showGuide });
     }
   }, [pixiRenderer, showGuide]);
   
-  // 現在のコードターゲットのノートをハイライト
+  // 現在のコードターゲットのノートをハイライト（無効化）
+  /*
   useEffect(() => {
     if (pixiRenderer && showGuide && gameState.currentChordTarget) {
       // 全てのキーのハイライトを一度クリア
@@ -335,6 +336,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       }
     }
   }, [pixiRenderer, showGuide, gameState.currentChordTarget]);
+  */
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）
   const renderHearts = useCallback((hp: number, maxHp: number, isPlayer: boolean = true) => {
@@ -461,6 +463,25 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           <div className="text-yellow-300 text-2xl font-bold tracking-wider drop-shadow-lg">
             {gameState.currentChordTarget.displayName}
           </div>
+          {/* 音名表示（ヒントがONの場合） */}
+          {showGuide && gameState.currentChordTarget.noteNames && (
+            <div className="mt-2 flex justify-center items-center gap-3">
+              {gameState.currentChordTarget.noteNames.map((noteName, index) => {
+                const noteMod12 = gameState.currentChordTarget.notes[index] % 12;
+                const isCorrect = gameState.correctNotes.has(noteMod12);
+                return (
+                  <div key={index} className="flex items-center gap-1">
+                    <span className={`text-lg ${isCorrect ? 'text-green-400' : 'text-gray-300'}`}>
+                      {noteName}
+                    </span>
+                    {isCorrect && (
+                      <span className="text-green-400 text-lg">✓</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
         
         {/* ファンタジーPIXIレンダラー（モンスターとエフェクト） */}

--- a/src/components/fantasy/FantasySettingsModal.tsx
+++ b/src/components/fantasy/FantasySettingsModal.tsx
@@ -141,11 +141,11 @@ const FantasySettingsModal: React.FC<FantasySettingsModalProps> = ({
                 className="rounded border-gray-600 text-blue-600 focus:ring-blue-500"
               />
               <span className="text-sm font-medium text-white">
-                ガイド表示（鍵盤ハイライト）
+                音名ヒント表示
               </span>
             </label>
             <p className="text-xs text-gray-400 mt-1">
-              出題コードの鍵盤がハイライト表示されます
+              コード名の下に構成音の音名（ド、ミ、ソなど）が表示されます
             </p>
           </div>
         </div>


### PR DESCRIPTION
Replace keyboard highlight with note name display and add real-time correct note feedback for improved learning.

Users can now see the constituent notes of a chord displayed below the chord name. As they play correct notes, a checkmark appears next to the note name and its color changes, providing immediate visual feedback on their progress within the current chord.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ddd538ae-0262-4ceb-91d0-862ae1a55a68) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ddd538ae-0262-4ceb-91d0-862ae1a55a68)