### PR TITLE
Fix fantasy mode bugs and simplify display

### DIFF
--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -362,19 +362,10 @@ const FantasyMain: React.FC = () => {
             {gameResult.result === 'clear' ? 'ステージクリア！' : 'ゲームオーバー'}
           </h2>
           
-          {/* スコア表示 */}
+          {/* 結果表示 */}
           <div className="bg-black bg-opacity-30 rounded-lg p-6 mb-6">
-            <div className="space-y-2 text-lg font-dotgothic16">
-              <div>スコア: <span className="text-yellow-300 font-bold">{gameResult.score.toLocaleString()}</span></div>
-              <div>正解数: <span className="text-green-300 font-bold">{gameResult.correctAnswers}</span> / {gameResult.totalQuestions}</div>
-              <div>
-                正解率: <span className={`font-bold ${
-                  (gameResult.correctAnswers / gameResult.totalQuestions) >= 0.8 ? 'text-green-300' : 
-                  (gameResult.correctAnswers / gameResult.totalQuestions) >= 0.6 ? 'text-yellow-300' : 'text-red-300'
-                }`}>
-                  {Math.round((gameResult.correctAnswers / gameResult.totalQuestions) * 100)}%
-                </span>
-              </div>
+            <div className="text-lg font-dotgothic16">
+              <div>正解数: <span className="text-green-300 font-bold text-2xl">{gameResult.correctAnswers}</span></div>
             </div>
             
             {/* 経験値獲得 */}

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -98,21 +98,22 @@ const FantasyMain: React.FC = () => {
           });
         }
         
-        // クリア記録を保存（既存記録がある場合は更新）
-        try {
-          const { error: clearError } = await supabase
-            .from('fantasy_stage_clears')
-            .upsert({
-              user_id: profile.id,
-              stage_id: currentStage.id,
-              score: score,
-              clear_type: result,
-              remaining_hp: result === 'clear' ? Math.max(1, 5 - (totalQuestions - correctAnswers)) : 0,
-              total_questions: totalQuestions,
-              correct_answers: correctAnswers
-            }, {
-              onConflict: 'user_id,stage_id'
-            });
+        // クリア記録を保存（クリアの場合のみ保存、ゲームオーバーは既存のクリア記録を上書きしない）
+        if (result === 'clear') {
+          try {
+            const { error: clearError } = await supabase
+              .from('fantasy_stage_clears')
+              .upsert({
+                user_id: profile.id,
+                stage_id: currentStage.id,
+                score: score,
+                clear_type: result,
+                remaining_hp: Math.max(1, 5 - (totalQuestions - correctAnswers)),
+                total_questions: totalQuestions,
+                correct_answers: correctAnswers
+              }, {
+                onConflict: 'user_id,stage_id'
+              });
           
           if (clearError) {
             console.error('ファンタジークリア記録保存エラー:', clearError);
@@ -129,10 +130,11 @@ const FantasyMain: React.FC = () => {
               }
             });
           } else {
-            devLog.debug('✅ ファンタジークリア記録保存完了');
+              devLog.debug('✅ ファンタジークリア記録保存完了');
+            }
+          } catch (clearSaveError) {
+            console.error('ファンタジークリア記録保存例外:', clearSaveError);
           }
-        } catch (clearSaveError) {
-          console.error('ファンタジークリア記録保存例外:', clearSaveError);
         }
         
         // ───────── 進捗の更新判定 ─────────

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -256,7 +256,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
       <div
         key={stage.id}
         className={cn(
-          "relative p-4 rounded-xl border-2 cursor-pointer transition-all duration-200 hover:scale-105",
+          "relative p-5 rounded-xl border-2 cursor-pointer transition-all duration-200 hover:scale-[1.02] flex items-center gap-4",
           unlocked
             ? "bg-white bg-opacity-10 border-white border-opacity-30 hover:bg-opacity-20"
             : "bg-gray-700 bg-opacity-50 border-gray-600 cursor-not-allowed",
@@ -264,31 +264,43 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         )}
         onClick={() => handleStageSelect(stage)}
       >
-        {/* クリアマーク */}
-        {isCleared && (
-          <div className="absolute top-2 right-2 text-yellow-400 text-2xl">
-            ⭐
-          </div>
-        )}
-        
         {/* ステージ番号 */}
-        <div className="text-white text-xl font-bold text-center">
+        <div className="text-white text-xl font-bold flex-shrink-0 w-16 text-center">
           {stage.stageNumber}
         </div>
         
-        {/* ロック表示 */}
-        {!unlocked && (
-          <div className="text-2xl text-center mt-2">
-            <span>🔒</span>
+        {/* コンテンツ部分 */}
+        <div className="flex-grow">
+          {/* ステージ名 */}
+          <div className={cn(
+            "text-lg font-medium mb-1",
+            unlocked ? "text-white" : "text-gray-400"
+          )}>
+            {unlocked ? stage.name : "???"}
           </div>
-        )}
+          
+          {/* 説明文 */}
+          <div className={cn(
+            "text-sm leading-relaxed",
+            unlocked ? "text-gray-300" : "text-gray-500"
+          )}>
+            {unlocked ? stage.description : "このステージはまだロックされています"}
+          </div>
+        </div>
         
-        {/* ステージ情報 - 敵の数のみ表示 */}
-        {unlocked && (
-          <div className="text-sm text-gray-300 text-center mt-2">
-            <div>敵: {stage.enemyCount}</div>
-          </div>
-        )}
+        {/* 右側のアイコン */}
+        <div className="flex-shrink-0">
+          {!unlocked && (
+            <div className="text-2xl">
+              <span>🔒</span>
+            </div>
+          )}
+          {isCleared && (
+            <div className="text-yellow-400 text-2xl">
+              ⭐
+            </div>
+          )}
+        </div>
       </div>
     );
   }, [isStageUnlocked, getStageClearInfo, handleStageSelect]);
@@ -389,7 +401,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
               ランク {selectedRank} - {groupedStages[selectedRank][0]?.name.includes('森') ? '初心者の世界' : '上級者の世界'}
             </h2>
             
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+            <div className="space-y-3">
               {groupedStages[selectedRank]
                 .sort((a, b) => {
                   const [, aStage] = a.stageNumber.split('-').map(Number);

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -4,29 +4,6 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { 
-  faGhost,
-  faTree, 
-  faSeedling,
-  faTint,
-  faSun,
-  faCube,
-  faStar,
-  faGem,
-  faWind,
-  faBolt,
-  faSkull,
-  faUserSecret,
-  faSpider,
-  faFish,
-  faDog,
-  faKhanda,
-  faHatWizard,
-  faCrow,
-  faEye,
-  faFire
-} from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
 import { devLog } from '@/utils/logger';
@@ -78,27 +55,7 @@ const groupStagesByRank = (stages: FantasyStage[]): Record<string, FantasyStage[
   }, {} as Record<string, FantasyStage[]>);
 };
 
-// ===== モンスターアイコンマッピング =====
-const MONSTER_ICONS: Record<string, any> = {
-  'ghost': faGhost,
-  'tree': faTree,
-  'seedling': faSeedling,
-  'droplet': faTint,
-  'sun': faSun,
-  'rock': faCube,
-  'sparkles': faStar,
-  'gem': faGem,
-  'wind_face': faWind,
-  'zap': faBolt,
-  'star2': faStar,
-  // ファンタジーモード用の敵アイコンマッピング - より適切なアイコンに変更
-  'vampire': faSkull, // バンパイア：頭蓋骨で威圧感を演出
-  'monster': faSpider, // モンスター：蜘蛛のまま
-  'reaper': faHatWizard, // 死神：魔法使いの帽子で神秘的に
-  'kraken': faEye, // クラーケン：目玉で不気味さを演出
-  'werewolf': faCrow, // 人狼：カラスで野生感を演出
-  'demon': faFire // 悪魔：炎で地獄感を演出
-};
+
 
 // ===== ランク背景色 =====
 const RANK_COLORS: Record<string, string> = {
@@ -315,44 +272,21 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         )}
         
         {/* ステージ番号 */}
-        <div className="text-white text-lg font-bold mb-2">
+        <div className="text-white text-xl font-bold text-center">
           {stage.stageNumber}
         </div>
         
-        {/* モンスターアイコン */}
-        <div className="text-4xl text-center mb-2">
-          {unlocked ? (
-            <FontAwesomeIcon 
-              icon={MONSTER_ICONS[stage.monsterIcon] || faGhost} 
-              className="text-gray-300 drop-shadow-md"
-            />
-          ) : (
+        {/* ロック表示 */}
+        {!unlocked && (
+          <div className="text-2xl text-center mt-2">
             <span>🔒</span>
-          )}
-        </div>
-        
-        {/* ステージ名 */}
-        <div className={cn(
-          "text-center font-medium mb-2",
-          unlocked ? "text-white" : "text-gray-400"
-        )}>
-          {stage.name}
-        </div>
-        
-        {/* ステージ情報 - 敵の数のみ表示 */}
-        {unlocked && (
-          <div className="text-xs text-gray-300 text-center">
-            <div>敵: {stage.enemyCount}</div>
           </div>
         )}
         
-        {/* クリア情報 */}
-        {clearInfo && (
-          <div className="mt-2 pt-2 border-t border-gray-600">
-            <div className="text-xs text-gray-300 text-center">
-              <div>スコア: {clearInfo.score}</div>
-              {clearInfo.totalQuestions > 0 && <div>正解率: {Math.round((clearInfo.correctAnswers / clearInfo.totalQuestions) * 100)}%</div>}
-            </div>
+        {/* ステージ情報 - 敵の数のみ表示 */}
+        {unlocked && (
+          <div className="text-sm text-gray-300 text-center mt-2">
+            <div>敵: {stage.enemyCount}</div>
           </div>
         )}
       </div>

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -339,13 +339,10 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           {stage.name}
         </div>
         
-        {/* ステージ情報 */}
+        {/* ステージ情報 - 敵の数のみ表示 */}
         {unlocked && (
-          <div className="text-xs text-gray-300 text-center space-y-1">
-            <div>HP: {stage.maxHp} / 敵: {stage.enemyCount} (HP:{stage.enemyHp})</div>
-            <div className="text-yellow-300">
-              {stage.mode === 'single' ? '単一コード' : 'コード進行'}
-            </div>
+          <div className="text-xs text-gray-300 text-center">
+            <div>敵: {stage.enemyCount}</div>
           </div>
         )}
         
@@ -414,8 +411,6 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           <div>
             <h1 className="text-3xl font-bold mb-2">🧙‍♂️ ファンタジーモード</h1>
             <div className="flex items-center space-x-6 text-sm">
-              <div>魔法使いランク: <span className="text-yellow-300 font-bold">{currentWizardRank}</span></div>
-              <div>クリア済みステージ: <span className="text-green-300 font-bold">{totalCleared}</span></div>
               <div>現在地: <span className="text-blue-300 font-bold">{userProgress?.currentStageNumber}</span></div>
             </div>
           </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Addresses multiple Fantasy Mode issues including global errors, persistent notes, clear mark logic, and UI simplification.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR implements the following fixes and improvements for Fantasy Mode:
-   **Global Error: Cannot read properties of null (reading 'off')**: Added null checks in `stopNote` to prevent errors when `globalSampler` is not active.
-   **Notes keep ringing**: Implemented active note tracking (`activeNotes` Set) to ensure previous notes are released before new ones are played, and improved `stopNote` logic.
-   **Clear mark disappears on game over**: Modified `handleGameComplete` to only save clear status when the game result is 'clear', preventing game over from overwriting clear records.
-   **Stage card display**: Simplified stage cards to display only the enemy count, hiding other details.
-   **Fantasy top UI**: Removed "Wizard Rank" and "Cleared Stages" displays from the Fantasy top screen to streamline the UI.

---

[Open in Web](https://cursor.com/agents?id=bc-97c423d5-bacb-4c61-b0c8-5dd312ff0da0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-97c423d5-bacb-4c61-b0c8-5dd312ff0da0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)