### PR TITLE
Fix fantasy magic spell sound effects

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/utils/cn';
 import { devLog } from '@/utils/logger';
 import { MonsterState as GameMonsterState } from './FantasyGameEngine';
 import { useEnemyStore } from '@/stores/enemyStore';
+import FantasySoundManager from '@/utils/FantasySoundManager';
 
 // ===== 型定義 =====
 
@@ -682,24 +683,40 @@ export class FantasyPIXIInstance {
       // 魔法タイプをローテーション
       const magicTypes = Object.keys(MAGIC_TYPES);
       const currentIndex = magicTypes.indexOf(this.currentMagicType);
+      devLog.debug('🎯 現在の魔法タイプ:', {
+        current: this.currentMagicType,
+        currentIndex,
+        magicTypes
+      });
       this.currentMagicType = magicTypes[(currentIndex + 1) % magicTypes.length];
       const magic = MAGIC_TYPES[this.currentMagicType];
+      devLog.debug('🎯 次の魔法タイプ:', {
+        next: this.currentMagicType,
+        magic
+      });
 
       // 魔法効果音を再生
-      try {
-        const { FantasySoundManager } = require('@/utils/FantasySoundManager');
-        // 魔法タイプを正しくマッピング
-        const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
-          'fire': 'fire',
-          'ice': 'ice',
-          'thunder': 'thunder'
-        };
-        const soundType = magicTypeMap[this.currentMagicType];
-        if (soundType) {
+      // 魔法タイプを正しくマッピング
+      const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
+        'fire': 'fire',
+        'ice': 'ice',
+        'thunder': 'thunder'
+      };
+      const soundType = magicTypeMap[this.currentMagicType];
+      devLog.debug('🔊 効果音タイプ:', {
+        currentMagicType: this.currentMagicType,
+        soundType,
+        magicTypeMap
+      });
+      if (soundType) {
+        try {
           FantasySoundManager.playMagic(soundType);
+          devLog.debug('🔊 魔法効果音再生(triggerAttackSuccessOnMonster):', soundType);
+        } catch (error) {
+          console.error('魔法効果音再生エラー:', error);
         }
-      } catch (error) {
-        console.error('Failed to play magic sound:', error);
+      } else {
+        console.warn('⚠️ soundTypeが未定義:', this.currentMagicType);
       }
 
       // 魔法名表示
@@ -758,24 +775,40 @@ export class FantasyPIXIInstance {
       // 魔法タイプをローテーション
       const magicTypes = Object.keys(MAGIC_TYPES);
       const currentIndex = magicTypes.indexOf(this.currentMagicType);
+      devLog.debug('🎯 現在の魔法タイプ:', {
+        current: this.currentMagicType,
+        currentIndex,
+        magicTypes
+      });
       this.currentMagicType = magicTypes[(currentIndex + 1) % magicTypes.length];
       const magic = MAGIC_TYPES[this.currentMagicType];
+      devLog.debug('🎯 次の魔法タイプ:', {
+        next: this.currentMagicType,
+        magic
+      });
 
       // 魔法効果音を再生
-      try {
-        const { FantasySoundManager } = require('@/utils/FantasySoundManager');
-        // 魔法タイプを正しくマッピング
-        const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
-          'fire': 'fire',
-          'ice': 'ice',
-          'thunder': 'thunder'
-        };
-        const soundType = magicTypeMap[this.currentMagicType];
-        if (soundType) {
+      // 魔法タイプを正しくマッピング
+      const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
+        'fire': 'fire',
+        'ice': 'ice',
+        'thunder': 'thunder'
+      };
+      const soundType = magicTypeMap[this.currentMagicType];
+      devLog.debug('🔊 効果音タイプ:', {
+        currentMagicType: this.currentMagicType,
+        soundType,
+        magicTypeMap
+      });
+      if (soundType) {
+        try {
           FantasySoundManager.playMagic(soundType);
+          devLog.debug('🔊 魔法効果音再生(triggerAttackSuccess):', soundType);
+        } catch (error) {
+          console.error('魔法効果音再生エラー:', error);
         }
-      } catch (error) {
-        console.error('Failed to play magic sound:', error);
+      } else {
+        console.warn('⚠️ soundTypeが未定義:', this.currentMagicType);
       }
 
       // 魔法名表示


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix magic sound effects not playing in fantasy mode.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `FantasySoundManager` was not correctly imported in `FantasyPIXIRenderer.tsx` (using `require()` instead of `import`), causing it to be undefined and preventing magic sound effects from playing. This PR corrects the import and adds robust error handling and detailed debug logs for sound playback.

---

[Open in Web](https://cursor.com/agents?id=bc-a7610a28-0695-43ef-b2cb-88baff8d26a8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a7610a28-0695-43ef-b2cb-88baff8d26a8)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)