### PR TITLE
Stabilize monster enraged visual effects

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -252,6 +252,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     setDamageShake(true);
     setTimeout(() => setDamageShake(false), 500);
     
+    // 怒り状態をリセット
+    if (fantasyPixiInstance && attackingMonsterId) {
+      fantasyPixiInstance.resetEnrage(attackingMonsterId);
+    }
+    
   }, [fantasyPixiInstance]);
   
   const handleGameCompleteCallback = useCallback((result: 'clear' | 'gameover', finalState: FantasyGameState) => {


### PR DESCRIPTION
Implement stable "enraged" monster animation to prevent flickering by managing state with a flag.

The previous implementation re-evaluated the monster's "enraged" state every frame based on a fluctuating gauge value, leading to constant creation and destruction of visual elements (scale, outline, anger mark) and causing flickering. This PR introduces an `isEnraged` flag that is set once when the gauge reaches 100% and reset only when the monster attacks, ensuring the visual effects are applied and removed cleanly without flickering.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8bc6ceac-ffe6-49ca-a472-ce066bd57221) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8bc6ceac-ffe6-49ca-a472-ce066bd57221)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)