### PR TITLE
Changes from background agent bc-a6996559-5295-4407-b3a3-1e3cfc756345

### DIFF
--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -383,7 +383,15 @@ const FantasyMain: React.FC = () => {
         showGuide: nextStageData.show_guide,
         monsterIcon: nextStageData.monster_icon,
         bgmUrl: nextStageData.bgm_url,
-        simultaneousMonsterCount: nextStageData.simultaneous_monster_count || 1
+        simultaneousMonsterCount: nextStageData.simultaneous_monster_count || 1,
+        // リズムモード関連フィールドを追加
+        game_type: nextStageData.game_type as 'quiz' | 'rhythm' | undefined,
+        rhythm_pattern: nextStageData.rhythm_pattern as 'random' | 'progression' | undefined,
+        bpm: nextStageData.bpm,
+        time_signature: nextStageData.time_signature as 3 | 4 | undefined,
+        loop_measures: nextStageData.loop_measures,
+        chord_progression_data: nextStageData.chord_progression_data,
+        mp3_url: nextStageData.mp3_url
       };
 
       setGameResult(null);

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -148,26 +148,44 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
       }
       
       //// データの変換とセット
-      const convertedStages: FantasyStage[] = (stagesData || []).map((stage: any) => ({
-        id: stage.id,
-        stageNumber: stage.stage_number,
-        name: stage.name,
-        description: stage.description || '',
-        maxHp: stage.max_hp,
-        enemyGaugeSeconds: stage.enemy_gauge_seconds,
-        enemyCount: stage.enemy_count,
-        enemyHp: stage.enemy_hp,
-        minDamage: stage.min_damage,
-        maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
-        allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
-        chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
-        showSheetMusic: stage.show_sheet_music,
-        showGuide: stage.show_guide,
-        monsterIcon: stage.monster_icon,
-        bgmUrl: stage.bgm_url,
-        simultaneousMonsterCount: stage.simultaneous_monster_count || 1
-      }));
+      const convertedStages: FantasyStage[] = (stagesData || []).map((stage: any) => {
+        // デバッグログを追加
+        devLog.debug('🎮 ステージデータ変換:', {
+          stage_number: stage.stage_number,
+          game_type: stage.game_type,
+          rhythm_pattern: stage.rhythm_pattern,
+          bpm: stage.bpm
+        });
+        
+        return {
+          id: stage.id,
+          stageNumber: stage.stage_number,
+          name: stage.name,
+          description: stage.description || '',
+          maxHp: stage.max_hp,
+          enemyGaugeSeconds: stage.enemy_gauge_seconds,
+          enemyCount: stage.enemy_count,
+          enemyHp: stage.enemy_hp,
+          minDamage: stage.min_damage,
+          maxDamage: stage.max_damage,
+          mode: stage.mode as 'single' | 'progression',
+          allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
+          chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
+          showSheetMusic: stage.show_sheet_music,
+          showGuide: stage.show_guide,
+          monsterIcon: stage.monster_icon,
+          bgmUrl: stage.bgm_url,
+          simultaneousMonsterCount: stage.simultaneous_monster_count || 1,
+          // リズムモード関連フィールドを追加
+          game_type: stage.game_type as 'quiz' | 'rhythm' | undefined,
+          rhythm_pattern: stage.rhythm_pattern as 'random' | 'progression' | undefined,
+          bpm: stage.bpm,
+          time_signature: stage.time_signature as 3 | 4 | undefined,
+          loop_measures: stage.loop_measures,
+          chord_progression_data: stage.chord_progression_data,
+          mp3_url: stage.mp3_url
+        };
+      });
       
       const convertedProgress: FantasyUserProgress = {
         id: userProgressData.id,


### PR DESCRIPTION
Map rhythm mode specific stage properties to fix incorrect mode detection.

Previously, `game_type` and other rhythm-related fields from the database were not being correctly mapped into the `FantasyStage` object in the frontend. This caused stages configured as 'rhythm' to default to 'quiz' mode, preventing rhythm mode functionality from being enabled. This change ensures the game correctly interprets and uses the rhythm mode settings from the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6996559-5295-4407-b3a3-1e3cfc756345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6996559-5295-4407-b3a3-1e3cfc756345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>