### PR TITLE
Manage enemy enraged state with zustand

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { devLog } from '@/utils/logger';
+import { useEnemyStore } from '@/stores/enemyStore';
 
 // ===== 型定義 =====
 
@@ -688,6 +689,11 @@ export const useFantasyGameEngine = ({
       if (attackingMonster) {
         console.log('🎲 Found attacking monster:', attackingMonster);
         devLog.debug('💥 モンスターゲージ満タン！攻撃開始', { monster: attackingMonster.name });
+        
+        // 怒り状態をストアに通知
+        const { setEnrage } = useEnemyStore.getState();
+        setEnrage(attackingMonster.id, true);
+        setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
         
         // 攻撃したモンスターのゲージをリセット
         const resetMonsters = updatedMonsters.map(m => 

--- a/src/stores/enemyStore.ts
+++ b/src/stores/enemyStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+type EnemyStore = {
+  /** 現在 "怒り中" のモンスター ID → true */
+  enraged: Record<string, boolean>;
+  /** 怒りフラグを立てる / 消す */
+  setEnrage: (id: string, value: boolean) => void;
+};
+
+export const useEnemyStore = create<EnemyStore>(set => ({
+  enraged: {},
+  setEnrage: (id, value) =>
+    set(state => ({
+      enraged: { ...state.enraged, [id]: value }
+    }))
+}));


### PR DESCRIPTION
Centralize monster "enraged state" in a Zustand store to decouple game logic and rendering.

This establishes a 3-layer architecture (logic, state, rendering), allowing future changes to AI or network synchronization without touching rendering code.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3714a522-4ec4-4f8d-b692-c20061816607) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3714a522-4ec4-4f8d-b692-c20061816607)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)