### PR TITLE
Update monster visuals and remove names

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -165,13 +165,13 @@ const createMonsterFromQueue = (
   previousChordId?: string,
   displayOpts?: DisplayOpts
 ): MonsterState => {
-  // 完全にランダムにモンスターを選択
-  const randomIndex = Math.floor(Math.random() * ENEMY_LIST.length);
-  const enemy = ENEMY_LIST[randomIndex];
+  // 提供された画像からランダムに選択（monster_01.png〜monster_63.png）
+  const monsterNumber = Math.floor(Math.random() * 63) + 1;
+  const monsterIcon = `monster_${monsterNumber.toString().padStart(2, '0')}`;
   const chord = selectUniqueRandomChord(allowedChords, previousChordId, displayOpts);
   
   return {
-    id: `${enemy.id}_${Date.now()}_${position}`,
+    id: `monster_${Date.now()}_${position}`,
     index: monsterIndex,
     position,
     currentHp: enemyHp,
@@ -179,8 +179,8 @@ const createMonsterFromQueue = (
     gauge: 0,
     chordTarget: chord!,
     correctNotes: [],
-    icon: enemy.icon,
-    name: enemy.name
+    icon: monsterIcon,
+    name: `モンスター${position}` // 攻撃時の識別用に位置情報を含める
   };
 };
 

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -52,6 +52,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 魔法名表示状態
   const [magicName, setMagicName] = useState<{ monsterId: string; name: string; isSpecial: boolean } | null>(null);
+  const [showMonsterAttackEffect, setShowMonsterAttackEffect] = useState(false); // ダメージエフェクト用
+  const [attackingMonsterId, setAttackingMonsterId] = useState<string | null>(null); // 攻撃中のモンスターID
+  const [showStageClearOverlay, setShowStageClearOverlay] = useState(false);
   
   // ★★★ 修正箇所 ★★★
   // ローカルのuseStateからgameStoreに切り替え
@@ -236,6 +239,15 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   const handleEnemyAttack = useCallback(async (attackingMonsterId?: string) => {
     console.log('🔥 handleEnemyAttack called with monsterId:', attackingMonsterId);
     devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
+    
+    // 攻撃中のモンスターを設定
+    if (attackingMonsterId) {
+      setAttackingMonsterId(attackingMonsterId);
+      // 1秒後に解除
+      setTimeout(() => {
+        setAttackingMonsterId(null);
+      }, 1000);
+    }
     
     // 敵の攻撃音を再生
     try {
@@ -768,7 +780,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       <div 
                         key={monster.id}
                         // ★★★ 修正点: flexアイテムとして定義、幅を設定 ★★★
-                        className="flex-shrink-0 flex flex-col items-center"
+                        className={cn(
+                          "flex-shrink-0 flex flex-col items-center transition-all duration-300",
+                          attackingMonsterId === monster.id && "animate-pulse scale-110" // 攻撃中のモンスターを強調
+                        )}
                         style={{ width: widthPercent, maxWidth }} // 動的に幅を設定
                       >
                       {/* コードネーム */}
@@ -837,9 +852,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       </div>
                       
                       {/* モンスター名 */}
-                      <div className="text-white text-xs font-bold text-center mb-1">
+                      {/* <div className="text-white text-xs font-bold text-center mb-1">
                         {monster.name}
-                      </div>
+                      </div> */}
                       
                       {/* HPゲージ */}
                       <div className="w-full h-3 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative">

--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -4,34 +4,6 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { 
-  faGhost,
-  faTree, 
-  faSeedling,
-  faTint,
-  faSun,
-  faCube,
-  faStar,
-  faGem,
-  faWind,
-  faBolt,
-  faDragon,
-  faSkull,
-  faFire,
-  faSnowflake,
-  faKhanda,
-  faUserSecret,
-  faSpider,
-  faFish,
-  faDog,
-  faBiohazard,
-  faBug,
-  faPaw,
-  faHatWizard,
-  faCrow,
-  faEye
-} from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 
 interface FantasyMonsterProps {
@@ -43,80 +15,26 @@ interface FantasyMonsterProps {
   className?: string;
 }
 
-// モンスターアイコンマッピング（FontAwesome）
-const MONSTER_ICONS: Record<string, any> = {
-  'ghost': faGhost,
-  'tree': faTree,
-  'seedling': faSeedling, 
-  'droplet': faTint,
-  'sun': faSun,
-  'rock': faCube,
-  'sparkles': faStar,
-  'gem': faGem,
-  'wind_face': faWind,
-  'zap': faBolt,
-  'star2': faStar,
-  'dragon': faDragon,
-  'skull': faSkull,
-  'fire': faFire,
-  'ice': faSnowflake,
-  'lightning': faBolt,
-  // ファンタジーモード用の敵アイコンマッピング - より適切なアイコンに変更
-  'vampire': faSkull, // バンパイア：頭蓋骨で威圧感を演出
-  'monster': faSpider, // モンスター：蜘蛛のまま
-  'reaper': faHatWizard, // 死神：魔法使いの帽子で神秘的に
-  'kraken': faEye, // クラーケン：目玉で不気味さを演出
-  'werewolf': faCrow, // 人狼：カラスで野生感を演出
-  'demon': faFire // 悪魔：炎で地獄感を演出
-};
-
 // モンスターサイズ設定
 const SIZE_CONFIGS = {
   small: {
-    monster: 'text-2xl',  // text-4xl から text-2xl に変更
+    monster: 'w-16 h-16',  // 小サイズ
     gauge: 'h-2',
     gaugeBg: 'h-2',
-    container: 'p-1'      // p-2 から p-1 に変更
+    container: 'p-1'
   },
   medium: {
-    monster: 'text-3xl',  // text-6xl から text-3xl に変更
-    gauge: 'h-2',         // h-3 から h-2 に変更
-    gaugeBg: 'h-2',       // h-3 から h-2 に変更
-    container: 'p-2'      // p-4 から p-2 に変更
+    monster: 'w-24 h-24',  // 中サイズ
+    gauge: 'h-2',
+    gaugeBg: 'h-2',
+    container: 'p-2'
   },
   large: {
-    monster: 'text-4xl',  // text-8xl から text-4xl に変更
-    gauge: 'h-3',         // h-4 から h-3 に変更
-    gaugeBg: 'h-3',       // h-4 から h-3 に変更
-    container: 'p-3'      // p-6 から p-3 に変更
+    monster: 'w-32 h-32',  // 大サイズ
+    gauge: 'h-3',
+    gaugeBg: 'h-3',
+    container: 'p-3'
   }
-};
-
-// モンスター特性（アイコンごとの特殊効果）- 明るい色に変更
-const MONSTER_TRAITS: Record<string, { color: string; glowColor: string; specialEffect?: string }> = {
-  'ghost': { color: 'text-blue-200', glowColor: 'drop-shadow-md', specialEffect: 'float' },
-  'tree': { color: 'text-green-400', glowColor: 'drop-shadow-md', specialEffect: 'sway' },
-  'seedling': { color: 'text-green-300', glowColor: 'drop-shadow-md' },
-  'droplet': { color: 'text-blue-400', glowColor: 'drop-shadow-md', specialEffect: 'bounce' },
-  'sun': { color: 'text-yellow-400', glowColor: 'drop-shadow-md', specialEffect: 'pulse' },
-  'rock': { color: 'text-stone-400', glowColor: 'drop-shadow-md' },
-  'sparkles': { color: 'text-yellow-300', glowColor: 'drop-shadow-md', specialEffect: 'sparkle' },
-  'gem': { color: 'text-cyan-400', glowColor: 'drop-shadow-md', specialEffect: 'shine' },
-  'wind_face': { color: 'text-sky-300', glowColor: 'drop-shadow-md', specialEffect: 'float' },
-  'zap': { color: 'text-yellow-400', glowColor: 'drop-shadow-md', specialEffect: 'shake' },
-  'star2': { color: 'text-yellow-300', glowColor: 'drop-shadow-md', specialEffect: 'twinkle' },
-  'dragon': { color: 'text-red-500', glowColor: 'drop-shadow-md' },
-  'skull': { color: 'text-red-400', glowColor: 'drop-shadow-md' },
-  'fire': { color: 'text-orange-400', glowColor: 'drop-shadow-md' },
-  'ice': { color: 'text-cyan-300', glowColor: 'drop-shadow-md' },
-  'lightning': { color: 'text-yellow-400', glowColor: 'drop-shadow-md' },
-  // ファンタジーモード用の敵特性 - 明るく見やすい色に変更
-  'vampire': { color: 'text-red-300', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
-  'monster': { color: 'text-purple-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
-  'reaper': { color: 'text-cyan-300', glowColor: 'drop-shadow-lg', specialEffect: 'float' },
-  'kraken': { color: 'text-blue-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' },
-  'werewolf': { color: 'text-amber-300', glowColor: 'drop-shadow-lg', specialEffect: 'shake' },
-  'demon': { color: 'text-orange-300', glowColor: 'drop-shadow-lg', specialEffect: 'pulse' }
 };
 
 const FantasyMonster: React.FC<FantasyMonsterProps> = ({
@@ -124,28 +42,32 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
   hp,
   maxHp,
   enemyGauge,
-  size = 'medium',  // 'large' から 'medium' に変更
+  size = 'medium',
   className
 }) => {
   const [isFloating, setIsFloating] = useState(false);
+  const [imageError, setImageError] = useState(false);
 
-  
   const sizeConfig = SIZE_CONFIGS[size];
-  const iconDef = MONSTER_ICONS[monsterIcon] || faGhost;
-  const traits = MONSTER_TRAITS[monsterIcon] || MONSTER_TRAITS['ghost'];
   
-
-  
-  // フローティングアニメーション（一部モンスターのアイドル状態）
+  // フローティングアニメーション
   useEffect(() => {
-    if (traits.specialEffect === 'float') {
-      const interval = setInterval(() => {
-        setIsFloating(prev => !prev);
-      }, 2000);
-      
-      return () => clearInterval(interval);
+    const interval = setInterval(() => {
+      setIsFloating(prev => !prev);
+    }, 2000);
+    
+    return () => clearInterval(interval);
+  }, []);
+  
+  // 画像パスの生成
+  const getImagePath = () => {
+    // monsterIconがmonster_01〜monster_63の形式の場合
+    if (monsterIcon.startsWith('monster_')) {
+      return `/monster_icons/${monsterIcon}.png`;
     }
-  }, [traits.specialEffect]);
+    // 互換性のため、古い形式も一応サポート
+    return `/monster_icons/monster_01.png`; // デフォルト画像
+  };
   
   // 敵ゲージのレンダリング
   const renderEnemyGauge = () => {
@@ -202,53 +124,35 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
     <div className={cn("text-center relative", sizeConfig.container, className)}>
       {/* メインモンスター */}
       <div className="relative inline-block">
-        {/* モンスター本体 */}
+        {/* モンスター画像 */}
         <div 
           className={cn(
-            "inline-block",
-            // 攻撃時の追加エフェクト
-
+            "inline-block relative",
+            isFloating && "transform -translate-y-2",
+            "transition-transform duration-1000"
           )}
-          style={{
-            filter: 'drop-shadow(0 0 10px rgba(255, 255, 255, 0.2))'
-          }}
         >
-          <FontAwesomeIcon
-            icon={iconDef}
-            className={cn(
-              "transition-all duration-300 select-none",
-              sizeConfig.monster,
-              traits.color,
-              // 基本アニメーション
-              traits.specialEffect === 'float' && isFloating && "transform -translate-y-2",
-              traits.specialEffect === 'bounce' && "animate-bounce",
-              traits.specialEffect === 'pulse' && "animate-pulse",
-              traits.specialEffect === 'shake' && "animate-pulse",
-              traits.specialEffect === 'sparkle' && "animate-pulse",
-              traits.specialEffect === 'shine' && "animate-pulse",
-              traits.specialEffect === 'twinkle' && "animate-ping",
-              traits.specialEffect === 'sway' && "hover:animate-pulse",
-
-              // グロー効果
-              traits.glowColor
-            )}
-          />
+          {!imageError ? (
+            <img
+              src={getImagePath()}
+              alt="Monster"
+              className={cn(
+                "object-contain",
+                sizeConfig.monster,
+                "drop-shadow-lg"
+              )}
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            // エラー時のフォールバック
+            <div className={cn(
+              "bg-gray-600 rounded-full flex items-center justify-center",
+              sizeConfig.monster
+            )}>
+              <span className="text-gray-400 text-2xl">?</span>
+            </div>
+          )}
         </div>
-        
-
-        
-        {/* 特殊エフェクトオーバーレイ */}
-        {traits.specialEffect === 'sparkle' && (
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="text-yellow-300 text-sm animate-ping opacity-50">✨</div>
-          </div>
-        )}
-        
-        {traits.specialEffect === 'shine' && (
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="text-white text-xs animate-pulse opacity-30">💫</div>
-          </div>
-        )}
       </div>
       
       {/* 敵の行動ゲージ */}
@@ -257,7 +161,7 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
       {/* HPバー（オプション） */}
       {renderHpBar()}
       
-      {/* モンスター名/タイプ表示（デバッグ用） */}
+      {/* デバッグ情報 */}
       {process.env.NODE_ENV === 'development' && (
         <div className="mt-2 text-xs text-gray-400">
           {monsterIcon} | ゲージ: {enemyGauge.toFixed(1)}%

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -267,33 +267,14 @@ export class FantasyPIXIInstance {
   // ★★★ 絵文字テクスチャ読み込みをモンスター画像読み込みに変更 ★★★
   private async loadMonsterTextures(): Promise<void> {
     try {
-      // ▼▼▼ 変更点 ▼▼▼
-      // 複数のモンスター画像をロードする（ENEMY_LISTと完全に一致させる）
-      const monsterIcons = ['devil', 'dragon', 'mao', 'mummy', 'shinigami', 'slime_green', 'slime_red', 'zombie', 'skeleton', 'grey', 'pumpkin', 'alien', 'bat1', 'bat2', 'ghost'];
-      /** まず .svg を読みに行き，失敗したら .png にフォールバックします */
-      const iconMap: Record<string, string> = {
-        devil:        'character_monster_devil_purple.svg',
-        dragon:       'character_monster_dragon_01_red.svg',
-        mao:          'character_monster_mao_01.svg',
-        mummy:        'character_monster_mummy_red.svg',
-        shinigami:    'character_monster_shinigami_01.svg',
-        slime_green:  'character_monster_slime_green.svg',
-        slime_red:    'character_monster_slime_red.svg',
-        zombie:       'character_monster_zombie_brown.svg',
-        skeleton:     'gaikotsu_01.svg',
-        grey:         'grey_green.svg',
-        pumpkin:      'jackolantern_01_orange.svg',
-        alien:        'kaseijin_green.svg',
-        bat1:         'komori_01.svg',
-        bat2:         'komori_02.svg',
-        ghost:        'yurei_halloween_orange.svg'
-      };
-
-      // プリロード用のアセット定義
+      // 提供された63個のモンスター画像を読み込む
       const monsterAssets: Record<string, string> = {};
-      for (const icon of monsterIcons) {
-        const path = `${import.meta.env.BASE_URL}data/${iconMap[icon]}`;
-        monsterAssets[icon] = path;
+      
+      // monster_01.png から monster_63.png までを読み込む
+      for (let i = 1; i <= 63; i++) {
+        const monsterName = `monster_${i.toString().padStart(2, '0')}`;
+        const path = `${import.meta.env.BASE_URL}monster_icons/${monsterName}.png`;
+        monsterAssets[monsterName] = path;
       }
 
       // バンドルとして一括ロード
@@ -301,16 +282,16 @@ export class FantasyPIXIInstance {
       await PIXI.Assets.loadBundle('monsterTextures');
 
       // ロードされたテクスチャを保存
-      for (const icon of monsterIcons) {
-        const texture = PIXI.Assets.get(icon);
+      for (let i = 1; i <= 63; i++) {
+        const monsterName = `monster_${i.toString().padStart(2, '0')}`;
+        const texture = PIXI.Assets.get(monsterName);
         if (texture) {
-          this.imageTextures.set(icon, texture);
-          devLog.debug(`✅ モンスターテクスチャ読み込み完了: ${icon}`);
+          this.imageTextures.set(monsterName, texture);
+          devLog.debug(`✅ モンスターテクスチャ読み込み完了: ${monsterName}`);
         } else {
-          devLog.debug(`❌ モンスターテクスチャ読み込み失敗: ${icon}`);
+          devLog.debug(`❌ モンスターテクスチャ読み込み失敗: ${monsterName}`);
         }
       }
-      // ▲▲▲ ここまで ▲▲▲
     } catch (error) {
       devLog.debug('❌ モンスターテクスチャの読み込みエラー:', error);
     }

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -254,17 +254,28 @@ export class FantasyPIXIInstance {
     // フォールバックテクスチャを作成
     this.createFallbackTextures();
     
-    // 絵文字テクスチャの事前読み込み
-    // this.loadEmojiTextures(); // ★ 削除
-    await this.loadMonsterTextures(); // ★★★ awaitを追加して読み込み完了を待つ ★★★
-    
-    // ★★★ 修正点(1): 魔法エフェクトのテクスチャ読み込みを追加 ★★★
-    await this.loadImageTextures(); // awaitを追加して読み込み完了を待つ
+    // 初期化処理を開始（非同期）
+    this.initializeAsync();
     
     // アニメーションループ開始
     this.startAnimationLoop();
     
     devLog.debug('✅ ファンタジーPIXI初期化完了（状態機械対応）');
+  }
+
+  // 非同期初期化処理
+  private async initializeAsync(): Promise<void> {
+    try {
+      // 絵文字テクスチャの事前読み込み
+      await this.loadMonsterTextures();
+      
+      // 魔法エフェクトのテクスチャ読み込みを追加
+      await this.loadImageTextures();
+      
+      devLog.debug('✅ 非同期初期化完了');
+    } catch (error) {
+      devLog.debug('❌ 非同期初期化エラー:', error);
+    }
   }
 
   // ★★★ 絵文字テクスチャ読み込みをモンスター画像読み込みに変更 ★★★

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -251,12 +251,15 @@ export class FantasyPIXIInstance {
     this.app.stage.addChild(this.effectContainer);
     this.app.stage.addChild(this.uiContainer);
     
+    // フォールバックテクスチャを作成
+    this.createFallbackTextures();
+    
     // 絵文字テクスチャの事前読み込み
     // this.loadEmojiTextures(); // ★ 削除
-    this.loadMonsterTextures(); // ★★★ 新しいメソッドを呼ぶ ★★★
+    await this.loadMonsterTextures(); // ★★★ awaitを追加して読み込み完了を待つ ★★★
     
     // ★★★ 修正点(1): 魔法エフェクトのテクスチャ読み込みを追加 ★★★
-    this.loadImageTextures(); // この行を追加して魔法画像をロードします
+    await this.loadImageTextures(); // awaitを追加して読み込み完了を待つ
     
     // アニメーションループ開始
     this.startAnimationLoop();
@@ -267,6 +270,8 @@ export class FantasyPIXIInstance {
   // ★★★ 絵文字テクスチャ読み込みをモンスター画像読み込みに変更 ★★★
   private async loadMonsterTextures(): Promise<void> {
     try {
+      devLog.debug('🎮 モンスターテクスチャ読み込み開始...');
+      
       // 提供された63個のモンスター画像を読み込む
       const monsterAssets: Record<string, string> = {};
       
@@ -277,21 +282,25 @@ export class FantasyPIXIInstance {
         monsterAssets[monsterName] = path;
       }
 
-      // バンドルとして一括ロード
-      await PIXI.Assets.addBundle('monsterTextures', monsterAssets);
-      await PIXI.Assets.loadBundle('monsterTextures');
+      devLog.debug('📁 モンスターテクスチャパス例:', {
+        monster_01: monsterAssets['monster_01'],
+        BASE_URL: import.meta.env.BASE_URL
+      });
 
-      // ロードされたテクスチャを保存
-      for (let i = 1; i <= 63; i++) {
-        const monsterName = `monster_${i.toString().padStart(2, '0')}`;
-        const texture = PIXI.Assets.get(monsterName);
-        if (texture) {
-          this.imageTextures.set(monsterName, texture);
-          devLog.debug(`✅ モンスターテクスチャ読み込み完了: ${monsterName}`);
-        } else {
-          devLog.debug(`❌ モンスターテクスチャ読み込み失敗: ${monsterName}`);
+      // 各画像を個別に読み込む（バンドルでのエラーを回避）
+      for (const [monsterName, path] of Object.entries(monsterAssets)) {
+        try {
+          const texture = await PIXI.Assets.load(path);
+          if (texture) {
+            this.imageTextures.set(monsterName, texture);
+            devLog.debug(`✅ モンスターテクスチャ読み込み完了: ${monsterName}`);
+          }
+        } catch (individualError) {
+          devLog.debug(`❌ 個別モンスターテクスチャ読み込み失敗: ${monsterName}`, individualError);
         }
       }
+
+      devLog.debug('✅ モンスターテクスチャ読み込み処理完了');
     } catch (error) {
       devLog.debug('❌ モンスターテクスチャの読み込みエラー:', error);
     }
@@ -307,40 +316,37 @@ export class FantasyPIXIInstance {
     const fallbackTexture = this.app.renderer.generateTexture(graphics);
     
     // デフォルトモンスター用のフォールバックテクスチャを設定
+    this.imageTextures.set('monster_01', fallbackTexture);
     this.imageTextures.set('default_monster', fallbackTexture);
   }
 
   // ★★★ 修正点(2): 画像読み込みパスを `public` ディレクトリ基準に修正 ★★★
   private async loadImageTextures(): Promise<void> {
     try {
-      // 魔法テクスチャのアセット定義
-      const magicAssets: Record<string, string> = {};
+      // 魔法テクスチャの個別読み込み
       for (const [key, magic] of Object.entries(MAGIC_TYPES)) {
-        const path = `${import.meta.env.BASE_URL}${magic.svg}`;
-        magicAssets[key] = path;
-      }
-      
-      // 怒りマークSVGを追加
-      magicAssets['angerMark'] = `${import.meta.env.BASE_URL}data/anger.svg`;
-
-      // バンドルとして一括ロード
-      await PIXI.Assets.addBundle('magicTextures', magicAssets);
-      await PIXI.Assets.loadBundle('magicTextures');
-
-      // ロードされたテクスチャを保存
-      for (const [key, magic] of Object.entries(MAGIC_TYPES)) {
-        const texture = PIXI.Assets.get(key);
-        if (texture) {
-          this.imageTextures.set(magic.svg, texture);
-          devLog.debug(`✅ 画像テクスチャ読み込み: ${magic.svg}`);
+        try {
+          const path = `${import.meta.env.BASE_URL}${magic.svg}`;
+          const texture = await PIXI.Assets.load(path);
+          if (texture) {
+            this.imageTextures.set(magic.svg, texture);
+            devLog.debug(`✅ 画像テクスチャ読み込み: ${magic.svg}`);
+          }
+        } catch (individualError) {
+          devLog.debug(`❌ 個別画像テクスチャ読み込み失敗: ${magic.svg}`, individualError);
         }
       }
       
-      // 怒りマークテクスチャを保存
-      const angerTexture = PIXI.Assets.get('angerMark');
-      if (angerTexture) {
-        this.imageTextures.set('angerMark', angerTexture);
-        devLog.debug('✅ 怒りマークテクスチャ読み込み: anger.svg');
+      // 怒りマークSVGを個別に読み込み
+      try {
+        const angerPath = `${import.meta.env.BASE_URL}data/anger.svg`;
+        const angerTexture = await PIXI.Assets.load(angerPath);
+        if (angerTexture) {
+          this.imageTextures.set('angerMark', angerTexture);
+          devLog.debug('✅ 怒りマークテクスチャ読み込み: anger.svg');
+        }
+      } catch (angerError) {
+        devLog.debug('❌ 怒りマークテクスチャ読み込み失敗:', angerError);
       }
       
       devLog.debug('✅ 全画像テクスチャ読み込み完了');
@@ -583,8 +589,8 @@ export class FantasyPIXIInstance {
       
       // テクスチャが見つからない場合はフォールバックを使用
       if (!texture || texture.destroyed) {
-        // devLog.debug('⚠️ モンスターテクスチャが見つかりません、フォールバックを使用:', { id, icon });
-        texture = this.imageTextures.get('default_monster');
+        devLog.debug('⚠️ モンスターテクスチャが見つかりません、フォールバックを使用:', { id, icon });
+        texture = this.imageTextures.get('monster_01');
         if (!texture || texture.destroyed) {
           devLog.debug('❌ フォールバックテクスチャも見つかりません');
           return null;

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -317,9 +317,10 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         {/* モンスターアイコン */}
         <div className="text-4xl text-center mb-2">
           {unlocked ? (
-            <FontAwesomeIcon 
-              icon={MONSTER_ICONS[stage.monsterIcon] || faGhost} 
-              className="text-gray-300 drop-shadow-md"
+            <img 
+              src="/monster_icons/monster_01.png"
+              alt="Monster"
+              className="w-16 h-16 mx-auto drop-shadow-md"
             />
           ) : (
             <span>🔒</span>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement random monster images, remove monster name display, and add visual identification for attacking monsters.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous system used fixed monster names and icons. This PR updates the monster display to randomly select from 63 new image assets, removes the text display of monster names, and introduces a visual pulse/scale effect to highlight which monster is currently attacking.

---

[Open in Web](https://cursor.com/agents?id=bc-1f673eb6-8660-447c-9c1f-ddf80916ab31) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1f673eb6-8660-447c-9c1f-ddf80916ab31) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)