### PR TITLE
Fix monster textures and ui display

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -138,12 +138,21 @@ const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
 // ===== 敵リスト定義 =====
 
 const ENEMY_LIST = [
-  { id: 'vampire', icon: 'vampire', name: 'ドラキュラ' },
-  { id: 'monster', icon: 'monster', name: '怪獣' },
-  { id: 'reaper', icon: 'reaper', name: '死神' },
-  { id: 'kraken', icon: 'kraken', name: 'クラーケン' },
-  { id: 'werewolf', icon: 'werewolf', name: '狼男' },
-  { id: 'demon', icon: 'demon', name: '魔王' }
+  { id: 'devil', icon: 'devil', name: '悪魔' },
+  { id: 'dragon', icon: 'dragon', name: 'レッドドラゴン' },
+  { id: 'mao', icon: 'mao', name: '魔王' },
+  { id: 'mummy', icon: 'mummy', name: 'ミイラ' },
+  { id: 'shinigami', icon: 'shinigami', name: '死神' },
+  { id: 'slime_green', icon: 'slime_green', name: 'グリーンスライム' },
+  { id: 'slime_red', icon: 'slime_red', name: 'レッドスライム' },
+  { id: 'zombie', icon: 'zombie', name: 'ゾンビ' },
+  { id: 'skeleton', icon: 'skeleton', name: 'スケルトン' },
+  { id: 'grey', icon: 'grey', name: 'グレイ' },
+  { id: 'pumpkin', icon: 'pumpkin', name: 'パンプキン' },
+  { id: 'alien', icon: 'alien', name: '火星人' },
+  { id: 'bat1', icon: 'bat1', name: 'コウモリ' },
+  { id: 'bat2', icon: 'bat2', name: 'バット' },
+  { id: 'ghost', icon: 'ghost', name: 'ゴースト' }
 ];
 
 // ===== ヘルパー関数 =====
@@ -158,7 +167,9 @@ const createMonsterFromQueue = (
   allowedChords: string[],
   previousChordId?: string
 ): MonsterState => {
-  const enemy = ENEMY_LIST[monsterIndex % ENEMY_LIST.length];
+  // 完全にランダムにモンスターを選択
+  const randomIndex = Math.floor(Math.random() * ENEMY_LIST.length);
+  const enemy = ENEMY_LIST[randomIndex];
   const chord = selectUniqueRandomChord(allowedChords, previousChordId);
   
   return {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -479,15 +479,20 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     return hearts;
   }, []);
   
-  const renderPlayerHpBar = (hp: number, maxHp: number) => (
-    <div className="w-40 h-4 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative">
-      <div
-        className="h-full bg-gradient-to-r from-green-500 to-green-700 transition-all duration-300"
-        style={{ width: `${(hp / maxHp) * 100}%` }}
-      />
-      <div className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white">
-        {hp}/{maxHp}
-      </div>
+  const renderHearts = (hp: number, maxHp: number) => (
+    <div className="flex space-x-0.5">
+      {Array.from({length: maxHp}).map((_, i) => (
+        <span 
+          key={i}
+          className={
+            i < hp
+            ? "text-red-500 drop-shadow-sm text-2xl"
+            : "text-gray-600 text-2xl"
+          }
+        >
+          ♥
+        </span>
+      ))}
     </div>
   );
   
@@ -771,10 +776,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       </div>
       
       {/* HP・SPゲージを固定配置 */}
-      <div className="absolute left-2 bottom-[140px] z-30">
-        {renderPlayerHpBar(gameState.playerHp, stage.maxHp)}
+      <div className="absolute left-2 bottom-2 z-50
+                  pointer-events-none bg-black/40 rounded px-2 py-1">
+        {renderHearts(gameState.playerHp, stage.maxHp)}
       </div>
-      <div className="absolute right-2 bottom-[140px] z-30">
+      <div className="absolute right-2 bottom-2 z-50
+                  pointer-events-none bg-black/40 rounded px-2 py-1">
         {renderSpGauge(gameState.playerSp)}
       </div>
       

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -282,7 +282,7 @@ export class FantasyPIXIInstance {
   private async loadMonsterTextures(): Promise<void> {
     try {
       // ▼▼▼ 変更点 ▼▼▼
-      // 複数のモンスター画像をロードする
+      // 複数のモンスター画像をロードする（ENEMY_LISTと完全に一致させる）
       const monsterIcons = ['devil', 'dragon', 'mao', 'mummy', 'shinigami', 'slime_green', 'slime_red', 'zombie', 'skeleton', 'grey', 'pumpkin', 'alien', 'bat1', 'bat2', 'ghost'];
       const iconMap: Record<string, string> = {
         devil:        'character_monster_devil_purple.png',
@@ -536,12 +536,18 @@ export class FantasyPIXIInstance {
     try {
       // ▼▼▼ 変更点 ▼▼▼
       // iconに基づいてテクスチャを動的に選択
-      const texture = this.imageTextures.get(icon);
-      // ▲▲▲ ここまで ▲▲▲
+      let texture = this.imageTextures.get(icon);
+      
+      // テクスチャが見つからない場合はフォールバックを使用
       if (!texture || texture.destroyed) {
-        devLog.debug('⚠️ モンスターテクスチャが見つかりません:', { id, icon });
-        return null;
+        devLog.debug('⚠️ モンスターテクスチャが見つかりません、フォールバックを使用:', { id, icon });
+        texture = this.imageTextures.get('default_monster');
+        if (!texture || texture.destroyed) {
+          devLog.debug('❌ フォールバックテクスチャも見つかりません');
+          return null;
+        }
       }
+      // ▲▲▲ ここまで ▲▲▲
       
       const sprite = new PIXI.Sprite(texture);
 


### PR DESCRIPTION
<!-- Resolve monster texture loading errors and enhance player UI display. -->

<!-- Previously, missing monster textures led to sprite creation failures, preventing magic effects and damage numbers from appearing. This PR updates monster lists and texture loading to ensure all monsters display correctly, including a fallback. Additionally, player HP is now shown with hearts, and both HP/SP displays are repositioned to avoid overlapping with the keyboard on mobile, improving overall UI clarity and responsiveness. -->

---

[Open in Web](https://www.cursor.com/agents?id=bc-5daad926-4b8f-4ae8-a2b9-04fe7fff2c56) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5daad926-4b8f-4ae8-a2b9-04fe7fff2c56)