### PR TITLE
ファンタジーモードのステージ選択画面で現在地のランクを選択

### DIFF
--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -213,6 +213,15 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
     loadFantasyData();
   }, [loadFantasyData]);
   
+  // 現在地のステージ番号からランクを設定
+  useEffect(() => {
+    if (userProgress && userProgress.currentStageNumber) {
+      const currentRank = userProgress.currentStageNumber.split('-')[0];
+      setSelectedRank(currentRank);
+      devLog.debug('🎮 現在のランクを設定:', currentRank);
+    }
+  }, [userProgress]);
+  
   // ステージがアンロックされているかチェック
   const isStageUnlocked = useCallback((stage: FantasyStage): boolean => {
     if (!userProgress) return false;


### PR DESCRIPTION
Automatically select the rank button corresponding to the user's current stage number on the Fantasy Mode stage selection screen.

---

[Open in Web](https://cursor.com/agents?id=bc-58d44566-6f73-42f6-aff2-3fd0b1a525c0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-58d44566-6f73-42f6-aff2-3fd0b1a525c0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)