### PR TITLE
Fix fantasy mode unplayable error

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -39,7 +39,7 @@ interface FantasyStage {
 interface FantasyGameState {
   currentStage: FantasyStage | null;
   currentQuestionIndex: number;
-  currentChordTarget: ChordDefinition;
+  currentChordTarget: ChordDefinition | null;
   playerHp: number;
   enemyGauge: number;
   score: number;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -393,7 +393,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           <button
             onClick={() => {
               devLog.debug('🎮 ゲーム開始ボタンクリック');
-              initializeGame();
+              initializeGame(stage);
             }}
             className="px-8 py-4 bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-400 hover:to-orange-400 text-black font-bold text-xl rounded-lg shadow-lg transform hover:scale-105 transition-all"
           >

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -77,6 +77,8 @@ interface DamageNumberData {
   startTime: number;
   startY: number;
   velocity: number;
+  life: number;
+  maxLife: number;
 }
 
 interface MagicType {
@@ -192,8 +194,7 @@ export class FantasyPIXIInstance {
     originalY: 0
   };
 
-  // 状態機械
-  private monsterStateMachine = new MonsterStateMachine();
+
 
 
   constructor(width: number, height: number, onMonsterDefeated?: () => void, onShowMagicName?: (magicName: string, isSpecial: boolean) => void) {
@@ -1399,7 +1400,6 @@ export class FantasyPIXIInstance {
     devLog.debug(`👾 Monster state changed: ${this.monsterGameState.state} -> ${newState}`, {
       previousState: this.monsterGameState.state,
       newState: newState,
-      health: this.monsterGameState.health,
       hitCount: this.monsterGameState.hitCount,
       isDestroyed: this.isDestroyed
     });

--- a/src/utils/performanceOptimizer.ts
+++ b/src/utils/performanceOptimizer.ts
@@ -565,7 +565,6 @@ declare global {
   interface Window {
     unifiedFrameController: UnifiedFrameController;
     renderOptimizer: RenderOptimizer;
-    performanceMonitor: PerformanceMonitor;
     performanceDebugger: PerformanceDebugger;
   }
 }


### PR DESCRIPTION
Fix unrecoverable errors in fantasy mode to restore functionality.

The previous commit introduced several issues causing the fantasy mode to be unplayable. These included type mismatches (`currentChordTarget`), missing arguments (`initializeGame`), undefined properties (`DamageNumberData`, `monsterGameState.health`), references to non-existent classes (`MonsterStateMachine`), and duplicate global declarations (`performanceMonitor`). This PR addresses these issues to ensure stable operation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6d301435-1e58-4fe6-8edf-30090207b2c1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6d301435-1e58-4fe6-8edf-30090207b2c1)