### PR TITLE
Fix game start after stage selection

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -444,10 +444,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   }, []);
   
   // ゲーム開始前画面（スタートボタン表示条件を修正）
-  if (!gameState.isGameActive || !gameState.currentChordTarget) {
+  if (!gameState.isGameActive) {
     devLog.debug('🎮 ゲーム開始前画面表示:', { 
       isGameActive: gameState.isGameActive,
-      hasCurrentChord: !!gameState.currentChordTarget,
+      activeMonsters: gameState.activeMonsters?.length || 0,
       stageName: stage.name
     });
     
@@ -471,7 +471,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           {process.env.NODE_ENV === 'development' && (
             <div className="mt-4 bg-black bg-opacity-50 text-white text-xs p-3 rounded">
               <div>ゲーム状態: {gameState.isGameActive ? 'アクティブ' : '非アクティブ'}</div>
-              <div>現在のコード: {gameState.currentChordTarget ? gameState.currentChordTarget.displayName : 'なし'}</div>
+              <div>アクティブモンスター数: {gameState.activeMonsters?.length || 0}</div>
               <div>許可コード数: {stage.allowedChords?.length || 0}</div>
               <div>敵ゲージ秒数: {stage.enemyGaugeSeconds}</div>
             </div>


### PR DESCRIPTION
<!-- Fixes Fantasy Mode game not starting by correcting game state check in `FantasyGameScreen.tsx`. -->

<!-- The `FantasyGameScreen.tsx` component was checking for `gameState.currentChordTarget` to determine if the game should start, but `FantasyGameEngine.tsx` no longer uses this property. This PR updates `FantasyGameScreen.tsx` to check `gameState.isGameActive` and display `activeMonsters` count for debugging, resolving the issue where the game would not proceed after stage selection. -->

---

[Open in Web](https://www.cursor.com/agents?id=bc-938028b8-ae87-43ae-a54b-a3ddf7a97088) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-938028b8-ae87-43ae-a54b-a3ddf7a97088)