### PR TITLE
Verify magic link login functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import LandingPage from '@/components/LandingPage';
 import AuthLanding from '@/components/auth/AuthLanding';
 import { useAuthStore } from '@/stores/authStore';
+import ToastContainer from '@/components/ui/ToastContainer';
 
 // LegacyApp はバンドルサイズが大きいため遅延読み込みする
 const LegacyApp = React.lazy(() => import('./LegacyApp'));
@@ -21,20 +22,23 @@ const App: React.FC = () => {
   }
 
   return (
-    <Suspense
-      fallback={
-        <div className="w-full h-screen flex items-center justify-center text-white">
-          Loading...
-        </div>
-      }
-    >
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/auth" element={<AuthLanding />} />
-        <Route path="/main" element={<LegacyApp />} />
-        <Route path="/*" element={<LegacyApp />} />
-      </Routes>
-    </Suspense>
+    <>
+      <Suspense
+        fallback={
+          <div className="w-full h-screen flex items-center justify-center text-white">
+            Loading...
+          </div>
+        }
+      >
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/auth" element={<AuthLanding />} />
+          <Route path="/main" element={<LegacyApp />} />
+          <Route path="/*" element={<LegacyApp />} />
+        </Routes>
+      </Suspense>
+      <ToastContainer />
+    </>
   );
 };
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,34 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
-import { useToast } from '@/stores/toastStore';
 
-const LandingPage: React.FC = () => {
-  const toast = useToast();
-
-  useEffect(() => {
-    // セッションストレージからマジックリンク送信メッセージをチェック
-    const magicLinkData = sessionStorage.getItem('magicLinkSent');
-    if (magicLinkData) {
-      try {
-        const { message, title, timestamp } = JSON.parse(magicLinkData);
-        // 5分以内のメッセージのみ表示
-        if (Date.now() - timestamp < 300000) {
-          toast.success(message, {
-            title,
-            duration: 5000,
-          });
-        }
-      } catch (e) {
-        console.error('マジックリンク通知の処理に失敗しました:', e);
-      } finally {
-        // 一度表示したら削除
-        sessionStorage.removeItem('magicLinkSent');
-      }
-    }
-  }, [toast]);
-
-  return (
+const LandingPage: React.FC = () => (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 to-black text-white p-4 space-y-6 text-center">
       <Helmet>
         <title>Jazz Learning Game</title>
@@ -41,7 +15,6 @@ const LandingPage: React.FC = () => {
         <Link to="/auth?guest=1" className="btn btn-secondary">ゲストプレイ</Link>
       </div>
     </div>
-  );
-};
+);
 
 export default LandingPage;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,20 +1,47 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
+import { useToast } from '@/stores/toastStore';
 
-const LandingPage: React.FC = () => (
-  <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 to-black text-white p-4 space-y-6 text-center">
-    <Helmet>
-      <title>Jazz Learning Game</title>
-      <meta name="description" content="Jazz Learning Game - Learn jazz piano and guitar through interactive gameplay" />
-    </Helmet>
-    <h1 className="text-4xl font-bold">Jazz Learning Game</h1>
-    <p className="max-w-xl">インタラクティブな学習体験でジャズの世界へ。</p>
-    <div className="flex space-x-4">
-      <Link to="/auth" className="btn btn-primary">ログイン / 会員登録</Link>
-      <Link to="/auth?guest=1" className="btn btn-secondary">ゲストプレイ</Link>
+const LandingPage: React.FC = () => {
+  const toast = useToast();
+
+  useEffect(() => {
+    // セッションストレージからマジックリンク送信メッセージをチェック
+    const magicLinkData = sessionStorage.getItem('magicLinkSent');
+    if (magicLinkData) {
+      try {
+        const { message, title, timestamp } = JSON.parse(magicLinkData);
+        // 5分以内のメッセージのみ表示
+        if (Date.now() - timestamp < 300000) {
+          toast.success(message, {
+            title,
+            duration: 5000,
+          });
+        }
+      } catch (e) {
+        console.error('マジックリンク通知の処理に失敗しました:', e);
+      } finally {
+        // 一度表示したら削除
+        sessionStorage.removeItem('magicLinkSent');
+      }
+    }
+  }, [toast]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 to-black text-white p-4 space-y-6 text-center">
+      <Helmet>
+        <title>Jazz Learning Game</title>
+        <meta name="description" content="Jazz Learning Game - Learn jazz piano and guitar through interactive gameplay" />
+      </Helmet>
+      <h1 className="text-4xl font-bold">Jazz Learning Game</h1>
+      <p className="max-w-xl">インタラクティブな学習体験でジャズの世界へ。</p>
+      <div className="flex space-x-4">
+        <Link to="/auth" className="btn btn-primary">ログイン / 会員登録</Link>
+        <Link to="/auth?guest=1" className="btn btn-secondary">ゲストプレイ</Link>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default LandingPage;

--- a/src/components/auth/AuthLanding.tsx
+++ b/src/components/auth/AuthLanding.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { useToast, getValidationMessage, handleApiError } from '@/stores/toastStore';
 import { 
@@ -15,7 +14,6 @@ const AuthLanding: React.FC = () => {
   const [signupDisabled, setSignupDisabled] = useState(false);
   const { loginWithMagicLink, enterGuestMode, loading, error } = useAuthStore();
   const toast = useToast();
-  const navigate = useNavigate();
 
   // 開発環境でのみデバッグ情報を表示
   useEffect(() => {
@@ -38,20 +36,15 @@ const AuthLanding: React.FC = () => {
     try {
       await loginWithMagicLink(email, mode);
       
-      // 成功メッセージを準備
+      // 成功メッセージを表示
       const successMessage = mode === 'signup' 
         ? 'Magic Link を送信しました（会員登録）'
         : 'Magic Link を送信しました（ログイン）';
-      
-      // セッションストレージに成功メッセージを保存
-      sessionStorage.setItem('magicLinkSent', JSON.stringify({
-        message: successMessage,
+        
+      toast.success(successMessage, {
         title: 'メール送信完了',
-        timestamp: Date.now()
-      }));
-      
-      // トップページにリダイレクト
-      navigate('/');
+        duration: 5000,
+      });
     } catch (err) {
       // エラーメッセージを適切に処理
       const errorMessage = err instanceof Error ? err.message : 'Magic Link送信に失敗しました';

--- a/src/components/auth/AuthLanding.tsx
+++ b/src/components/auth/AuthLanding.tsx
@@ -12,7 +12,10 @@ const AuthLanding: React.FC = () => {
   const [email, setEmail] = useState('');
   const [showDebugInfo, setShowDebugInfo] = useState(false);
   const [signupDisabled, setSignupDisabled] = useState(false);
-  const { loginWithMagicLink, enterGuestMode, loading, error } = useAuthStore();
+  const [useOtp, setUseOtp] = useState(false); // OTPモードの切り替え
+  const [otpCode, setOtpCode] = useState(''); // OTPコード
+  const [otpSent, setOtpSent] = useState(false); // OTP送信済みフラグ
+  const { loginWithMagicLink, verifyOtp, enterGuestMode, loading, error } = useAuthStore();
   const toast = useToast();
 
   // 開発環境でのみデバッグ情報を表示
@@ -36,15 +39,24 @@ const AuthLanding: React.FC = () => {
     try {
       await loginWithMagicLink(email, mode);
       
-      // 成功メッセージを表示
-      const successMessage = mode === 'signup' 
-        ? 'Magic Link を送信しました（会員登録）'
-        : 'Magic Link を送信しました（ログイン）';
-        
-      toast.success(successMessage, {
-        title: 'メール送信完了',
-        duration: 5000,
-      });
+      if (useOtp) {
+        // OTPモードの場合
+        setOtpSent(true);
+        toast.success('認証コードを送信しました。メールをご確認ください。', {
+          title: 'コード送信完了',
+          duration: 5000,
+        });
+      } else {
+        // マジックリンクモードの場合
+        const successMessage = mode === 'signup' 
+          ? 'Magic Link を送信しました（会員登録）'
+          : 'Magic Link を送信しました（ログイン）';
+          
+        toast.success(successMessage, {
+          title: 'メール送信完了',
+          duration: 5000,
+        });
+      }
     } catch (err) {
       // エラーメッセージを適切に処理
       const errorMessage = err instanceof Error ? err.message : 'Magic Link送信に失敗しました';
@@ -58,6 +70,26 @@ const AuthLanding: React.FC = () => {
       } else {
         toast.error(handleApiError(err, 'Magic Link送信'));
       }
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    if (!otpCode.trim()) {
+      return toast.error('認証コードを入力してください');
+    }
+    
+    if (otpCode.length !== 6) {
+      return toast.error('認証コードは6桁で入力してください');
+    }
+
+    try {
+      await verifyOtp(email, otpCode);
+      toast.success('ログインに成功しました', {
+        title: 'ログイン完了',
+        duration: 3000,
+      });
+    } catch (err) {
+      toast.error(handleApiError(err, 'OTP検証'));
     }
   };
 
@@ -167,24 +199,89 @@ const AuthLanding: React.FC = () => {
         )}
 
         <div className="bg-slate-800/60 p-6 rounded-lg space-y-4">
-          <div>
-            <label className="block text-sm mb-1">メールアドレスでログイン / 登録</label>
-            <input
-              type="email"
-              className="input input-bordered w-full"
-              value={email}
-              onChange={e=>setEmail(e.target.value)}
-              placeholder="you@example.com"
-            />
+          {/* OTPモード切り替えトグル */}
+          <div className="flex items-center justify-between mb-4">
+            <label className="text-sm">認証方法</label>
+            <div className="flex items-center space-x-2">
+              <span className={`text-sm ${!useOtp ? 'text-blue-400' : 'text-gray-400'}`}>マジックリンク</span>
+              <label className="swap swap-flip">
+                <input 
+                  type="checkbox" 
+                  checked={useOtp} 
+                  onChange={(e) => {
+                    setUseOtp(e.target.checked);
+                    setOtpSent(false);
+                    setOtpCode('');
+                  }} 
+                />
+                <div className="swap-on">📱</div>
+                <div className="swap-off">✉️</div>
+              </label>
+              <span className={`text-sm ${useOtp ? 'text-blue-400' : 'text-gray-400'}`}>認証コード</span>
+            </div>
           </div>
-          <div className="flex space-x-2">
-            <button className="btn btn-primary flex-1" disabled={loading || signupDisabled} onClick={()=>{void handleSendLink('signup')}}>
-              会員登録
-            </button>
-            <button className="btn btn-outline flex-1" disabled={loading} onClick={()=>{void handleSendLink('login')}}>
-              ログイン
-            </button>
-          </div>
+
+          {!otpSent ? (
+            <>
+              <div>
+                <label className="block text-sm mb-1">メールアドレスでログイン / 登録</label>
+                <input
+                  type="email"
+                  className="input input-bordered w-full"
+                  value={email}
+                  onChange={e=>setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                />
+              </div>
+              <div className="flex space-x-2">
+                <button className="btn btn-primary flex-1" disabled={loading || signupDisabled} onClick={()=>{void handleSendLink('signup')}}>
+                  会員登録
+                </button>
+                <button className="btn btn-outline flex-1" disabled={loading} onClick={()=>{void handleSendLink('login')}}>
+                  ログイン
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="text-center text-sm text-gray-300 mb-4">
+                <p>{email} に6桁の認証コードを送信しました</p>
+                <p className="text-xs text-gray-400 mt-1">メールが届かない場合は迷惑メールフォルダをご確認ください</p>
+              </div>
+              <div>
+                <label className="block text-sm mb-1">認証コード（6桁）</label>
+                <input
+                  type="text"
+                  className="input input-bordered w-full text-center text-2xl tracking-widest"
+                  value={otpCode}
+                  onChange={e => {
+                    const value = e.target.value.replace(/[^0-9]/g, '');
+                    if (value.length <= 6) {
+                      setOtpCode(value);
+                    }
+                  }}
+                  placeholder="000000"
+                  maxLength={6}
+                />
+              </div>
+              <button 
+                className="btn btn-primary w-full" 
+                disabled={loading || otpCode.length !== 6} 
+                onClick={()=>{void handleVerifyOtp()}}
+              >
+                認証する
+              </button>
+              <button 
+                className="btn btn-ghost btn-sm w-full" 
+                onClick={() => {
+                  setOtpSent(false);
+                  setOtpCode('');
+                }}
+              >
+                戻る
+              </button>
+            </>
+          )}
           {error && <p className="text-red-400 text-sm">{error}</p>}
           {signupDisabled && (
             <div className="bg-orange-900/30 border border-orange-500/50 rounded p-3 text-sm">
@@ -195,7 +292,9 @@ const AuthLanding: React.FC = () => {
               </div>
             </div>
           )}
-          <div className="text-center text-xs text-gray-400">リンクを開くと自動でログインします</div>
+          <div className="text-center text-xs text-gray-400">
+            {useOtp ? '認証コードは異なるデバイスでも使用できます' : 'リンクを開くと自動でログインします（同じブラウザでのみ有効）'}
+          </div>
           
           {/* トラブルシューティング情報 */}
           <div className="text-center text-xs text-gray-500 space-y-1">

--- a/src/components/auth/AuthLanding.tsx
+++ b/src/components/auth/AuthLanding.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { useToast, getValidationMessage, handleApiError } from '@/stores/toastStore';
 import { 
@@ -14,6 +15,7 @@ const AuthLanding: React.FC = () => {
   const [signupDisabled, setSignupDisabled] = useState(false);
   const { loginWithMagicLink, enterGuestMode, loading, error } = useAuthStore();
   const toast = useToast();
+  const navigate = useNavigate();
 
   // 開発環境でのみデバッグ情報を表示
   useEffect(() => {
@@ -36,15 +38,20 @@ const AuthLanding: React.FC = () => {
     try {
       await loginWithMagicLink(email, mode);
       
-      // 成功メッセージを表示
+      // 成功メッセージを準備
       const successMessage = mode === 'signup' 
         ? 'Magic Link を送信しました（会員登録）'
         : 'Magic Link を送信しました（ログイン）';
-        
-      toast.success(successMessage, {
+      
+      // セッションストレージに成功メッセージを保存
+      sessionStorage.setItem('magicLinkSent', JSON.stringify({
+        message: successMessage,
         title: 'メール送信完了',
-        duration: 5000,
-      });
+        timestamp: Date.now()
+      }));
+      
+      // トップページにリダイレクト
+      navigate('/');
     } catch (err) {
       // エラーメッセージを適切に処理
       const errorMessage = err instanceof Error ? err.message : 'Magic Link送信に失敗しました';


### PR DESCRIPTION
Implement OTP authentication to allow cross-device login and ensure magic link sent toast is displayed.

Magic links using Supabase's default PKCE flow do not work across different browsers/devices for security reasons. This PR introduces an OTP (One-Time Password) authentication option, allowing users to choose between magic link (same device) and OTP (cross-device) for login. Additionally, it fixes an issue where the 'Magic Link sent' toast notification was not visible due to the `ToastContainer` being missing from the main application layout.

---

[Open in Web](https://www.cursor.com/agents?id=bc-db006641-dca3-45c0-b2ef-d7f83e0bbcd5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-db006641-dca3-45c0-b2ef-d7f83e0bbcd5)