### PR TITLE
Fix reference error in random chord selection

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -275,7 +275,7 @@ export const useFantasyGameEngine = ({
 
     // 最初のコードを取得
     const firstChord = stage.mode === 'single' 
-                  ? selectRandomChord(stage.allowedChords, previousChordId)
+                  ? selectRandomChord(stage.allowedChords)
       : getProgressionChord(stage.chordProgression || [], 0);
     if (!firstChord) {
       devLog.debug('❌ 最初のコードが見つかりません');


### PR DESCRIPTION
Remove undefined `previousChordId` argument from `selectRandomChord` call during game initialization to fix `ReferenceError`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-78a59422-ee38-4cc8-bb2f-93f82f55db6f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-78a59422-ee38-4cc8-bb2f-93f82f55db6f)