### PR TITLE
Refactor fantasy attack system

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -700,8 +700,10 @@ export const useFantasyGameEngine = ({
         setEnrage(attackingMonster.id, true);
         setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
         
-        // 攻撃したモンスターのゲージをリセット（SPの場合は全敵で既にリセット済み）
-        const resetMonsters = updatedMonsters;
+        // 攻撃したモンスターのゲージをリセット
+        const resetMonsters = updatedMonsters.map(m => 
+          m.id === attackingMonster.id ? { ...m, gauge: 0 } : m
+        );
         
         // 攻撃処理を非同期で実行
         console.log('🚀 Calling handleEnemyAttack with id:', attackingMonster.id);

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -700,10 +700,8 @@ export const useFantasyGameEngine = ({
         setEnrage(attackingMonster.id, true);
         setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
         
-        // 攻撃したモンスターのゲージをリセット
-        const resetMonsters = updatedMonsters.map(m => 
-          m.id === attackingMonster.id ? { ...m, gauge: 0 } : m
-        );
+        // 攻撃したモンスターのゲージをリセット（SPの場合は全敵で既にリセット済み）
+        const resetMonsters = updatedMonsters;
         
         // 攻撃処理を非同期で実行
         console.log('🚀 Calling handleEnemyAttack with id:', attackingMonster.id);
@@ -794,7 +792,13 @@ export const useFantasyGameEngine = ({
         });
 
         // プレイヤーの状態更新
-        stateAfterAttack.playerSp = isSpecialAttack ? 0 : Math.min(stateAfterAttack.playerSp + completedMonsters.length, 5);
+        if (isSpecialAttack) {
+          stateAfterAttack.playerSp = 0;
+          // SPアタック: 全モンスターのゲージをリセット
+          stateAfterAttack.activeMonsters = stateAfterAttack.activeMonsters.map(m => ({ ...m, gauge: 0 }));
+        } else {
+          stateAfterAttack.playerSp = Math.min(stateAfterAttack.playerSp + completedMonsters.length, 5);
+        }
         stateAfterAttack.score += 1000 * completedMonsters.length;
         stateAfterAttack.correctAnswers += completedMonsters.length;
         

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -123,6 +123,10 @@ const MAGIC_TYPES: Record<string, MagicType> = {
   },
 };
 
+// ===== ヒットアイコン（完全ランダム） =====
+const ATTACK_ICONS: string[] = Array.from({ length: 12 }, (_, i) => `attack_icons/attack_${String(i+1).padStart(2,'0')}.png`);
+const SP_ICON = 'attack_icons/swingswingswing.png';
+
 // ===== モンスターシンボルマッピング（フラットデザイン） =====
 const MONSTER_EMOJI: Record<string, string> = {
   'vampire': '☠', // 頭蓋骨（バンパイア）
@@ -187,11 +191,9 @@ export class FantasyPIXIInstance {
   private chordNameText: PIXI.Text | null = null;
 
   
-  private currentMagicType: string = 'fire';
+  // 魔法タイプ概念を削除
   // ★★★ MONSTER_EMOJI と loadEmojiTextures を削除、またはコメントアウト ★★★
-  /*
-  private emojiTextures: Map<string, PIXI.Texture> = new Map();
-  */
+
   private imageTextures: Map<string, PIXI.Texture> = new Map(); // ★ imageTextures は残す
   
   private isDestroyed: boolean = false;
@@ -332,27 +334,40 @@ export class FantasyPIXIInstance {
   // ★★★ 修正点(2): 画像読み込みパスを `public` ディレクトリ基準に修正 ★★★
   private async loadImageTextures(): Promise<void> {
     try {
-      // 魔法テクスチャのアセット定義
-      const magicAssets: Record<string, string> = {};
-      for (const [key, magic] of Object.entries(MAGIC_TYPES)) {
-        const path = `${import.meta.env.BASE_URL}${magic.svg}`;
-        magicAssets[key] = path;
+      // 攻撃アイコンのアセット定義
+      const attackAssets: Record<string, string> = {};
+      
+      // 通常攻撃アイコン
+      for (const iconPath of ATTACK_ICONS) {
+        const key = iconPath;
+        const path = `${import.meta.env.BASE_URL}${iconPath}`;
+        attackAssets[key] = path;
       }
       
+      // SPアタックアイコン
+      attackAssets[SP_ICON] = `${import.meta.env.BASE_URL}${SP_ICON}`;
+      
       // 怒りマークSVGを追加
-      magicAssets['angerMark'] = `${import.meta.env.BASE_URL}data/anger.svg`;
+      attackAssets['angerMark'] = `${import.meta.env.BASE_URL}data/anger.svg`;
 
       // バンドルとして一括ロード
-      await PIXI.Assets.addBundle('magicTextures', magicAssets);
-      await PIXI.Assets.loadBundle('magicTextures');
+      await PIXI.Assets.addBundle('attackTextures', attackAssets);
+      await PIXI.Assets.loadBundle('attackTextures');
 
       // ロードされたテクスチャを保存
-      for (const [key, magic] of Object.entries(MAGIC_TYPES)) {
-        const texture = PIXI.Assets.get(key);
+      for (const iconPath of ATTACK_ICONS) {
+        const texture = PIXI.Assets.get(iconPath);
         if (texture) {
-          this.imageTextures.set(magic.svg, texture);
-          devLog.debug(`✅ 画像テクスチャ読み込み: ${magic.svg}`);
+          this.imageTextures.set(iconPath, texture);
+          devLog.debug(`✅ 攻撃アイコン読み込み: ${iconPath}`);
         }
+      }
+      
+      // SPアイコンテクスチャを保存
+      const spTexture = PIXI.Assets.get(SP_ICON);
+      if (spTexture) {
+        this.imageTextures.set(SP_ICON, spTexture);
+        devLog.debug(`✅ SPアイコン読み込み: ${SP_ICON}`);
       }
       
       // 怒りマークテクスチャを保存
@@ -730,61 +745,21 @@ export class FantasyPIXIInstance {
   }
 
   // マルチモンスター用攻撃成功エフェクト
-  triggerAttackSuccessOnMonster(monsterId: string, chordName: string | undefined, isSpecial: boolean, damageDealt: number, defeated: boolean): void {
+  triggerAttackSuccessOnMonster(monsterId: string, _chordName: string | undefined, isSpecial: boolean, damageDealt: number, defeated: boolean): void {
     const monsterData = this.monsterSprites.get(monsterId);
     if (!monsterData || this.isDestroyed) return;
     
     try {
-      // 魔法タイプをローテーション
-      const magicTypes = Object.keys(MAGIC_TYPES);
-      const currentIndex = magicTypes.indexOf(this.currentMagicType);
-      devLog.debug('🎯 現在の魔法タイプ:', {
-        current: this.currentMagicType,
-        currentIndex,
-        magicTypes
-      });
-      this.currentMagicType = magicTypes[(currentIndex + 1) % magicTypes.length];
-      const magic = MAGIC_TYPES[this.currentMagicType];
-      devLog.debug('🎯 次の魔法タイプ:', {
-        next: this.currentMagicType,
-        magic
-      });
+      // 旧魔法システムを廃止し、アイコン／効果音は完全ランダム
+      const iconPath = isSpecial ? SP_ICON : ATTACK_ICONS[Math.floor(Math.random()*ATTACK_ICONS.length)];
 
-      // 魔法効果音を再生
-      // 魔法タイプを正しくマッピング
-      const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
-        'fire': 'fire',
-        'ice': 'ice',
-        'thunder': 'thunder'
-      };
-      const soundType = magicTypeMap[this.currentMagicType];
-      devLog.debug('🔊 効果音タイプ:', {
-        currentMagicType: this.currentMagicType,
-        soundType,
-        magicTypeMap
-      });
-      if (soundType) {
-        try {
-          FantasySoundManager.playMagic(soundType);
-          devLog.debug('🔊 魔法効果音再生(triggerAttackSuccessOnMonster):', soundType);
-        } catch (error) {
-          console.error('魔法効果音再生エラー:', error);
-        }
-      } else {
-        console.warn('⚠️ soundTypeが未定義:', this.currentMagicType);
-      }
+      // 効果音はランダム再生
+      FantasySoundManager.playMagic();
 
-      // 魔法名表示
-      const magicName = isSpecial ? magic.tier2Name : magic.name;
-      const magicColor = isSpecial ? magic.tier2Color : magic.color;
-      
-      // HTMLでの表示のためコールバックを呼び出す
-      if (this.onShowMagicName) {
-        this.onShowMagicName(magicName, isSpecial, monsterId);
-      }
+      // 魔法名の概念を廃止 – 表示しない
 
       monsterData.gameState.isHit = true;
-      monsterData.gameState.hitColor = magicColor;
+      // 当たりエフェクトで色を変えない
 
       // よろめきエフェクト
       monsterData.gameState.staggerOffset = {
@@ -793,10 +768,13 @@ export class FantasyPIXIInstance {
       };
 
       // ダメージ数値を表示（モンスターの位置に）
-      this.createDamageNumberAt(damageDealt, magicColor, monsterData.visualState.x, monsterData.visualState.y - 50);
+      this.createDamageNumberAt(damageDealt, 0xffffff, monsterData.visualState.x, monsterData.visualState.y - 50);
 
       // エフェクトをモンスターの位置に作成
-      this.createImageMagicEffectAt(magic.svg, magicColor, isSpecial, monsterData.visualState.x, monsterData.visualState.y);
+      this.createImageMagicEffectAt(iconPath, 0xffffff, isSpecial, monsterData.visualState.x, monsterData.visualState.y);
+
+      // SPアタックは横からのカットインを追加
+      if (isSpecial) this.createCutIn();
 
       // 状態を更新
       monsterData.gameState.hitCount++;
@@ -820,63 +798,22 @@ export class FantasyPIXIInstance {
   }
 
   // ▼▼▼ 攻撃成功エフェクトを修正 ▼▼▼
-  triggerAttackSuccess(chordName: string | undefined, isSpecial: boolean, damageDealt: number, defeated: boolean): void { // ★ 4番目の引数 defeated を受け取る
+  triggerAttackSuccess(_chordName: string | undefined, isSpecial: boolean, damageDealt: number, defeated: boolean): void { // ★ 4番目の引数 defeated を受け取る
     // 状態ガード: 消滅中または完全消滅中は何もしない
     if (this.isDestroyed || this.monsterGameState.state === 'FADING_OUT' || this.monsterGameState.state === 'GONE') {
       return;
     }
 
     try {
-      // 魔法タイプをローテーション
-      const magicTypes = Object.keys(MAGIC_TYPES);
-      const currentIndex = magicTypes.indexOf(this.currentMagicType);
-      devLog.debug('🎯 現在の魔法タイプ:', {
-        current: this.currentMagicType,
-        currentIndex,
-        magicTypes
-      });
-      this.currentMagicType = magicTypes[(currentIndex + 1) % magicTypes.length];
-      const magic = MAGIC_TYPES[this.currentMagicType];
-      devLog.debug('🎯 次の魔法タイプ:', {
-        next: this.currentMagicType,
-        magic
-      });
-
-      // 魔法効果音を再生
-      // 魔法タイプを正しくマッピング
-      const magicTypeMap: Record<string, 'fire' | 'ice' | 'thunder'> = {
-        'fire': 'fire',
-        'ice': 'ice',
-        'thunder': 'thunder'
-      };
-      const soundType = magicTypeMap[this.currentMagicType];
-      devLog.debug('🔊 効果音タイプ:', {
-        currentMagicType: this.currentMagicType,
-        soundType,
-        magicTypeMap
-      });
-      if (soundType) {
-        try {
-          FantasySoundManager.playMagic(soundType);
-          devLog.debug('🔊 魔法効果音再生(triggerAttackSuccess):', soundType);
-        } catch (error) {
-          console.error('魔法効果音再生エラー:', error);
-        }
-      } else {
-        console.warn('⚠️ soundTypeが未定義:', this.currentMagicType);
-      }
-
-      // 魔法名表示
-      const magicName = isSpecial ? magic.tier2Name : magic.name;
-      const magicColor = isSpecial ? magic.tier2Color : magic.color;
-      
-      // HTMLでの表示のためコールバックを呼び出す
-      if (this.onShowMagicName) {
-        this.onShowMagicName(magicName, isSpecial, 'default');
-      }
+      const iconPath = isSpecial ? SP_ICON : ATTACK_ICONS[Math.floor(Math.random()*ATTACK_ICONS.length)];
+      FantasySoundManager.playMagic();
+      this.createImageMagicEffect(iconPath, 0xffffff, isSpecial);
+      if (isSpecial) this.createCutIn();
 
       this.monsterGameState.isHit = true;
-      this.monsterGameState.hitColor = magicColor;
+      // ヒット時の色変化を削除
+
+      // モンスター tint を維持
 
       // 5発目の場合はよろめきエフェクトを無効化
       if (this.monsterGameState.hitCount < 4) {
@@ -890,9 +827,7 @@ export class FantasyPIXIInstance {
       }
 
       // ダメージ数値を表示（エンジンから渡された値を使用）
-      this.createDamageNumber(damageDealt, magicColor);
-
-      this.createImageMagicEffect(magic.svg, magicColor, isSpecial);
+      this.createDamageNumber(damageDealt, 0xffffff);
 
       // 状態を更新
       this.monsterGameState.hitCount++;
@@ -903,7 +838,7 @@ export class FantasyPIXIInstance {
       }
 
       devLog.debug('⚔️ 攻撃成功:', { 
-        magic: magic.name, 
+        magic: 'random', 
         damage: damageDealt,
         defeated: defeated, // ログにも追加
         hitCount: this.monsterGameState.hitCount, 
@@ -1803,6 +1738,30 @@ export class FantasyPIXIInstance {
   private isSpriteInvalid = (s: PIXI.DisplayObject | null | undefined) =>
     !s || (s as any).destroyed || !(s as any).transform;
 
+  /** 横から画面を斬り抜けるカットインエフェクト（SP専用） */
+  private createCutIn() {
+    const texture = this.imageTextures.get(SP_ICON);
+    if (!texture) return;
+    const spr = new PIXI.Sprite(texture);
+    spr.anchor.set(0.5, 0.5);
+    spr.y = this.app.screen.height / 2;
+    spr.x = -spr.width;
+    spr.scale.set(0.6);
+    this.effectContainer.addChild(spr);
+    const targetX = this.app.screen.width + spr.width;
+    const duration = 600; // ms
+    const start = performance.now();
+    const animate = (now: number) => {
+      const t = (now - start) / duration;
+      if (t >= 1) {
+        this.effectContainer.removeChild(spr); spr.destroy();
+        return;
+      }
+      spr.x = -spr.width + (targetX + spr.width) * t;
+      requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }
 
 }
 

--- a/src/utils/FantasySoundManager.ts
+++ b/src/utils/FantasySoundManager.ts
@@ -30,7 +30,7 @@
  *   FSM.setVolume(newVolume);  // 0‑1 の値を渡す
  */
 
-export type MagicSeType = 'fire' | 'ice' | 'thunder';
+export type MagicSeType = 'random';
 
 interface LoadedAudio {
   /** プリロード済みのベース Audio インスタンス（再生には clone する） */
@@ -50,11 +50,13 @@ export class FantasySoundManager {
 
   // ─────────────────────────────────────────────
   // fields
+  // 効果音を 4 種類 + 敵攻撃 1 種類 に統一
   private readonly audioMap: Record<string, LoadedAudio> = {
     enemy_attack: { base: new Audio(), ready: false },
-    fire:          { base: new Audio(), ready: false },
-    ice:           { base: new Audio(), ready: false },
-    thunder:       { base: new Audio(), ready: false }
+    magic0:       { base: new Audio(), ready: false }, // shaker
+    magic1:       { base: new Audio(), ready: false }, // dry-brush-snare
+    magic2:       { base: new Audio(), ready: false }, // brush-snare
+    magic3:       { base: new Audio(), ready: false }  // clap
   };
 
   /** マスターボリューム (0‑1) */
@@ -65,7 +67,7 @@ export class FantasySoundManager {
   // ─────────────────────────────────────────────
   // public static wrappers – 使いやすいように static 経由のエイリアスを用意
   public static async init(defaultVolume = 0.8) { return this.instance._init(defaultVolume); }
-  public static playMagic(type: MagicSeType) { return this.instance._playMagic(type); }
+  public static playMagic(type?: MagicSeType) { return this.instance._playMagic(type); }
   public static playEnemyAttack() { return this.instance._playSe('enemy_attack'); }
   public static setVolume(v: number) { return this.instance._setVolume(v); }
   public static getVolume() { return this.instance._volume; }
@@ -112,9 +114,10 @@ export class FantasySoundManager {
 
     const promises = [
       load('enemy_attack', 'enemy_attack.mp3'),
-      load('fire',          'fire.mp3'),
-      load('ice',           'ice.mp3'),
-      load('thunder',       'thunder.mp3')
+      load('magic0',       'shaker.mp3'),
+      load('magic1',       'dry-brush-snare.mp3'),
+      load('magic2',       'brush-snare.mp3'),
+      load('magic3',       'clap.mp3')
     ];
 
     return Promise.all(promises).then(() => {
@@ -136,10 +139,15 @@ export class FantasySoundManager {
     });
   }
 
-  private _playMagic(type: MagicSeType) {
-    // magic type -> key mapping is 1:1
-    console.debug(`[FantasySoundManager] playMagic called with type: ${type}`);
-    this._playSe(type);
+  /**
+   * 魔法効果音を完全ランダムで再生する。
+   * 呼び出し側は "type" を意識する必要がないため無視する。
+   */
+  private _playMagic(_type?: any) {
+    const keys = ['magic0', 'magic1', 'magic2', 'magic3'] as const;
+    const pick = keys[Math.floor(Math.random() * keys.length)];
+    console.debug('[FantasySoundManager] playMagic (random) →', pick);
+    this._playSe(pick);
   }
 
   private _playSe(key: keyof typeof this.audioMap) {


### PR DESCRIPTION
魔法タイプを撤廃し、攻撃演出をランダム化。SPアタックに専用カットインと全敵ゲージリセットを追加。

---

[Open in Web](https://cursor.com/agents?id=bc-73c22ae6-7848-41ea-b174-3896bbb4453d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-73c22ae6-7848-41ea-b174-3896bbb4453d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)