### PR TITLE
Fix fantasy mode keyboard click sound

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -298,7 +298,18 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // MIDI/音声入力のハンドリング
   const handleNoteInputBridge = useCallback(async (note: number) => {
-    // ファンタジーゲームエンジンにのみ送信（音声はMidiControllerが処理）
+    // 鍵盤クリック時にも音声を再生（MIDIControllerのplayNoteを使用）
+    if (midiControllerRef.current && (midiControllerRef.current as any).playMidiSound) {
+      try {
+        const { playNote } = await import('@/utils/MidiController');
+        await playNote(note, 100); // velocity 100で再生
+        devLog.debug('🎵 鍵盤クリック音再生:', { note });
+      } catch (error) {
+        console.error('Failed to play note:', error);
+      }
+    }
+    
+    // ファンタジーゲームエンジンに入力を送信
     engineHandleNoteInput(note);
   }, [engineHandleNoteInput]);
   
@@ -359,7 +370,16 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       // キーボードのクリックイベントを接続
       renderer.setKeyCallbacks(
         (note: number) => handleNoteInputBridge(note),
-        (note: number) => {} // マウスリリース時の処理はMidiControllerが担当
+        async (note: number) => {
+          // マウスリリース時に音を止める
+          try {
+            const { stopNote } = await import('@/utils/MidiController');
+            stopNote(note);
+            devLog.debug('🎵 鍵盤リリース音停止:', { note });
+          } catch (error) {
+            console.error('Failed to stop note:', error);
+          }
+        }
       );
       
               // MIDIControllerにキーハイライト機能を設定（通常プレイと同様の処理）


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable sound playback for fantasy mode piano key clicks by explicitly calling MidiController functions.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `handleNoteInputBridge` only forwarded key input to the game engine, causing no sound to play on key clicks. MIDI input worked because `MidiController` handled sound playback automatically. This PR adds explicit calls to `playNote` and `stopNote` within `handleNoteInputBridge` and the key release callback, respectively, to ensure sound is produced and stopped correctly for mouse clicks.

---

[Open in Web](https://www.cursor.com/agents?id=bc-99c036a0-d7c8-4eb4-8fc2-24e8fc6d5c06) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-99c036a0-d7c8-4eb4-8fc2-24e8fc6d5c06)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)