### PR TITLE
Pass defeated status to next enemy

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -63,12 +63,13 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     });
   }, []);
   
-  const handleChordCorrect = useCallback((chord: ChordDefinition, isSpecial: boolean, damageDealt: number) => {
-    devLog.debug('✅ 正解:', { name: chord.displayName, special: isSpecial, damage: damageDealt });
+  const handleChordCorrect = useCallback((chord: ChordDefinition, isSpecial: boolean, damageDealt: number, defeated: boolean) => { // ★ 4番目の引数 defeated を受け取る
+    devLog.debug('✅ 正解:', { name: chord.displayName, special: isSpecial, damage: damageDealt, defeated: defeated });
     
     // ファンタジーPIXIエフェクトをトリガー（コード名を渡す）
     if (fantasyPixiInstance) {
-      fantasyPixiInstance.triggerAttackSuccess(chord.displayName, isSpecial, damageDealt);
+      // ★ fantasyPixiInstance.triggerAttackSuccess に defeated を渡す
+      fantasyPixiInstance.triggerAttackSuccess(chord.displayName, isSpecial, damageDealt, defeated);
     }
     
   }, [fantasyPixiInstance]);

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -36,8 +36,6 @@ interface MonsterVisualState {
 }
 
 interface MonsterGameState {
-  health: number;
-  maxHealth: number;
   isAttacking: boolean;
   isHit: boolean;
   hitColor: number;
@@ -235,8 +233,6 @@ export class FantasyPIXIInstance {
     
     // モンスターのゲーム状態初期化
     this.monsterGameState = {
-      health: 5,
-      maxHealth: 5,
       isAttacking: false,
       isHit: false,
       hitColor: 0xFF6B6B,
@@ -378,8 +374,6 @@ export class FantasyPIXIInstance {
       };
       
       // ゲーム状態をリセット
-      // ★ HPはステージから受け取るため、ここではリセットしない
-      // this.monsterGameState.health = this.monsterGameState.maxHealth;
       this.monsterGameState.hitCount = 0;
       this.monsterGameState.state = 'IDLE';
       
@@ -469,7 +463,7 @@ export class FantasyPIXIInstance {
   }
 
   // ▼▼▼ 攻撃成功エフェクトを修正 ▼▼▼
-  triggerAttackSuccess(chordName: string | undefined, isSpecial: boolean, damageDealt: number): void {
+  triggerAttackSuccess(chordName: string | undefined, isSpecial: boolean, damageDealt: number, defeated: boolean): void { // ★ 4番目の引数 defeated を受け取る
     // 状態ガード: 消滅中または完全消滅中は何もしない
     if (this.isDestroyed || this.monsterGameState.state === 'FADING_OUT' || this.monsterGameState.state === 'GONE') {
       return;
@@ -510,16 +504,16 @@ export class FantasyPIXIInstance {
       // 状態を更新
       this.monsterGameState.hitCount++;
 
-      // 敵のHPが0になった場合の処理
-      if (this.monsterGameState.health <= 0) {
+      // ★ 修正点: 内部のHP判定を削除し、引数の defeated を使う
+      if (defeated) {
         this.setMonsterState('FADING_OUT');
       }
 
       devLog.debug('⚔️ 攻撃成功:', { 
         magic: magic.name, 
         damage: damageDealt,
+        defeated: defeated, // ログにも追加
         hitCount: this.monsterGameState.hitCount, 
-        enemyHp: this.monsterGameState.health,
         state: this.monsterGameState.state
       });
 
@@ -1373,12 +1367,6 @@ export class FantasyPIXIInstance {
         this.onDefeated?.();
       } 
     }
-  }
-
-  // GameScreenからHPを受け取るメソッドを追加
-  public setHp(hp: number, maxHp: number) {
-    this.monsterGameState.health = hp;
-    this.monsterGameState.maxHealth = maxHp;
   }
 }
 


### PR DESCRIPTION
Propagate monster defeat status to PIXI renderer to fix game progression and centralize HP management.

Previously, the game engine determined monster defeat, but this information was not explicitly passed to the PIXI renderer, which also attempted to manage monster HP internally. This desynchronization prevented the renderer from triggering the fade-out animation, stopping game progression. This PR ensures the engine is the single source of truth for monster defeat, passing this status through the game screen to the PIXI renderer, which then correctly initiates the defeat animation and allows the game to proceed to the next enemy.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0a8f2df8-7cb4-4121-9baf-6f2db49412f4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0a8f2df8-7cb4-4121-9baf-6f2db49412f4)