### PR TITLE
Fix midi device reset on stage reselection

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -119,6 +119,22 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       localStorage.removeItem('fantasyMidiDeviceId');
     }
   }, [midiDeviceId]);
+
+  // ステージ変更時にMIDI接続を確認・復元
+  useEffect(() => {
+    const restoreMidiConnection = async () => {
+      if (midiControllerRef.current && midiDeviceId) {
+        const isRestored = await midiControllerRef.current.checkAndRestoreConnection();
+        if (isRestored) {
+          devLog.debug('✅ ステージ変更後のMIDI接続を復元しました');
+        }
+      }
+    };
+
+    // 少し遅延を入れて確実に復元
+    const timer = setTimeout(restoreMidiConnection, 100);
+    return () => clearTimeout(timer);
+  }, [stage, midiDeviceId]); // stageが変更されたときに実行
   
   // PIXI.js レンダラー
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -605,6 +605,22 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     connectMidiDevice();
   }, [settings.selectedMidiDevice, pixiRenderer]); // pixiRendererを依存配列に追加
 
+  // 楽曲変更時にMIDI接続を確認・復元
+  useEffect(() => {
+    const restoreMidiConnection = async () => {
+      if (midiControllerRef.current && settings.selectedMidiDevice && pixiRenderer) {
+        const isRestored = await midiControllerRef.current.checkAndRestoreConnection();
+        if (isRestored) {
+          log.info('✅ 楽曲変更後のMIDI接続を復元しました');
+        }
+      }
+    };
+
+    // 少し遅延を入れて確実に復元
+    const timer = setTimeout(restoreMidiConnection, 200);
+    return () => clearTimeout(timer);
+  }, [currentSong, settings.selectedMidiDevice, pixiRenderer]); // currentSongが変更されたときに実行
+
   // 音声デバイス選択変更監視
   useEffect(() => {
     const connectAudioDevice = async () => {

--- a/src/components/ui/MidiDeviceManager.tsx
+++ b/src/components/ui/MidiDeviceManager.tsx
@@ -168,6 +168,22 @@ export const MidiDeviceSelector: React.FC<MidiDeviceSelectorProps> = ({
   className = ''
 }) => {
   const { devices, isRefreshing, error, refreshDevices } = useMidiDevices();
+  const [forceReconnect, setForceReconnect] = useState(false);
+
+  // デバイス選択時の処理を改善
+  const handleDeviceChange = (newDeviceId: string | null) => {
+    // 同じデバイスを選択した場合は一度切断してから再接続
+    if (newDeviceId && newDeviceId === value) {
+      console.log('🔄 同じデバイスが選択されました。再接続を試みます...');
+      // 一度nullを設定してから再度設定することで再接続を強制
+      onChange(null);
+      setTimeout(() => {
+        onChange(newDeviceId);
+      }, 100);
+    } else {
+      onChange(newDeviceId);
+    }
+  };
 
   return (
     <div className={`space-y-3 ${className}`}>
@@ -179,7 +195,7 @@ export const MidiDeviceSelector: React.FC<MidiDeviceSelectorProps> = ({
         <div className="flex gap-2">
           <select
             value={value || ''}
-            onChange={(e) => onChange(e.target.value || null)}
+            onChange={(e) => handleDeviceChange(e.target.value || null)}
             className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-blue-600"
             disabled={isRefreshing}
           >

--- a/src/utils/MidiController.ts
+++ b/src/utils/MidiController.ts
@@ -401,6 +401,38 @@ export class MIDIController {
     return this.currentDeviceId;
   }
 
+  /**
+   * 現在選択されているデバイスとの接続状態を確認し、必要に応じて再接続する
+   * @returns 接続が成功したかどうか
+   */
+  public async checkAndRestoreConnection(): Promise<boolean> {
+    if (!this.currentDeviceId) {
+      return false;
+    }
+
+    // 現在のデバイスが実際に接続されているか確認
+    if (!this.midiAccess) {
+      console.warn('⚠️ MIDI access not available');
+      return false;
+    }
+
+    const input = this.midiAccess.inputs.get(this.currentDeviceId);
+    if (!input || input.state !== 'connected') {
+      console.log('🔄 Device disconnected, attempting to reconnect...');
+      return this.connectDevice(this.currentDeviceId);
+    }
+
+    // 既に接続されているが、メッセージハンドラが設定されていない場合
+    if (!input.onmidimessage) {
+      console.log('🔧 Restoring message handler for connected device');
+      input.onmidimessage = this.handleMIDIMessage;
+      this.isEnabled = true;
+      this.notifyConnectionChange(true);
+    }
+
+    return true;
+  }
+
   public getCurrentDeviceName(): string | null {
     if (!this.currentDeviceId || !this.midiAccess) return null;
     


### PR DESCRIPTION
Ensures MIDI device connections persist across stage/song changes and simplifies device re-selection.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ac5f0de3-9a49-40f1-bb5b-afc2d2614f3e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ac5f0de3-9a49-40f1-bb5b-afc2d2614f3e)