### PR TITLE
Enhance enemy monster attack visuals

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -216,6 +216,15 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     // ★★★ 花火エフェクトを追加 ★★★
     if (attackingMonsterId) {
+      // PIXIのチャージエフェクトを開始
+      if (fantasyPixiInstance) {
+        fantasyPixiInstance.triggerMonsterChargingAttack(attackingMonsterId, true);
+        // 攻撃後にチャージ状態を解除
+        setTimeout(() => {
+          fantasyPixiInstance.triggerMonsterChargingAttack(attackingMonsterId, false);
+        }, 1000);
+      }
+      
       const el = gaugeRefs.current.get(attackingMonsterId);
       if (el) {
         const rect = el.getBoundingClientRect();

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -219,10 +219,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       // PIXIのチャージエフェクトを開始
       if (fantasyPixiInstance) {
         fantasyPixiInstance.triggerMonsterChargingAttack(attackingMonsterId, true);
-        // 攻撃後にチャージ状態を解除
-        setTimeout(() => {
-          fantasyPixiInstance.triggerMonsterChargingAttack(attackingMonsterId, false);
-        }, 1000);
+        // チャージ状態の解除はupdateMonsterAnimationで自動的に行われる
       }
       
       const el = gaugeRefs.current.get(attackingMonsterId);


### PR DESCRIPTION
Add visual effects (red tint/outline, anger mark, scale increase) to monsters when their attack gauge is full by integrating effects with `gameState` to prevent animation loop resets.

---

[Open in Web](https://www.cursor.com/agents?id=bc-68714cce-7289-467c-a83e-21dfafe8b2fe) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-68714cce-7289-467c-a83e-21dfafe8b2fe)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)