### PR TITLE
Enable fantasy mode exp, remove lesson/mission bonuses

### DIFF
--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -194,13 +194,16 @@ const FantasyMain: React.FC = () => {
           // addXp関数をインポートして使用
           const { addXp } = await import('@/platform/supabaseXp');
           
+          // 会員ランクによる倍率を適用
+          const membershipMultiplier = profile.rank === 'premium' ? 1.5 : profile.rank === 'platinum' ? 2 : 1;
+          
           const xpResult = await addXp({
             songId: null, // ファンタジーモードなので曲IDはnull
             baseXp: xpGain,
             speedMultiplier: 1,
             rankMultiplier: 1,
             transposeMultiplier: 1,
-            membershipMultiplier: 1,
+            membershipMultiplier: membershipMultiplier, // 契約ランクによる倍率を適用
             reason: reason
           });
           

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -374,7 +374,18 @@ const FantasyMain: React.FC = () => {
             {/* 経験値獲得 */}
             <div className="mt-4 pt-4 border-t border-gray-600 font-dotgothic16">
               <div className="text-blue-300">
-                経験値 +{gameResult.result === 'clear' ? 1000 : 200} XP
+                基本経験値: {gameResult.result === 'clear' ? 1000 : 200} XP
+              </div>
+              {profile && (profile.rank === 'premium' || profile.rank === 'platinum') && (
+                <div className="text-yellow-300 text-sm mt-1">
+                  契約ランクボーナス: ×{profile.rank === 'premium' ? '1.5' : '2.0'}
+                </div>
+              )}
+              <div className="text-green-300 font-bold text-xl mt-2">
+                獲得: +{gameResult.result === 'clear' ? 
+                  (profile?.rank === 'platinum' ? 2000 : profile?.rank === 'premium' ? 1500 : 1000) : 
+                  (profile?.rank === 'platinum' ? 400 : profile?.rank === 'premium' ? 300 : 200)
+                } XP
               </div>
             </div>
           </div>

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -378,7 +378,7 @@ const FantasyMain: React.FC = () => {
               </div>
               {profile && (profile.rank === 'premium' || profile.rank === 'platinum') && (
                 <div className="text-yellow-300 text-sm mt-1">
-                  契約ランクボーナス: ×{profile.rank === 'premium' ? '1.5' : '2.0'}
+                  ランクボーナス {profile.rank === 'premium' ? 'プレミアム1.5x' : 'プラチナ2.0x'}
                 </div>
               )}
               <div className="text-green-300 font-bold text-xl mt-2">

--- a/src/components/game/ResultModal.tsx
+++ b/src/components/game/ResultModal.tsx
@@ -72,8 +72,8 @@ const ResultModal: React.FC = () => {
             scoreRank: score.rank as any,
             playbackSpeed: settings.playbackSpeed,
             transposed: settings.transpose !== 0,
-            lessonBonusMultiplier: lessonContext ? 2 : 1,
-            missionBonusMultiplier: missionContext ? 2 : 1,
+            lessonBonusMultiplier: 1, // レッスンボーナスを削除（2→1）
+            missionBonusMultiplier: 1, // ミッションボーナスを削除（2→1）
             challengeBonusMultiplier: 1, // TODO: challengeから
             seasonMultiplier: profile.next_season_xp_multiplier ?? 1,
           });
@@ -96,7 +96,7 @@ const ResultModal: React.FC = () => {
             rankMultiplier: 1, // 新しい計算方式では基本XPに含まれているため1
             transposeMultiplier: settings.transpose !== 0 ? 1.3 : 1,
             membershipMultiplier: profile.rank === 'premium' ? 1.5 : profile.rank === 'platinum' ? 2 : 1,
-            missionMultiplier: (lessonContext || missionContext) ? 2 : 1, // レッスンまたはミッションの場合は2倍
+            missionMultiplier: 1, // レッスン・ミッションボーナスを削除（2→1）
             reason: lessonContext ? 'lesson_clear' : missionContext ? 'mission_clear' : 'song_clear', // コンテキストに応じた理由を指定
           });
 

--- a/src/components/mission/MissionPage.tsx
+++ b/src/components/mission/MissionPage.tsx
@@ -73,8 +73,7 @@ const MissionPage: React.FC = () => {
                   <h2 className="text-lg font-semibold">月間ミッション</h2>
                 </div>
                 <p className="text-gray-300 text-sm">
-                  毎月新しいミッションが登場します。ミッションをクリアして報酬を獲得しましょう！<br/>
-                  <span className="font-semibold text-yellow-300">※ミッション曲はスコアボーナスが2倍！</span>
+                  毎月新しいミッションが登場します。ミッションをクリアして報酬を獲得しましょう！
                 </p>
               </div>
 

--- a/src/utils/xpCalculator.ts
+++ b/src/utils/xpCalculator.ts
@@ -9,8 +9,8 @@ export interface XPCalcParams {
   scoreRank: ScoreRank;
   playbackSpeed: number; // 0.5 ~ 1.0 (1.0 = 標準)
   transposed: boolean;   // true で 1.3x
-  lessonBonusMultiplier?: number;   // レッスン曲 2x など
-  missionBonusMultiplier?: number;  // ミッション報酬 1.3x など
+  lessonBonusMultiplier?: number;   // レッスン曲ボーナス（現在は1.0）
+  missionBonusMultiplier?: number;  // ミッション報酬ボーナス（現在は1.0）
   challengeBonusMultiplier?: number; // チャレンジ報酬
   seasonMultiplier?: number; // プロフィール next_season_xp_multiplier
 }


### PR DESCRIPTION
Enable experience multipliers in fantasy mode and remove lesson/mission experience bonuses.

---

[Open in Web](https://cursor.com/agents?id=bc-3cd6c02c-38f7-4df2-9422-57b01acb1da9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3cd6c02c-38f7-4df2-9422-57b01acb1da9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)