### PR TITLE
ログインフローのワンタイムパスワード問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import LandingPage from '@/components/LandingPage';
 import AuthLanding from '@/components/auth/AuthLanding';
+import AuthCallback from '@/components/auth/AuthCallback';
 import { useAuthStore } from '@/stores/authStore';
 import ToastContainer from '@/components/ui/ToastContainer';
 
@@ -33,6 +34,7 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/auth" element={<AuthLanding />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
           <Route path="/main" element={<LegacyApp />} />
           <Route path="/*" element={<LegacyApp />} />
         </Routes>

--- a/src/components/auth/AuthCallback.tsx
+++ b/src/components/auth/AuthCallback.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import { useToast } from '@/stores/toastStore';
+
+/**
+ * マジックリンク認証後のコールバックページ
+ * URLのhashパラメータから認証情報を取得し、セッションを確立する
+ */
+const AuthCallback: React.FC = () => {
+  const navigate = useNavigate();
+  const { init } = useAuthStore();
+  const toast = useToast();
+  const [processing, setProcessing] = useState(true);
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        // URLのhashパラメータを確認
+        const hashParams = new URLSearchParams(window.location.hash.substring(1));
+        const error = hashParams.get('error');
+        const errorDescription = hashParams.get('error_description');
+
+        if (error) {
+          console.error('認証エラー:', error, errorDescription);
+          toast.error(errorDescription || '認証に失敗しました', {
+            title: '認証エラー',
+            duration: 5000,
+          });
+          navigate('/');
+          return;
+        }
+
+        // 認証状態を初期化（これによりSupabaseがトークンを処理する）
+        await init();
+
+        toast.success('ログインに成功しました', {
+          title: 'ログイン完了',
+          duration: 3000,
+        });
+
+        // ホーム画面にリダイレクト
+        navigate('/');
+      } catch (err) {
+        console.error('コールバック処理エラー:', err);
+        toast.error('認証処理中にエラーが発生しました', {
+          title: 'エラー',
+          duration: 5000,
+        });
+        navigate('/');
+      } finally {
+        setProcessing(false);
+      }
+    };
+
+    void handleCallback();
+  }, [init, navigate, toast]);
+
+  if (processing) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 to-black text-white">
+        <div className="flex flex-col items-center space-y-4">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+          <div>認証処理中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default AuthCallback;

--- a/src/components/auth/AuthLanding.tsx
+++ b/src/components/auth/AuthLanding.tsx
@@ -37,7 +37,7 @@ const AuthLanding: React.FC = () => {
     }
 
     try {
-      await loginWithMagicLink(email, mode);
+      await loginWithMagicLink(email, mode, useOtp);
       
       if (useOtp) {
         // OTPモードの場合


### PR DESCRIPTION
Fix OTP and Magic Link login flows by separating their logic and implementing a dedicated callback for magic links.

The `signInWithOtp` function was being used for both OTP and magic links without proper differentiation, leading to incorrect email content (no 6-digit code for OTP) and broken redirection for magic links. This PR introduces a `useOtp` flag to distinguish the flows and adds a new `/auth/callback` page to correctly handle magic link redirections and session establishment.

---

[Open in Web](https://www.cursor.com/agents?id=bc-353f1657-6aa5-4078-a408-a4e4b09eb984) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-353f1657-6aa5-4078-a408-a4e4b09eb984)