### PR TITLE
Continue fantasy mode multi-monster implementation

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -487,12 +487,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // SPゲージ表示
   const renderSpGauge = useCallback((sp: number) => {
     const spBlocks = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 5; i++) {
       spBlocks.push(
         <div
           key={i}
           className={cn(
-            "w-12 h-3 rounded transition-all duration-300",
+            "w-10 h-3 rounded transition-all duration-300",
             i < sp ? 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.7)]' : 'bg-gray-600'
           )}
         />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance Fantasy Mode multi-monster gameplay by ensuring unique chords, adjusting SP mechanics, and improving input reliability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses issues where the same chord could appear for multiple monsters simultaneously, and where rapid correct inputs were sometimes not registered. It also rebalances the SP gauge system to allow for a more strategic special attack and adds a consequence for taking enemy damage.

---

[Open in Web](https://www.cursor.com/agents?id=bc-00ddb096-f68b-4056-a6f5-2d6fd5b0a5c8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-00ddb096-f68b-4056-a6f5-2d6fd5b0a5c8)