### PR TITLE
Increase fantasy mode monster count and adjust size

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -35,13 +35,13 @@ interface FantasyStage {
   showGuide: boolean; // ガイド表示設定を追加
   monsterIcon: string;
   bgmUrl?: string;
-  simultaneousMonsterCount: number; // 同時出現モンスター数 (1-3)
+  simultaneousMonsterCount: number; // 同時出現モンスター数 (1-8)
 }
 
 interface MonsterState {
   id: string;
   index: number; // モンスターリストのインデックス
-  position: 'A' | 'B' | 'C'; // 列位置
+  position: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H'; // 列位置（最大8体対応）
   currentHp: number;
   maxHp: number;
   gauge: number;
@@ -165,7 +165,7 @@ const ENEMY_LIST = [
  */
 const createMonsterFromQueue = (
   monsterIndex: number,
-  position: 'A' | 'B' | 'C',
+  position: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H',
   enemyHp: number,
   allowedChords: string[],
   previousChordId?: string
@@ -190,12 +190,19 @@ const createMonsterFromQueue = (
 };
 
 /**
- * 位置を割り当て（A, B, C列に均等配置）
+ * 位置を割り当て（A-H列に均等配置）
  */
-const assignPositions = (count: number): ('A' | 'B' | 'C')[] => {
-  if (count === 1) return ['B']; // 1体の場合は中央
-  if (count === 2) return ['A', 'C']; // 2体の場合は左右
-  return ['A', 'B', 'C']; // 3体の場合は全列
+const assignPositions = (count: number): ('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H')[] => {
+  const allPositions: ('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H')[] = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+  
+  if (count === 1) return ['D']; // 1体の場合は中央寄り
+  if (count === 2) return ['C', 'F']; // 2体の場合は左右に配置
+  if (count === 3) return ['B', 'D', 'F']; // 3体の場合は均等配置
+  if (count === 4) return ['A', 'C', 'E', 'G']; // 4体の場合は均等配置
+  if (count === 5) return ['A', 'C', 'D', 'E', 'G']; // 5体の場合
+  if (count === 6) return ['A', 'B', 'C', 'E', 'F', 'G']; // 6体の場合
+  if (count === 7) return ['A', 'B', 'C', 'D', 'E', 'F', 'G']; // 7体の場合
+  return allPositions.slice(0, count); // 8体以上の場合は全列使用
 };
 
 /**
@@ -818,7 +825,7 @@ export const useFantasyGameEngine = ({
         const monstersToAddCount = Math.min(slotsToFill, newMonsterQueue.length);
 
         if (monstersToAddCount > 0) {
-          const availablePositions = ['A', 'B', 'C'].filter(pos => !remainingMonsters.some(m => m.position === pos));
+                      const availablePositions = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].filter(pos => !remainingMonsters.some(m => m.position === pos));
           const lastUsedChordId = completedMonsters.length > 0 ? completedMonsters[0].chordTarget.id : undefined;
 
           for (let i = 0; i < monstersToAddCount; i++) {
@@ -826,7 +833,7 @@ export const useFantasyGameEngine = ({
             const position = availablePositions[i] || 'B';
             const newMonster = createMonsterFromQueue(
               monsterIndex,
-              position as 'A' | 'B' | 'C',
+              position as 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H',
               stateAfterAttack.maxEnemyHp,
               stateAfterAttack.currentStage!.allowedChords,
               lastUsedChordId // 直前のコードを避ける

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -727,35 +727,75 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
               // ★★★ 修正点: flexboxで中央揃え、gap-0で隣接 ★★★
               <div className="flex justify-center items-start w-full mx-auto gap-0" style={{ height: 'min(120px,22vw)' }}>
                 {gameState.activeMonsters
-                  .sort((a, b) => a.position.localeCompare(b.position)) // 'A', 'B', 'C'順でソート
+                  .sort((a, b) => a.position.localeCompare(b.position)) // 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'順でソート
                   .map((monster) => {
+                    // モンスター数に応じて幅を動的に計算
+                    const monsterCount = gameState.activeMonsters.length;
+                    let widthPercent: string;
+                    let maxWidth: string;
+                    
+                    // モバイル判定（768px未満）
+                    const isMobile = window.innerWidth < 768;
+                    
+                    if (isMobile) {
+                      // モバイルの場合
+                      if (monsterCount <= 3) {
+                        widthPercent = '30%';
+                        maxWidth = '120px';
+                      } else if (monsterCount <= 5) {
+                        widthPercent = '18%';
+                        maxWidth = '80px';
+                      } else {
+                        // 6体以上
+                        widthPercent = '12%';
+                        maxWidth = '60px';
+                      }
+                    } else {
+                      // デスクトップの場合
+                      if (monsterCount <= 3) {
+                        widthPercent = '30%';
+                        maxWidth = '220px';
+                      } else if (monsterCount <= 5) {
+                        widthPercent = '18%';
+                        maxWidth = '150px';
+                      } else {
+                        // 6体以上
+                        widthPercent = '12%';
+                        maxWidth = '120px';
+                      }
+                    }
+                    
                     return (
                       <div 
                         key={monster.id}
                         // ★★★ 修正点: flexアイテムとして定義、幅を設定 ★★★
                         className="flex-shrink-0 flex flex-col items-center"
-                        style={{ width: '30%', maxWidth: '220px' }} // 幅を固定し、最大幅も設定
+                        style={{ width: widthPercent, maxWidth }} // 動的に幅を設定
                       >
                       {/* コードネーム */}
-                      <div className="text-yellow-300 text-xl font-bold text-center mb-1 truncate w-full"> {/* w-fullを追加 */}
+                      <div className={`text-yellow-300 font-bold text-center mb-1 truncate w-full ${
+                        monsterCount > 5 ? 'text-sm' : monsterCount > 3 ? 'text-base' : 'text-xl'
+                      }`}>
                         {monster.chordTarget.displayName}
                       </div>
                       
                       {/* ★★★ ここにヒント表示を追加 ★★★ */}
-                      <div className="mt-1 text-sm font-medium h-6 text-center">
+                      <div className={`mt-1 font-medium h-6 text-center ${
+                        monsterCount > 5 ? 'text-xs' : 'text-sm'
+                      }`}>
                         {monster.chordTarget.notes.map((note, index) => {
                           const noteMod12 = note % 12;
                           const noteName = getNoteNameFromMidi(note);
                           const isCorrect = monster.correctNotes.includes(noteMod12);
                           if (!showGuide && !isCorrect) {
                             return (
-                              <span key={index} className="mx-0.5 opacity-0 text-xs">
+                              <span key={index} className={`mx-0.5 opacity-0 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'}`}>
                                 ?
                               </span>
                             );
                           }
                           return (
-                            <span key={index} className={`mx-0.5 text-xs ${isCorrect ? 'text-green-400 font-bold' : 'text-gray-300'}`}>
+                            <span key={index} className={`mx-0.5 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'} ${isCorrect ? 'text-green-400 font-bold' : 'text-gray-300'}`}>
                               {noteName}
                               {isCorrect && '✓'}
                             </span>

--- a/supabase/migrations/20250721130002_increase_simultaneous_monsters.sql
+++ b/supabase/migrations/20250721130002_increase_simultaneous_monsters.sql
@@ -1,0 +1,11 @@
+-- 同時出現モンスター数の上限を8体に増やす
+
+-- 既存の制約を削除
+ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_simultaneous_monster_count_check;
+
+-- 新しい制約を追加（1-8体）
+ALTER TABLE fantasy_stages ADD CONSTRAINT fantasy_stages_simultaneous_monster_count_check 
+CHECK (simultaneous_monster_count >= 1 AND simultaneous_monster_count <= 8);
+
+-- コメントを更新
+COMMENT ON COLUMN fantasy_stages.simultaneous_monster_count IS '同時に出現するモンスターの数 (1-8)';


### PR DESCRIPTION
Increase simultaneous monster appearance count to 8 in fantasy mode and add responsive sizing for monsters on smaller screens.

---

[Open in Web](https://cursor.com/agents?id=bc-4583806d-6f45-4f1e-a32c-e221a6da9db4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4583806d-6f45-4f1e-a32c-e221a6da9db4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)