### PR TITLE
Fix fantasy mode chord and note display

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -15,6 +15,7 @@ interface ChordDefinition {
   id: string;          // コードのID（例: 'CM7', 'G7', 'Am'）
   displayName: string; // 表示名（言語・簡易化設定に応じて変更）
   notes: number[];     // MIDIノート番号の配列
+  noteNames: string[]; // ★ 理論的に正しい音名配列を追加
   quality: string;     // コードの性質（'major', 'minor', 'dominant7'など）
   root: string;        // ルート音（例: 'C', 'G', 'A'）
 }
@@ -122,6 +123,7 @@ const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDe
     id: chordId,
     displayName: resolved.displayName,
     notes: midiNotes,
+    noteNames: resolved.notes, // 理論的に正しい音名配列を追加
     quality: resolved.quality,
     root: resolved.root
   };

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -13,6 +13,8 @@ import { PIXINotesRenderer, PIXINotesRendererInstance } from '../game/PIXINotesR
 import { FantasyPIXIRenderer, FantasyPIXIInstance } from './FantasyPIXIRenderer';
 import FantasySettingsModal from './FantasySettingsModal';
 import type { DisplayOpts } from '@/utils/display-note';
+import { toDisplayName } from '@/utils/display-note';
+import { note as parseNote } from 'tonal';
 
 interface FantasyGameScreenProps {
   stage: FantasyStage;
@@ -296,12 +298,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 現在の敵情報を取得
   const currentEnemy = getCurrentEnemy(gameState.currentEnemyIndex);
-  
-  // MIDI番号から音名を取得する関数
-  const getNoteNameFromMidi = (midiNote: number): string => {
-    const noteNames = ['ド', 'ド#', 'レ', 'レ#', 'ミ', 'ファ', 'ファ#', 'ソ', 'ソ#', 'ラ', 'ラ#', 'シ'];
-    return noteNames[midiNote % 12];
-  };
   
   // MIDI/音声入力のハンドリング
   const handleNoteInputBridge = useCallback(async (note: number) => {
@@ -791,10 +787,18 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       <div className={`mt-1 font-medium h-6 text-center ${
                         monsterCount > 5 ? 'text-xs' : 'text-sm'
                       }`}>
-                        {monster.chordTarget.notes.map((note, index) => {
-                          const noteMod12 = note % 12;
-                          const noteName = getNoteNameFromMidi(note);
+                        {monster.chordTarget.noteNames.map((noteName, index) => {
+                          // 表示オプションを定義
+                          const displayOpts: DisplayOpts = { lang: currentNoteNameLang, simple: currentSimpleNoteName };
+                          // 表示用の音名に変換
+                          const displayNoteName = toDisplayName(noteName, displayOpts);
+                          
+                          // 正解判定用にMIDI番号を計算 (tonal.jsを使用)
+                          const noteObj = parseNote(noteName + '4'); // オクターブはダミー
+                          const noteMod12 = noteObj.midi !== null ? noteObj.midi % 12 : -1;
+                          
                           const isCorrect = monster.correctNotes.includes(noteMod12);
+
                           if (!showGuide && !isCorrect) {
                             return (
                               <span key={index} className={`mx-0.5 opacity-0 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'}`}>
@@ -804,7 +808,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                           }
                           return (
                             <span key={index} className={`mx-0.5 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'} ${isCorrect ? 'text-green-400 font-bold' : 'text-gray-300'}`}>
-                              {noteName}
+                              {displayNoteName}
                               {isCorrect && '✓'}
                             </span>
                           );

--- a/src/utils/display-note.ts
+++ b/src/utils/display-note.ts
@@ -14,6 +14,7 @@ export interface DisplayOpts {
 
 /**
  * 英語音名からドレミ（カタカナ）への変換マップ
+ * ★ ダブルシャープ(x)や理論的な異名同音の表記を追加・修正
  */
 const SOLFEGE_MAP: Record<string, string> = {
   // 基本音名
@@ -21,20 +22,21 @@ const SOLFEGE_MAP: Record<string, string> = {
   'G': 'ソ', 'A': 'ラ', 'B': 'シ',
   
   // シャープ系
-  'C#': 'ド♯', 'D#': 'レ♯', 'E#': 'ファ', 'F#': 'ファ♯',
-  'G#': 'ソ♯', 'A#': 'ラ♯', 'B#': 'ド',
+  'C#': 'ド♯', 'D#': 'レ♯', 'F#': 'ファ♯', 'G#': 'ソ♯', 'A#': 'ラ♯',
   
   // フラット系
-  'Cb': 'シ', 'Db': 'レ♭', 'Eb': 'ミ♭', 'Fb': 'ミ',
-  'Gb': 'ソ♭', 'Ab': 'ラ♭', 'Bb': 'シ♭',
+  'Db': 'レ♭', 'Eb': 'ミ♭', 'Gb': 'ソ♭', 'Ab': 'ラ♭', 'Bb': 'シ♭',
   
-  // ダブルシャープ（簡易化前）
-  'Cx': 'レ', 'Dx': 'ミ', 'Ex': 'ファ♯', 'Fx': 'ソ',
-  'Gx': 'ラ', 'Ax': 'シ', 'Bx': 'ド♯',
+  // 理論的な異名同音（簡易表示OFFの時に使われる）
+  'E#': 'ミ♯', 'B#': 'シ♯',
+  'Fb': 'ファ♭', 'Cb': 'シ♭',
+
+  // ダブルシャープ (## と x の両方に対応)
+  'C##': 'ドx', 'D##': 'レx', 'E##': 'ミx', 'F##': 'ファx', 'G##': 'ソx', 'A##': 'ラx', 'B##': 'シx',
+  'Cx': 'ドx', 'Dx': 'レx', 'Ex': 'ミx', 'Fx': 'ファx', 'Gx': 'ソx', 'Ax': 'ラx', 'Bx': 'シx',
   
-  // ダブルフラット（簡易化前）
-  'Cbb': 'シ♭', 'Dbb': 'ド', 'Ebb': 'レ', 'Fbb': 'ミ♭',
-  'Gbb': 'ファ', 'Abb': 'ソ', 'Bbb': 'ラ'
+  // ダブルフラット
+  'Cbb': 'ド♭♭', 'Dbb': 'レ♭♭', 'Ebb': 'ミ♭♭', 'Fbb': 'ファ♭♭', 'Gbb': 'ソ♭♭', 'Abb': 'ラ♭♭', 'Bbb': 'シ♭♭'
 };
 
 /**
@@ -55,6 +57,7 @@ const SIMPLIFY_MAP: Record<string, string> = {
 
 /**
  * 音名を表示用に変換（オクターブ情報なし）
+ * ★ 簡易表示ロジックを改善
  * @param noteName 元の音名（例: 'C', 'F#', 'Gbb', 'Fx4'）
  * @param opts 表示オプション
  * @returns 表示用音名（オクターブなし）
@@ -70,19 +73,19 @@ export function toDisplayName(noteName: string, opts: DisplayOpts): string {
   let displayName = parsed.name;
   
   // 簡易表記が有効な場合
-  if (opts.simple) {
-    // ダブルシャープ・ダブルフラットの場合のみ簡易化
-    if (Math.abs(parsed.alt) > 1) {
-      // tonal v6では、Note.enharmonic()を使用
-      const enharmonicNote = Note.enharmonic(displayName);
-      if (enharmonicNote && enharmonicNote !== displayName) {
-        displayName = enharmonicNote;
-      } else if (SIMPLIFY_MAP[displayName]) {
-        // フォールバック: 手動マッピング
-        displayName = SIMPLIFY_MAP[displayName];
-      }
+  if (opts.simple && parsed.alt !== 0) {
+    // シャープ・フラットが1つでも付いていれば簡易化を試みる
+    const enharmonicNote = Note.enharmonic(displayName);
+    if (enharmonicNote && enharmonicNote !== displayName) {
+      displayName = enharmonicNote;
+    } else if (SIMPLIFY_MAP[displayName]) {
+      // フォールバック: 手動マッピング
+      displayName = SIMPLIFY_MAP[displayName];
     }
   }
+  
+  // ## を x に置換（表示統一のため）
+  displayName = displayName.replace("##", "x");
   
   // 言語変換
   if (opts.lang === 'solfege') {
@@ -95,6 +98,7 @@ export function toDisplayName(noteName: string, opts: DisplayOpts): string {
 
 /**
  * コード名を表示用に変換
+ * ★ 日本語サフィックス変換のロジックを改善
  * @param chordName コード名（例: 'CM7', 'F#m7', 'Bb7'）
  * @param opts 表示オプション
  * @returns 表示用コード名
@@ -109,15 +113,30 @@ export function toDisplayChordName(chordName: string, opts: DisplayOpts): string
   const [, root, suffix] = match;
   const displayRoot = toDisplayName(root, opts);
   
-  // サフィックスの表示変換（必要に応じて拡張）
+  // サフィックスの表示変換
   let displaySuffix = suffix;
+
   if (opts.lang === 'solfege') {
-    // 日本語表記の場合のサフィックス変換
-    displaySuffix = suffix
-      .replace('maj', 'メジャー')
-      .replace('min', 'マイナー')
-      .replace('dim', 'ディミニッシュ')
-      .replace('aug', 'オーグメント');
+    // 日本語表記の場合のサフィックス変換マップ
+    const suffixMap: Record<string, string> = {
+      'M7': 'メジャー7',
+      'maj7': 'メジャー7',
+      'm7': 'マイナー7',
+      '7': '7', // ドミナントセブンスはそのまま「7」
+      'maj': 'メジャー',
+      'm': 'マイナー',
+      'dim': 'ディミニッシュ',
+      'aug': 'オーグメント',
+      'sus4': 'サス4',
+      'sus2': 'サス2',
+      // 必要に応じて他のサフィックスも追加
+    };
+    displaySuffix = suffixMap[suffix] ?? suffix;
+  } else {
+    // 英語表記の場合、'maj' は省略することが多い
+    if (suffix === 'maj') {
+      displaySuffix = '';
+    }
   }
   
   return displayRoot + displaySuffix;


### PR DESCRIPTION
Fixes incorrect note and chord name display in Fantasy mode by retaining theoretical note spellings until UI rendering.

The previous implementation converted theoretical note names (e.g., 'Bb', 'F##') to MIDI numbers too early, losing essential enharmonic information. This led to display inaccuracies like C7 showing 'A#' instead of 'Bb'. This PR ensures theoretical note names are preserved until the final UI rendering, using them directly for display and improving the `display-note.ts` utility for accurate conversion.

---

[Open in Web](https://cursor.com/agents?id=bc-cfe8f9b0-8180-4987-a29d-2312e3ac95d2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cfe8f9b0-8180-4987-a29d-2312e3ac95d2) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)