### PR TITLE
Fix duplicate variable declarations in vite build

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -574,8 +574,7 @@ export class FantasyPIXIInstance {
         let life = 800; // アニメーション時間を短く
         const targetX = this.monsterVisualState.x + (isSpecial ? (Math.random() - 0.5) * 80 : 0);
         const targetY = this.monsterVisualState.y + (isSpecial ? (Math.random() - 0.5) * 40 : 0);
-        const startX = magicSprite.x;
-        const startY = magicSprite.y;
+        // startXとstartYは既に上で宣言されているため、ここでは削除
         
         const animate = () => {
           if (this.isDestroyed || !magicSprite || magicSprite.destroyed) {


### PR DESCRIPTION
<!-- Remove duplicate variable declarations to fix build error. -->

<!-- The build failed because `startX` and `startY` were declared twice in `FantasyPIXIRenderer.tsx`, causing "The symbol has already been declared" errors. This PR removes the redundant declarations. -->

---

[Open in Web](https://www.cursor.com/agents?id=bc-cb3c3e28-2986-488d-81a6-64971886cda3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cb3c3e28-2986-488d-81a6-64971886cda3)