### PR TITLE
Implement and refine fantasy mode features

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -26,7 +26,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   onGameComplete,
   onBackToStageSelect
 }) => {
-  const { handleNoteInput } = useGameStore();
+  // useGameStoreの使用を削除（ファンタジーモードでは不要）
   
   // エフェクト状態
   const [isMonsterAttacking, setIsMonsterAttacking] = useState(false);
@@ -85,6 +85,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   const handleEnemyAttack = useCallback(() => {
     devLog.debug('💥 敵の攻撃!');
+    
+    // モンスター攻撃状態を設定
+    setIsMonsterAttacking(true);
+    setTimeout(() => setIsMonsterAttacking(false), 600);
     
     // ファンタジーPIXIでモンスター攻撃エフェクト
     if (fantasyPixiInstance) {
@@ -158,12 +162,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       devLog.debug('🎹 音声再生エラー:', error);
     }
     
-    // 通常のゲームストアの入力処理
-    handleNoteInput(note);
-    
-    // ファンタジーゲームエンジンにも送信
+    // ファンタジーゲームエンジンにのみ送信（重複を防ぐため）
     engineHandleNoteInput(note);
-  }, [handleNoteInput, engineHandleNoteInput, pixiRenderer]);
+  }, [engineHandleNoteInput, pixiRenderer]);
   
   // PIXI.jsレンダラーの準備完了ハンドラー
   const handlePixiReady = useCallback((renderer: PIXINotesRendererInstance | null) => {

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -280,17 +280,17 @@ const FantasyMain: React.FC = () => {
         <div className="text-white text-center max-w-md p-4">
           {/* 結果アイコン */}
           <div className="text-8xl mb-6">
-            {gameResult.result === 'clear' ? '🏆' : '💀'}
+            {gameResult.result === 'clear' ? '🏆' : '😵'}
           </div>
           
           {/* 結果タイトル */}
-          <h2 className="text-3xl font-bold mb-4">
+          <h2 className="text-3xl font-bold mb-4 font-dotgothic16">
             {gameResult.result === 'clear' ? 'ステージクリア！' : 'ゲームオーバー'}
           </h2>
           
           {/* スコア表示 */}
           <div className="bg-black bg-opacity-30 rounded-lg p-6 mb-6">
-            <div className="space-y-2 text-lg">
+            <div className="space-y-2 text-lg font-dotgothic16">
               <div>スコア: <span className="text-yellow-300 font-bold">{gameResult.score.toLocaleString()}</span></div>
               <div>正解数: <span className="text-green-300 font-bold">{gameResult.correctAnswers}</span> / {gameResult.totalQuestions}</div>
               <div>

--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -242,8 +242,8 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
               traits.specialEffect === 'shine' && "animate-pulse",
               traits.specialEffect === 'twinkle' && "animate-ping",
               traits.specialEffect === 'sway' && "hover:animate-pulse",
-              // 攻撃時のエフェクト
-              isAttacking && "transform scale-125 text-red-500",
+              // 攻撃時のエフェクト - スケールを1.5倍に増強
+              isAttacking && "transform scale-150 text-red-500",
               // グロー効果
               !isAttacking && traits.glowColor
             )}
@@ -252,7 +252,7 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
         
         {/* 怒りマーク（攻撃時） */}
         {showRageEffect && (
-          <div className="absolute -top-4 -right-4 text-red-500 text-2xl animate-bounce z-10">
+          <div className="absolute -top-8 -right-8 text-red-500 text-4xl animate-bounce z-10">
             💢
           </div>
         )}


### PR DESCRIPTION
Implement fantasy mode improvements including result screen adjustments, fixing double damage on mobile, and enhancing enemy attack visuals.

This PR addresses user requests for fantasy mode:
- **Result Screen:** Changed game over icon from skull (💀) to dizzy face (😵) and applied `font-dotgothic16` for better aesthetics.
- **Mobile Double Damage Fix:** The `handleNoteInputBridge` was inadvertently calling both the general `handleNoteInput` and the fantasy-specific `engineHandleNoteInput`, leading to duplicate note processing and double damage on mobile. The fix removes the redundant call to `handleNoteInput`.
- **Enemy Attack Effect:** Enhanced visual feedback for enemy attacks by increasing the monster icon scale to 1.5x and making the 💢 mark larger, repositioned, and animated for better visibility.

---

[Open in Web](https://www.cursor.com/agents?id=bc-2eb21ecc-2278-4835-bc0f-c49a8121cdb5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2eb21ecc-2278-4835-bc0f-c49a8121cdb5)