### PR TITLE
Changes from background agent bc-7e2741b0-f30f-4d21-becf-f22dc7bb27dc

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -687,52 +687,18 @@ export class FantasyPIXIInstance {
         this.monsterVisualState.visible = false;
         this.monsterGameState.isFadingOut = false;
         
-        // 1秒後に次の敵を生成
-        setTimeout(() => {
-          if (!this.isDestroyed) {
-            this.resetMonsterState();
-          }
-        }, 1000);
+        // ▼▼▼ 修正点: 1秒後の状態リセット処理を削除 ▼▼▼
+        // この処理が競合状態の原因でした。
+        // 新しいモンスターの生成は、親コンポーネントからの
+        // `monsterIcon` propsの変更によってトリガーされるべきです。
       }
     };
     
     fadeOut();
   }
 
-  // モンスター状態のリセット
-  private resetMonsterState(): void {
-    if (this.isDestroyed) return;
-    
-    // ビジュアル状態をリセット
-    this.monsterVisualState = {
-      x: this.app.screen.width / 2,
-      y: this.app.screen.height / 2 - 20,
-      scale: 1.0,
-      rotation: 0,
-      tint: 0xFFFFFF,
-      alpha: 1.0,
-      visible: true
-    };
-    
-    // ゲーム状態をリセット
-    this.monsterGameState = {
-      health: 5,
-      maxHealth: 5,
-      isAttacking: false,
-      isHit: false,
-      hitColor: 0xFFFFFF,
-      originalColor: 0xFFFFFF,
-      staggerOffset: { x: 0, y: 0 },
-      hitCount: 0,
-      isFadingOut: false,
-      isTransitioning: false
-    };
-    
-    // スプライトを更新
-    this.updateMonsterSprite();
-    
-    devLog.debug('🔄 モンスター状態リセット完了');
-  }
+  // ▼▼▼ 修正点: 不要になったため関数ごと削除 ▼▼▼
+  // private resetMonsterState(): void { ... }
 
   // 魔法パーティクル作成
   private createMagicParticles(magic: MagicType): void {


### PR DESCRIPTION
Remove unnecessary monster state reset logic to fix a race condition causing 'Cannot set properties of null' error after monster defeat.

The previous implementation attempted to reset and re-display an old monster's state after a fade-out, which created a race condition with the parent component's logic for displaying new monsters. This could lead to errors when trying to access properties of a sprite that was already destroyed or in an invalid state. The updated logic ensures the monster simply remains hidden until a new one is explicitly provided by the parent component.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7e2741b0-f30f-4d21-becf-f22dc7bb27dc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7e2741b0-f30f-4d21-becf-f22dc7bb27dc)