### PR TITLE
Add fantasy section to header

### DIFF
--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -36,6 +36,7 @@ const GameHeader: React.FC = () => {
           </HashButton>
 
           <HashButton hash="#lessons">レッスン</HashButton>
+          <HashButton hash="#fantasy">ファンタジー</HashButton>
           <HashButton hash="#ranking">ランキング</HashButton>
           <HashButton hash="#missions">ミッション</HashButton>
           <HashButton hash="#diary">日記</HashButton>


### PR DESCRIPTION
Add 'ファンタジー' (Fantasy) to the header navigation to the right of 'レッスン' (Lessons).

---

[Open in Web](https://cursor.com/agents?id=bc-2e69a085-dd80-4b36-b1e4-4baecc3ba5dd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2e69a085-dd80-4b36-b1e4-4baecc3ba5dd) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)