### PR TITLE
Implement rhythm mode with synchronized attack gauges

### DIFF
--- a/src/components/common/JudgmentMarker.tsx
+++ b/src/components/common/JudgmentMarker.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface Props {
+  position: number; // パーセンテージ（0-100）
+}
+
+export const JudgmentMarker: React.FC<Props> = ({ position }) => {
+  return (
+    <div 
+      className="absolute top-0 bottom-0 w-1 bg-yellow-400 shadow-lg"
+      style={{ left: `${position}%` }}
+    >
+      {/* 上部の三角形マーカー */}
+      <div className="absolute -top-2 -left-2 w-0 h-0 
+                      border-l-[5px] border-l-transparent
+                      border-r-[5px] border-r-transparent
+                      border-b-[8px] border-b-yellow-400" />
+    </div>
+  );
+};

--- a/src/components/common/ReadyOverlay.tsx
+++ b/src/components/common/ReadyOverlay.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface Props {
+  count: number; // 3→2→1→0
+}
+
+export const ReadyOverlay: React.FC<Props> = ({ count }) => {
+  const txt = count > 0 ? count.toString() : 'GO!';
+  const textSize = count > 0 ? 'text-9xl' : 'text-8xl';
+  const textColor = count === 1 ? 'text-yellow-400' : 
+                   count === 0 ? 'text-green-400' : 'text-white';
+  
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 pointer-events-none">
+      <span className={`font-bold ${textSize} ${textColor} animate-ping`}>
+        {txt}
+      </span>
+    </div>
+  );
+};

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -413,8 +413,12 @@ const createRhythmMonster = (
   const beatDurationMs = 60000 / bpm;
   const absBeat = (timing.measure - 1) * timeSignature + (timing.beat - 1);
   const nowAudio = useRhythmStore.getState().lastAudioTime; // ★ 現在のAudio時刻(ms)
-  const targetTimeMs = nowAudio + absBeat * beatDurationMs;
+  let targetTimeMs = nowAudio + absBeat * beatDurationMs;
   const appearLeadMs = 4000; // 4秒前に出現
+  // targetTime が近すぎる場合は 1 小節ずつ先送り
+  while (targetTimeMs - nowAudio < appearLeadMs) {
+    targetTimeMs += timeSignature * beatDurationMs;
+  }
   const spawnTimeMs = targetTimeMs - appearLeadMs;
   
   // spawn以前は0、target時点で100になるように初期ゲージを計算

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -10,6 +10,9 @@ import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';
 import { useEnemyStore } from '@/stores/enemyStore';
 import { MONSTERS, getStageMonsterIds } from '@/data/monsters';
 import * as PIXI from 'pixi.js';
+import { RhythmManager } from '@/utils/RhythmManager';
+import { ProgressionManager } from '@/utils/ProgressionManager';
+import { SyncMonitor } from '@/utils/SyncMonitor';
 
 // ===== 型定義 =====
 
@@ -41,6 +44,20 @@ interface FantasyStage {
   monsterIcon: string;
   bgmUrl?: string;
   simultaneousMonsterCount: number; // 同時出現モンスター数 (1-8)
+  // リズムモード関連
+  game_type?: 'quiz' | 'rhythm';
+  rhythm_pattern?: 'random' | 'progression';
+  bpm?: number;
+  time_signature?: 3 | 4;
+  loop_measures?: number;
+  chord_progression_data?: {
+    chords: Array<{
+      chord: string;
+      measure: number;
+      beat: number;
+    }>;
+  };
+  mp3_url?: string;
 }
 
 interface MonsterState {
@@ -54,6 +71,14 @@ interface MonsterState {
   correctNotes: number[]; // このモンスター用の正解済み音
   icon: string;
   name: string;
+  // リズムモード用
+  timing?: {
+    measure: number;
+    beat: number;
+    spawnTime: number; // 出現時刻（ms）
+    targetTime: number; // 判定時刻（ms）
+  };
+  questionNumber?: number; // プログレッションパターン用
 }
 
 interface FantasyGameState {
@@ -86,6 +111,15 @@ interface FantasyGameState {
   simultaneousMonsterCount: number; // 同時表示数
   // ゲーム完了処理中フラグ
   isCompleting: boolean;
+  // リズムモード関連
+  rhythmManager?: RhythmManager;
+  progressionManager?: ProgressionManager;
+  syncMonitor?: SyncMonitor;
+  isReady: boolean;
+  readyCountdown: number; // 3→2→1→0
+  currentMeasure: number;
+  currentBeat: number;
+  timeOffset: number; // 同期補正用のオフセット
 }
 
 interface FantasyGameEngineProps {
@@ -337,6 +371,73 @@ const selectRandomChord = (allowedChords: string[], previousChordId?: string, di
 };
 
 /**
+ * リズムランダムパターン用のモンスター生成タイミング計算
+ */
+const generateRandomRhythmTiming = (
+  measure: number,
+  timeSignature: number,
+  bpm: number
+): { measure: number; beat: number } => {
+  // 各小節でランダムな拍を選択
+  const possibleBeats = timeSignature === 4 
+    ? [1, 1.5, 2, 2.5, 3, 3.5, 4] 
+    : [1, 1.5, 2, 2.5, 3];
+  
+  const randomBeat = possibleBeats[Math.floor(Math.random() * possibleBeats.length)];
+  
+  return {
+    measure,
+    beat: randomBeat
+  };
+};
+
+/**
+ * リズムモード用のモンスター生成
+ */
+const createRhythmMonster = (
+  monsterIndex: number,
+  position: MonsterState['position'],
+  hp: number,
+  chord: ChordDefinition,
+  timing: { measure: number; beat: number },
+  bpm: number,
+  startTimeMs: number,
+  monsterIds: string[],
+  timeSignature: number = 4  // 追加
+): MonsterState => {
+  const monsterId = monsterIds[monsterIndex % monsterIds.length];
+  const monsterData = MONSTERS[monsterId] || MONSTERS['slime_green'];
+  
+  // タイミング計算
+  const beatDurationMs = 60000 / bpm;
+  const beatsFromStart = (timing.measure - 1) * timeSignature + (timing.beat - 1);
+  const targetTimeMs = startTimeMs + (beatsFromStart * beatDurationMs);
+  const spawnTimeMs = targetTimeMs - 4000; // 4秒前に出現
+  
+  // 0秒地点のコードの場合、初期ゲージを調整
+  const initialGauge = targetTimeMs <= startTimeMs ? 80 : 0;
+  
+  return {
+    id: `monster_${Date.now()}_${Math.random()}`,
+    index: monsterIndex,
+    position,
+    currentHp: hp,
+    maxHp: hp,
+    gauge: initialGauge,
+    chordTarget: chord,
+    correctNotes: [],
+    icon: monsterData.icon,
+    name: monsterData.name,
+    timing: {
+      measure: timing.measure,
+      beat: timing.beat,
+      spawnTime: spawnTimeMs,
+      targetTime: targetTimeMs
+    }
+  };
+};
+
+/**
  * コード進行から次のコードを取得
  */
 const getProgressionChord = (progression: string[], questionIndex: number, displayOpts?: DisplayOpts): ChordDefinition | null => {
@@ -372,6 +473,8 @@ export const useFantasyGameEngine = ({
   const [stageMonsterIds, setStageMonsterIds] = useState<string[]>([]);
   // プリロードしたテクスチャを保持
   const imageTexturesRef = useRef<Map<string, PIXI.Texture>>(new Map());
+  // クイズモード用のオーディオ参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   
   const [gameState, setGameState] = useState<FantasyGameState>({
     currentStage: null,
@@ -401,20 +504,119 @@ export const useFantasyGameEngine = ({
     monsterQueue: [],
     simultaneousMonsterCount: 1,
     // ゲーム完了処理中フラグ
-    isCompleting: false
+    isCompleting: false,
+    // リズムモード関連
+    rhythmManager: undefined,
+    progressionManager: undefined,
+    syncMonitor: undefined,
+    isReady: false,
+    readyCountdown: 3,
+    currentMeasure: 0,
+    currentBeat: 0,
+    timeOffset: 0
   });
   
   const [enemyGaugeTimer, setEnemyGaugeTimer] = useState<NodeJS.Timeout | null>(null);
   
+  // リズムランダムパターン用のモンスター生成スケジューラー
+  const scheduleRandomMonster = useCallback((measure: number) => {
+    setGameState(prevState => {
+      if (!prevState.currentStage || 
+          prevState.currentStage.game_type !== 'rhythm' || 
+          prevState.currentStage.rhythm_pattern !== 'random' ||
+          !prevState.isGameActive) {
+        return prevState;
+      }
+      
+      // すでにアクティブなモンスターがいる場合はスキップ
+      if (prevState.activeMonsters.length > 0) {
+        return prevState;
+      }
+      
+      // モンスターキューから次のモンスターを取得
+      if (prevState.monsterQueue.length === 0) {
+        // 全てのモンスターを倒した
+        return prevState;
+      }
+      
+      const nextMonsterIndex = prevState.monsterQueue[0];
+      const remainingQueue = prevState.monsterQueue.slice(1);
+      
+      // ランダムなタイミングを生成
+      const timing = generateRandomRhythmTiming(
+        measure,
+        prevState.currentStage.time_signature || 4,
+        prevState.currentStage.bpm || 120
+      );
+      
+      // ランダムなコードを選択
+      const lastChordId = prevState.activeMonsters.length > 0 
+        ? prevState.activeMonsters[prevState.activeMonsters.length - 1].chordTarget.id 
+        : undefined;
+      const chord = selectRandomChord(
+        prevState.currentStage.allowedChords,
+        lastChordId,
+        displayOpts || { lang: 'en', simple: false }
+      );
+      
+      if (!chord) return prevState;
+      
+      // モンスターを生成
+      const newMonster = createRhythmMonster(
+        nextMonsterIndex,
+        'A', // ランダムパターンは常に1体なのでA列固定
+        prevState.currentStage.enemyHp,
+        chord,
+        timing,
+        prevState.currentStage.bpm || 120,
+        performance.now(),
+        stageMonsterIds,
+        prevState.currentStage.time_signature || 4 // タイムシグネチャーを渡す
+      );
+      
+      devLog.debug('🎲 ランダムモンスター生成:', {
+        measure: timing.measure,
+        beat: timing.beat,
+        chord: chord.displayName
+      });
+      
+      return {
+        ...prevState,
+        activeMonsters: [newMonster],
+        monsterQueue: remainingQueue
+      };
+    });
+  }, [stageMonsterIds, displayOpts]);
+  
   // ゲーム初期化
-  const initializeGame = useCallback(async (stage: FantasyStage) => {
-    devLog.debug('🎮 ファンタジーゲーム初期化:', { stage: stage.name });
+  const initializeGame = useCallback(async (stage: FantasyStage, displayOptsParam?: DisplayOpts) => {
+    devLog.debug('🎮 initializeGame called with stage:', stage);
+    devLog.debug('🎮 Stage game_type:', stage.game_type);
+    devLog.debug('🎮 Stage rhythm_pattern:', stage.rhythm_pattern);
+    
+    // ステージデータを正規化（デフォルト値を設定）
+    const normalizedStage: FantasyStage = {
+      ...stage,
+      game_type: stage.game_type || 'quiz',
+      rhythm_pattern: stage.rhythm_pattern || undefined,
+      bpm: stage.bpm || 120,
+      time_signature: stage.time_signature || 4,
+      loop_measures: stage.loop_measures || 8,
+      chord_progression_data: stage.chord_progression_data || undefined,
+      mp3_url: stage.mp3_url || '/demo-1.mp3'
+    };
+    
+    devLog.debug('🎮 ファンタジーゲーム初期化:', { stage: normalizedStage.name });
+
+    // gameTypeのデフォルト値を設定
+    const gameType = normalizedStage.game_type || 'quiz';
+    devLog.debug('🔍 リズムモードのデバッグ: gameType =', gameType);
 
     // 新しいステージ定義から値を取得
-    const totalEnemies = stage.enemyCount;
-    const enemyHp = stage.enemyHp;
+    const totalEnemies = normalizedStage.enemyCount;
+    const enemyHp = normalizedStage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
-    const simultaneousCount = stage.simultaneousMonsterCount || 1;
+    const simultaneousCount = normalizedStage.simultaneousMonsterCount || 1;
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -453,6 +655,66 @@ export const useFantasyGameEngine = ({
       devLog.error('❌ モンスター画像プリロード失敗:', error);
     }
 
+    // リズムモード固有の初期化
+    let rhythmManager: RhythmManager | undefined;
+    let progressionManager: ProgressionManager | undefined;
+    let syncMonitor: SyncMonitor | undefined;
+
+    if (gameType === 'rhythm') {
+      devLog.debug('🎵 リズムモード検出、RhythmManagerとSyncMonitorを初期化');
+      
+      try {
+        // RhythmManagerの初期化
+        rhythmManager = new RhythmManager({
+          audioUrl: normalizedStage.mp3_url || '/demo-1.mp3',
+          bpm: normalizedStage.bpm || 120,
+          timeSignature: normalizedStage.time_signature || 4,
+          loopMeasures: normalizedStage.loop_measures || 8,
+          volume: 0.7
+        });
+        devLog.debug('✅ RhythmManager初期化成功');
+      } catch (error) {
+        devLog.error('❌ RhythmManager初期化エラー:', error);
+      }
+      
+      // SyncMonitorの初期化
+      try {
+        syncMonitor = new SyncMonitor(
+          performance.now() + 3000, // ゲーム開始時刻（Readyフェーズ後）
+          performance.now() + 3000  // 音楽開始時刻（同じ）
+        );
+        devLog.debug('✅ SyncMonitor初期化成功');
+      } catch (error) {
+        devLog.error('❌ SyncMonitor初期化エラー:', error);
+      }
+      
+      // コールバックの設定
+      if (rhythmManager) {
+        rhythmManager.onBeat((pos) => {
+          devLog.debug('🎵 Beat:', pos);
+        });
+
+        rhythmManager.onLoop(() => {
+          devLog.debug('🔄 Loop triggered');
+        });
+        
+        // onMeasureは後でuseEffectで設定（scheduleRandomMonsterを使うため）
+      }
+      
+      // プログレッションパターンの場合、ProgressionManagerを初期化
+      if (normalizedStage.rhythm_pattern === 'progression' && normalizedStage.chord_progression_data) {
+        try {
+          progressionManager = new ProgressionManager(
+            normalizedStage.chord_progression_data,
+            normalizedStage.loop_measures || 8
+          );
+          devLog.debug('✅ ProgressionManager初期化成功');
+        } catch (error) {
+          devLog.error('❌ ProgressionManager初期化エラー:', error);
+        }
+      }
+    }
+
     // ▼▼▼ 修正点1: モンスターキューをシャッフルする ▼▼▼
     // モンスターキューを作成（0からtotalEnemies-1までのインデックス）
     const monsterIndices = Array.from({ length: totalEnemies }, (_, i) => i);
@@ -478,18 +740,51 @@ export const useFantasyGameEngine = ({
       const monsterIndex = monsterQueue.shift()!;
       // simultaneousMonsterCount === 1 のとき、0 番目のみ即生成。
       if (i === 0 || simultaneousCount > 1) {
-        const monster = createMonsterFromQueue(
-          monsterIndex,
-          positions[i],
-          enemyHp,
-          stage.allowedChords,
-          lastChordId,
-          displayOpts,
-          monsterIds        // ✅ 今回作った配列
-        );
-        activeMonsters.push(monster);
-        usedChordIds.push(monster.chordTarget.id);
-        lastChordId = monster.chordTarget.id;
+        // リズムプログレッションパターンの場合
+        if (gameType === 'rhythm' && normalizedStage.rhythm_pattern === 'progression' && progressionManager) {
+          devLog.debug('🎯 リズムプログレッションパターンでモンスター生成開始');
+          const initialChords = progressionManager.getInitialChords();
+          if (i < initialChords.length) {
+            const chordAssignment = initialChords[i];
+            const chord = getChordDefinition(chordAssignment.chord, displayOptsParam);
+            if (chord) {
+              devLog.debug('🎯 プログレッションモンスター生成:', {
+                index: i,
+                chord: chordAssignment.chord,
+                questionNumber: chordAssignment.questionNumber
+              });
+              const monster = createRhythmMonster(
+                monsterIndex,
+                positions[i],
+                enemyHp,
+                chord,
+                chordAssignment.timing,
+                normalizedStage.bpm || 120,
+                performance.now() + 3000, // Readyフェーズ後に開始
+                monsterIds,
+                normalizedStage.time_signature || 4 // タイムシグネチャーを渡す
+              );
+              monster.questionNumber = chordAssignment.questionNumber;
+              activeMonsters.push(monster);
+              usedChordIds.push(monster.chordTarget.id);
+              lastChordId = monster.chordTarget.id;
+            }
+          }
+        } else {
+          // 既存の処理（クイズモード、リズムランダムモード）
+          const monster = createMonsterFromQueue(
+            monsterIndex,
+            positions[i],
+            enemyHp,
+            normalizedStage.allowedChords,
+            lastChordId,
+            displayOptsParam,
+            monsterIds        // ✅ 今回作った配列
+          );
+          activeMonsters.push(monster);
+          usedChordIds.push(monster.chordTarget.id);
+          lastChordId = monster.chordTarget.id;
+        }
       }
     }
 
@@ -498,10 +793,10 @@ export const useFantasyGameEngine = ({
     const firstChord = firstMonster ? firstMonster.chordTarget : null;
 
     const newState: FantasyGameState = {
-      currentStage: stage,
+      currentStage: normalizedStage,
       currentQuestionIndex: 0,
       currentChordTarget: firstChord,
-      playerHp: stage.maxHp,
+      playerHp: normalizedStage.maxHp,
       enemyGauge: 0,
       score: 0,
       totalQuestions: totalQuestions,
@@ -525,21 +820,45 @@ export const useFantasyGameEngine = ({
       monsterQueue,
       simultaneousMonsterCount: simultaneousCount,
       // ゲーム完了処理中フラグ
-      isCompleting: false
+      isCompleting: false,
+      // リズムモード関連
+      rhythmManager: rhythmManager,
+      progressionManager: progressionManager,
+      syncMonitor: syncMonitor,
+      isReady: gameType === 'rhythm', // リズムモードの場合はReadyフェーズから開始
+      readyCountdown: gameType === 'rhythm' ? 3 : 0,
+      currentMeasure: 0,
+      currentBeat: 0,
+      timeOffset: 0
     };
 
     setGameState(newState);
     onGameStateChange(newState);
 
+    // クイズモードでも音楽を再生
+    if (gameType !== 'rhythm') {
+      const audio = new Audio(normalizedStage.mp3_url || '/demo-1.mp3');
+      audio.loop = true;
+      audio.volume = 0.7;
+      
+      // Safari対策: play() promise 無視
+      void audio.play().catch(err => {
+        devLog.warn('⚠️ 音楽自動再生失敗（ユーザー操作が必要）:', err);
+      });
+      
+      // クリーンアップ用に保存
+      audioRef.current = audio;
+    }
+
     devLog.debug('✅ ゲーム初期化完了:', {
-      stage: stage.name,
+      stage: normalizedStage.name,
       totalEnemies,
       enemyHp,
       totalQuestions,
       simultaneousCount,
       activeMonsters: activeMonsters.length
     });
-  }, [onGameStateChange]);
+  }, [onGameStateChange, displayOpts]);
   
   // 次の問題への移行（マルチモンスター対応）
   const proceedToNextQuestion = useCallback(() => {
@@ -734,6 +1053,78 @@ export const useFantasyGameEngine = ({
         return prevState;
       }
       
+      // リズムモードの場合
+      if (prevState.currentStage.game_type === 'rhythm' && prevState.rhythmManager) {
+        const currentPos = prevState.rhythmManager.getCurrentPosition();
+        const currentTimeMs = performance.now();
+        
+        // 同期チェック
+        if (prevState.syncMonitor?.shouldCheckSync(currentTimeMs)) {
+          const syncStatus = prevState.syncMonitor.checkSync(
+            prevState.rhythmManager.getCurrentPosition().absoluteBeat * (60 / (prevState.currentStage.bpm || 120)),
+            currentTimeMs,
+            prevState.currentStage.bpm || 120
+          );
+          
+          if (!syncStatus.inSync && syncStatus.correction) {
+            devLog.warn('🔄 同期補正:', { drift: syncStatus.drift, correction: syncStatus.correction });
+            // タイムオフセットを徐々に補正
+            const newOffset = prevState.syncMonitor.autoCorrect(
+              prevState.timeOffset,
+              syncStatus.correction
+            );
+            
+            return {
+              ...prevState,
+              timeOffset: newOffset
+            };
+          }
+        }
+        
+        // 各モンスターのゲージを音楽に同期して更新
+        const updatedMonsters = prevState.activeMonsters.map(monster => {
+          if (!monster.timing) return monster;
+          
+          // 判定時刻までの残り時間から逆算してゲージを計算（タイムオフセットを考慮）
+          const timeToTarget = monster.timing.targetTime - currentTimeMs + prevState.timeOffset;
+          const totalTime = prevState.currentStage.enemyGaugeSeconds * 1000;
+          const gaugeProgress = Math.max(0, Math.min(100, (1 - timeToTarget / totalTime) * 100));
+          
+          return {
+            ...monster,
+            gauge: gaugeProgress
+          };
+        });
+        
+        // 判定タイミングを過ぎたモンスターをチェック（判定ウィンドウ外）
+        const missedMonster = updatedMonsters.find(m => 
+          m.timing && currentTimeMs > m.timing.targetTime + 200
+        );
+        
+        if (missedMonster) {
+          devLog.debug('⏰ 判定タイミングミス！', { monster: missedMonster.name });
+          // 攻撃処理を実行
+          setTimeout(() => handleEnemyAttack(missedMonster.id), 0);
+          
+          // ミスしたモンスターを削除して新しいモンスターを生成
+          const filteredMonsters = updatedMonsters.filter(m => m.id !== missedMonster.id);
+          // TODO: 新しいモンスター生成処理
+          
+          return {
+            ...prevState,
+            activeMonsters: filteredMonsters
+          };
+        }
+        
+        return {
+          ...prevState,
+          activeMonsters: updatedMonsters,
+          currentMeasure: currentPos.measure,
+          currentBeat: currentPos.beat
+        };
+      }
+      
+      // クイズモードの場合（既存の処理）
       const incrementRate = 100 / (prevState.currentStage.enemyGaugeSeconds * 10); // 100ms間隔で更新
       
       // 各モンスターのゲージを更新
@@ -795,6 +1186,119 @@ export const useFantasyGameEngine = ({
 
       devLog.debug('🎹 ノート入力受信 (in updater):', { note, noteMod12: note % 12 });
 
+      // リズムモードの判定処理
+      if (prevState.currentStage?.game_type === 'rhythm' && prevState.rhythmManager) {
+        const currentTimeMs = performance.now();
+        const noteMod12 = note % 12;
+        
+        // 判定ウィンドウ内のモンスターを探す
+        const judgeableMonsters = prevState.activeMonsters.filter(monster => {
+          if (!monster.timing) return false;
+          const timeToTarget = monster.timing.targetTime - currentTimeMs;
+          return timeToTarget >= -200 && timeToTarget <= 200; // 判定ウィンドウは±200ms
+        });
+        
+        if (judgeableMonsters.length === 0) {
+          // 判定ウィンドウ内にモンスターがいない
+          devLog.debug('❌ タイミングミス: 判定ウィンドウ外');
+          return prevState;
+        }
+        
+        // 最も判定タイミングに近いモンスターを選択
+        const targetMonster = judgeableMonsters.reduce((closest, current) => {
+          const closestDiff = Math.abs(closest.timing!.targetTime - currentTimeMs);
+          const currentDiff = Math.abs(current.timing!.targetTime - currentTimeMs);
+          return currentDiff < closestDiff ? current : closest;
+        });
+        
+        // 音の判定を行う
+        const targetNotes = [...new Set(targetMonster.chordTarget.notes.map(n => n % 12))];
+        
+        if (!targetNotes.includes(noteMod12)) {
+          // 間違った音
+          devLog.debug('❌ 間違った音:', { input: noteMod12, expected: targetNotes });
+          return prevState;
+        }
+        
+        // 正解した音を記録
+        const newCorrectNotes = [...targetMonster.correctNotes, noteMod12];
+        const updatedMonster = { ...targetMonster, correctNotes: newCorrectNotes };
+        
+        // コードが完成したかチェック
+        if (newCorrectNotes.length === targetNotes.length) {
+          // パーフェクト判定かチェック
+          const timeDiff = Math.abs(targetMonster.timing!.targetTime - currentTimeMs);
+          const isPerfect = timeDiff <= 50;
+          
+          devLog.debug('✅ コード完成！', { 
+            chord: targetMonster.chordTarget.displayName,
+            perfect: isPerfect,
+            timeDiff 
+          });
+          
+          // モンスターを倒す処理（後で実装）
+          const filteredMonsters = prevState.activeMonsters.filter(m => m.id !== targetMonster.id);
+          
+          // 次のモンスターを生成
+          let newMonsters = [...filteredMonsters];
+          
+          // プログレッションパターンの場合、即座に補充
+          if (prevState.currentStage.rhythm_pattern === 'progression' && 
+              prevState.progressionManager && 
+              prevState.monsterQueue.length > 0) {
+            const nextMonsterIndex = prevState.monsterQueue[0];
+            const remainingQueue = prevState.monsterQueue.slice(1);
+            
+            const chordAssignment = prevState.progressionManager.getNextChordForColumn(targetMonster.position);
+            const chord = getChordDefinition(chordAssignment.chord, displayOpts);
+            
+            if (chord) {
+              const newMonster = createRhythmMonster(
+                nextMonsterIndex,
+                targetMonster.position,
+                prevState.currentStage.enemyHp,
+                chord,
+                chordAssignment.timing,
+                prevState.currentStage.bpm || 120,
+                currentTimeMs,
+                stageMonsterIds,
+                prevState.currentStage.time_signature || 4 // タイムシグネチャーを渡す
+              );
+              newMonster.questionNumber = chordAssignment.questionNumber;
+              newMonsters.push(newMonster);
+              
+              return {
+                ...prevState,
+                activeMonsters: newMonsters,
+                monsterQueue: remainingQueue,
+                correctAnswers: prevState.correctAnswers + 1,
+                score: prevState.score + (isPerfect ? 200 : 100),
+                enemiesDefeated: prevState.enemiesDefeated + 1
+              };
+            }
+          }
+          
+          return {
+            ...prevState,
+            activeMonsters: newMonsters,
+            correctAnswers: prevState.correctAnswers + 1,
+            score: prevState.score + (isPerfect ? 200 : 100),
+            enemiesDefeated: prevState.enemiesDefeated + 1
+          };
+        }
+        
+        // まだコードが完成していない
+        const updatedMonsters = prevState.activeMonsters.map(m => 
+          m.id === targetMonster.id ? updatedMonster : m
+        );
+        
+        return {
+          ...prevState,
+          activeMonsters: updatedMonsters
+        };
+      }
+
+      // 以下、既存のクイズモード処理
       const noteMod12 = note % 12;
       const completedMonsters: MonsterState[] = [];
       let hasAnyNoteChanged = false;
@@ -926,7 +1430,7 @@ export const useFantasyGameEngine = ({
         return newState;
       }
     });
-  }, [onChordCorrect, onGameComplete, onGameStateChange]);
+  }, [onChordCorrect, onGameComplete, onGameStateChange, displayOpts, stageMonsterIds]);
   
   // 次の敵へ進むための新しい関数
   const proceedToNextEnemy = useCallback(() => {
@@ -1017,6 +1521,45 @@ export const useFantasyGameEngine = ({
   //     initializeGame(stage);
   //   }
   // }, [stage, initializeGame]);
+
+  // Readyフェーズのカウントダウン処理
+  useEffect(() => {
+    if (gameState.isReady && gameState.readyCountdown >= 0) {
+      const countdownTimer = setTimeout(() => {
+        setGameState(prevState => {
+          if (prevState.readyCountdown === 0) {
+            // カウントダウン終了、音楽開始
+            prevState.rhythmManager?.start();
+            devLog.debug('🎵 音楽開始！');
+            return {
+              ...prevState,
+              isReady: false,
+              readyCountdown: -1
+            };
+          } else {
+            // カウントダウンを減らす
+            return {
+              ...prevState,
+              readyCountdown: prevState.readyCountdown - 1
+            };
+          }
+        });
+      }, 1000);
+
+      return () => clearTimeout(countdownTimer);
+    }
+  }, [gameState.isReady, gameState.readyCountdown]);
+
+  // リズムマネージャーの小節コールバック設定
+  useEffect(() => {
+    if (gameState.rhythmManager && 
+        gameState.currentStage?.game_type === 'rhythm' && 
+        gameState.currentStage?.rhythm_pattern === 'random') {
+      gameState.rhythmManager.onMeasure((measure) => {
+        scheduleRandomMonster(measure);
+      });
+    }
+  }, [gameState.rhythmManager, gameState.currentStage, scheduleRandomMonster]);
   
   // コンポーネント破棄時のクリーンアップ
   useEffect(() => {
@@ -1025,12 +1568,26 @@ export const useFantasyGameEngine = ({
         devLog.debug('⏰ 敵ゲージタイマー クリーンアップで停止');
         clearInterval(enemyGaugeTimer);
       }
+      // リズムマネージャーのクリーンアップ
+      if (gameState.rhythmManager) {
+        gameState.rhythmManager.stop();
+      }
+      // クイズモード用音楽のクリーンアップ
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
       // if (inputTimeout) { // 削除
       //   devLog.debug('⏰ 入力タイムアウト クリーンアップで停止'); // 削除
       //   clearTimeout(inputTimeout); // 削除
       // } // 削除
     };
   }, []);
+  
+  // ゲーム完了時の処理
+  const handleGameComplete = useCallback((result: 'clear' | 'gameover', finalState: FantasyGameState) => {
+    onGameComplete(result, finalState.score, finalState.correctAnswers, finalState.totalQuestions);
+  }, [onGameComplete]);
   
 
   

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -15,6 +15,8 @@ import FantasySettingsModal from './FantasySettingsModal';
 import type { DisplayOpts } from '@/utils/display-note';
 import { toDisplayName } from '@/utils/display-note';
 import { note as parseNote } from 'tonal';
+import { ReadyOverlay } from '../common/ReadyOverlay';
+import { JudgmentMarker } from '../common/JudgmentMarker';
 
 interface FantasyGameScreenProps {
   stage: FantasyStage;
@@ -578,7 +580,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // 敵のゲージ表示（黄色系）
   const renderEnemyGauge = useCallback(() => {
     return (
-      <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
+      <div className="relative w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
         <div 
           className="h-full bg-gradient-to-r from-yellow-500 to-orange-400 rounded-full transition-all duration-200 ease-out"
           style={{ 
@@ -586,9 +588,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
             boxShadow: gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
           }}
         />
+        {/* リズムモードの場合、判定マーカーを表示 */}
+        {stage.game_type === 'rhythm' && <JudgmentMarker position={80} />}
       </div>
     );
-  }, [gameState.enemyGauge]);
+  }, [gameState.enemyGauge, stage.game_type]);
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
@@ -623,9 +627,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // ★ マウント時 autoStart なら即開始
   useEffect(() => {
     if (autoStart) {
-      initializeGame(stage);
+      initializeGame(stage, { lang: currentNoteNameLang, simple: currentSimpleNoteName });
     }
-  }, [autoStart, initializeGame, stage]);
+  }, [autoStart, initializeGame, stage, currentNoteNameLang, currentSimpleNoteName]);
 
   // ゲーム開始前画面（オーバーレイ表示中は表示しない）
   if (!overlay && !gameState.isCompleting && (!gameState.isGameActive || !gameState.currentChordTarget)) {
@@ -649,7 +653,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           <button
             onClick={() => {
               devLog.debug('🎮 ゲーム開始ボタンクリック');
-              initializeGame(stage);
+              initializeGame(stage, { lang: currentNoteNameLang, simple: currentSimpleNoteName });
             }}
             className="px-8 py-4 bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-400 hover:to-orange-400 text-black font-bold text-xl rounded-lg shadow-lg transform hover:scale-105 transition-all"
           >
@@ -852,6 +856,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                           className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
                           style={{ width: `${monster.gauge}%` }}
                         />
+                        {/* リズムモードの場合、判定マーカーを表示 */}
+                        {stage.game_type === 'rhythm' && <JudgmentMarker position={80} />}
                       </div>
                       
                       {/* HPゲージ */}
@@ -1068,6 +1074,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
             {overlay.text}
           </span>
         </div>
+      )}
+      
+      {/* Readyフェーズオーバーレイ */}
+      {gameState.isReady && gameState.readyCountdown >= 0 && (
+        <ReadyOverlay count={gameState.readyCountdown} />
       )}
     </div>
   );

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -383,7 +383,15 @@ const FantasyMain: React.FC = () => {
         showGuide: nextStageData.show_guide,
         monsterIcon: nextStageData.monster_icon,
         bgmUrl: nextStageData.bgm_url,
-        simultaneousMonsterCount: nextStageData.simultaneous_monster_count || 1
+        simultaneousMonsterCount: nextStageData.simultaneous_monster_count || 1,
+        // リズムモード関連フィールドを追加
+        game_type: nextStageData.game_type as 'quiz' | 'rhythm' | undefined,
+        rhythm_pattern: nextStageData.rhythm_pattern as 'random' | 'progression' | undefined,
+        bpm: nextStageData.bpm,
+        time_signature: nextStageData.time_signature as 3 | 4 | undefined,
+        loop_measures: nextStageData.loop_measures,
+        chord_progression_data: nextStageData.chord_progression_data,
+        mp3_url: nextStageData.mp3_url
       };
 
       setGameResult(null);

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -148,26 +148,44 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
       }
       
       //// データの変換とセット
-      const convertedStages: FantasyStage[] = (stagesData || []).map((stage: any) => ({
-        id: stage.id,
-        stageNumber: stage.stage_number,
-        name: stage.name,
-        description: stage.description || '',
-        maxHp: stage.max_hp,
-        enemyGaugeSeconds: stage.enemy_gauge_seconds,
-        enemyCount: stage.enemy_count,
-        enemyHp: stage.enemy_hp,
-        minDamage: stage.min_damage,
-        maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
-        allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
-        chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
-        showSheetMusic: stage.show_sheet_music,
-        showGuide: stage.show_guide,
-        monsterIcon: stage.monster_icon,
-        bgmUrl: stage.bgm_url,
-        simultaneousMonsterCount: stage.simultaneous_monster_count || 1
-      }));
+      const convertedStages: FantasyStage[] = (stagesData || []).map((stage: any) => {
+        // デバッグログを追加
+        devLog.debug('🎮 ステージデータ変換:', {
+          stage_number: stage.stage_number,
+          game_type: stage.game_type,
+          rhythm_pattern: stage.rhythm_pattern,
+          bpm: stage.bpm
+        });
+        
+        return {
+          id: stage.id,
+          stageNumber: stage.stage_number,
+          name: stage.name,
+          description: stage.description || '',
+          maxHp: stage.max_hp,
+          enemyGaugeSeconds: stage.enemy_gauge_seconds,
+          enemyCount: stage.enemy_count,
+          enemyHp: stage.enemy_hp,
+          minDamage: stage.min_damage,
+          maxDamage: stage.max_damage,
+          mode: stage.mode as 'single' | 'progression',
+          allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
+          chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
+          showSheetMusic: stage.show_sheet_music,
+          showGuide: stage.show_guide,
+          monsterIcon: stage.monster_icon,
+          bgmUrl: stage.bgm_url,
+          simultaneousMonsterCount: stage.simultaneous_monster_count || 1,
+          // リズムモード関連フィールドを追加
+          game_type: stage.game_type as 'quiz' | 'rhythm' | undefined,
+          rhythm_pattern: stage.rhythm_pattern as 'random' | 'progression' | undefined,
+          bpm: stage.bpm,
+          time_signature: stage.time_signature as 3 | 4 | undefined,
+          loop_measures: stage.loop_measures,
+          chord_progression_data: stage.chord_progression_data,
+          mp3_url: stage.mp3_url
+        };
+      });
       
       const convertedProgress: FantasyUserProgress = {
         id: userProgressData.id,

--- a/src/stores/rhythmStore.ts
+++ b/src/stores/rhythmStore.ts
@@ -10,9 +10,11 @@ interface RhythmState {
     beat: number;           // 小数込み (1.0,1.5…)
     absoluteBeat: number;   // loop 0 始まり
   };
+  lastAudioTime: number;          // ★ Audio の現在時刻(ms)
   setPlaying: (flag: boolean) => void;
   setStart: (t: number) => void;
   setPos: (pos: RhythmState['currentPos']) => void;
+  setLastAudioTime: (t: number) => void;
 }
 
 export const useRhythmStore = create<RhythmState>()((set) => ({
@@ -21,7 +23,9 @@ export const useRhythmStore = create<RhythmState>()((set) => ({
   bpm: 120,
   beatDuration: 500,
   currentPos: { measure: 0, beat: 0, absoluteBeat: 0 },
+  lastAudioTime: 0,
   setPlaying: (f) => set({ isPlaying: f }),
   setStart: (t) => set({ startAt: t }),
   setPos: (p) => set({ currentPos: p }),
+  setLastAudioTime: (t) => set({ lastAudioTime: t }),
 }));

--- a/src/stores/rhythmStore.ts
+++ b/src/stores/rhythmStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface RhythmState {
+  isPlaying: boolean;
+  startAt: number;          // High-res 時刻 (ms)
+  bpm: number;
+  beatDuration: number;     // 1beat ms
+  currentPos: {
+    measure: number;
+    beat: number;           // 小数込み (1.0,1.5…)
+    absoluteBeat: number;   // loop 0 始まり
+  };
+  setPlaying: (flag: boolean) => void;
+  setStart: (t: number) => void;
+  setPos: (pos: RhythmState['currentPos']) => void;
+}
+
+export const useRhythmStore = create<RhythmState>()((set) => ({
+  isPlaying: false,
+  startAt: 0,
+  bpm: 120,
+  beatDuration: 500,
+  currentPos: { measure: 0, beat: 0, absoluteBeat: 0 },
+  setPlaying: (f) => set({ isPlaying: f }),
+  setStart: (t) => set({ startAt: t }),
+  setPos: (p) => set({ currentPos: p }),
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -641,6 +641,20 @@ export interface FantasyStage {
   show_guide: boolean;
   simultaneous_monster_count?: number;
   monster_icon?: string;
+  // リズムモード関連
+  game_type?: 'quiz' | 'rhythm';
+  rhythm_pattern?: 'random' | 'progression';
+  bpm?: number;
+  time_signature?: 3 | 4;
+  loop_measures?: number;
+  chord_progression_data?: {
+    chords: Array<{
+      chord: string;
+      measure: number;
+      beat: number;
+    }>;
+  };
+  mp3_url?: string;
 }
 
 export interface LessonContext {

--- a/src/utils/ProgressionManager.ts
+++ b/src/utils/ProgressionManager.ts
@@ -1,0 +1,125 @@
+export interface ChordProgressionData {
+  chords: Array<{
+    chord: string;
+    measure: number;
+    beat: number;
+  }>;
+}
+
+export interface ChordAssignment {
+  questionNumber: number;
+  chord: string;
+  timing: TimingInfo;
+  column: string;
+}
+
+export interface TimingInfo {
+  measure: number;
+  beat: number;
+  cycleNumber: number;
+}
+
+interface ProgressionState {
+  totalChords: number;          // 総コード数
+  currentCycle: number;         // 現在のサイクル（何周目か）
+  columnAssignments: Map<string, number>; // 列と問題番号のマッピング
+  nextQuestionNumber: number;   // 次に出題する問題番号
+  answeredCount: number;        // 回答済みの総数
+}
+
+export class ProgressionManager {
+  private state: ProgressionState;
+  private chordData: ChordProgressionData;
+  private loopMeasures: number;
+
+  constructor(chordData: ChordProgressionData, loopMeasures: number) {
+    this.chordData = chordData;
+    this.loopMeasures = loopMeasures;
+    this.state = {
+      totalChords: chordData.chords.length,
+      currentCycle: 0,
+      columnAssignments: new Map([
+        ['A', 1], ['B', 2], ['C', 3], ['D', 4]
+      ]),
+      nextQuestionNumber: 5,
+      answeredCount: 0
+    };
+  }
+
+  // モンスター撃破時の次のコード取得
+  getNextChordForColumn(column: string): ChordAssignment {
+    const currentAssignment = this.state.columnAssignments.get(column)!;
+    const nextNumber = this.getNextQuestionNumber(column);
+    
+    // 実際のコードインデックスを計算（1ベースを0ベースに変換）
+    const chordIndex = (nextNumber - 1) % this.state.totalChords;
+    const chord = this.chordData.chords[chordIndex];
+    
+    // タイミング計算（次のサイクルを考慮）
+    const cycleOffset = Math.floor((nextNumber - 1) / this.state.totalChords);
+    const timing = this.calculateTiming(chord, cycleOffset);
+    
+    // 列の割り当てを更新
+    this.state.columnAssignments.set(column, nextNumber);
+    this.state.answeredCount++;
+    
+    return {
+      questionNumber: nextNumber,
+      chord: chord.chord,
+      timing: timing,
+      column: column
+    };
+  }
+
+  // 問題番号の計算（補充ロジックに基づく）
+  private getNextQuestionNumber(column: string): number {
+    // 現在の4体の最大問題番号を取得
+    const currentNumbers = Array.from(this.state.columnAssignments.values());
+    const maxNumber = Math.max(...currentNumbers);
+    
+    // 次のセットの開始番号
+    const nextSetStart = Math.floor(maxNumber / 4) * 4 + 5;
+    
+    // 列のオフセット
+    const columnOffset = ['A', 'B', 'C', 'D'].indexOf(column);
+    
+    return nextSetStart + columnOffset;
+  }
+
+  // 無限ループを考慮したタイミング計算
+  private calculateTiming(
+    chordData: { measure: number; beat: number },
+    cycleOffset: number
+  ): TimingInfo {
+    const absoluteMeasure = chordData.measure + (cycleOffset * this.loopMeasures);
+    
+    return {
+      measure: absoluteMeasure,
+      beat: chordData.beat,
+      cycleNumber: cycleOffset
+    };
+  }
+
+  // 初期4体のコード情報を取得
+  getInitialChords(): ChordAssignment[] {
+    const columns = ['A', 'B', 'C', 'D'] as const;
+    return columns.map((column, index) => {
+      const chordData = this.chordData.chords[index];
+      return {
+        questionNumber: index + 1,
+        chord: chordData.chord,
+        timing: {
+          measure: chordData.measure,
+          beat: chordData.beat,
+          cycleNumber: 0
+        },
+        column: column
+      };
+    });
+  }
+
+  // 現在の状態を取得（デバッグ用）
+  getState(): Readonly<ProgressionState> {
+    return { ...this.state };
+  }
+}

--- a/src/utils/RhythmManager.ts
+++ b/src/utils/RhythmManager.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-magic-numbers */
+import { useRhythmStore } from '../stores/rhythmStore';
+
 export interface RhythmPosition {
   measure: number;      // 1,2,3…
   beat: number;         // 1.0,1.5,2 …
@@ -62,7 +64,11 @@ export class RhythmManager {
   }
 
   onBeat(cb: CB<RhythmPosition>) { 
-    this.beatCb = cb; 
+    this.beatCb = (pos) => {
+      // Update rhythm store with current position
+      useRhythmStore.getState().setPos(pos);
+      if (cb) cb(pos);
+    };
   }
 
   onMeasure(cb: CB<number>) { 

--- a/src/utils/RhythmManager.ts
+++ b/src/utils/RhythmManager.ts
@@ -115,6 +115,8 @@ export class RhythmManager {
 
   /* ───────── internal ───────── */
   private process() {
+    // ★ 毎フレーム Audio 時刻を同期
+    useRhythmStore.getState().setLastAudioTime(this.audio.currentTime * 1000);
     const pos = this.getCurrentPosition();
 
     // ループ判定

--- a/src/utils/RhythmManager.ts
+++ b/src/utils/RhythmManager.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-magic-numbers */
+export interface RhythmPosition {
+  measure: number;      // 1,2,3…
+  beat: number;         // 1.0,1.5,2 …
+  absoluteBeat: number; // 開始からの累計拍
+}
+
+export interface JudgmentWindow {
+  start: number;  // ms (Audio currentTime*1000)
+  end: number;    // ms
+  perfect: boolean;
+}
+
+type CB<T> = (arg: T) => void;
+
+export class RhythmManager {
+  /** immutable config */
+  private readonly bpm: number;
+  private readonly tsig: number;
+  private readonly loopMeasures: number;
+
+  /** runtime */
+  private audio: HTMLAudioElement;
+  private lastBeat = -1;
+  private lastMeasure = -1;
+  private loopCb?: CB<void>;
+  private beatCb?: CB<RhythmPosition>;
+  private measureCb?: CB<number>;
+  private raf = 0;
+  private loopCount = 0;
+
+  constructor(cfg: {
+    audioUrl: string;
+    bpm: number;
+    timeSignature: number;
+    loopMeasures: number;
+    volume?: number;
+  }) {
+    this.bpm = cfg.bpm;
+    this.tsig = cfg.timeSignature;
+    this.loopMeasures = cfg.loopMeasures;
+    this.audio = new Audio(cfg.audioUrl);
+    this.audio.loop = false; // 手動ループ
+    this.audio.volume = cfg.volume ?? 0.7;
+  }
+
+  /* ───────── public ───────── */
+  start(startOffset = 0) {
+    this.audio.currentTime = startOffset;
+    // Safari 対策: play() promise 無視
+    void this.audio.play();
+    const tick = () => {
+      this.process();
+      this.raf = requestAnimationFrame(tick);
+    };
+    this.raf = requestAnimationFrame(tick);
+  }
+
+  stop() {
+    cancelAnimationFrame(this.raf);
+    this.audio.pause();
+  }
+
+  onBeat(cb: CB<RhythmPosition>) { 
+    this.beatCb = cb; 
+  }
+
+  onMeasure(cb: CB<number>) { 
+    this.measureCb = cb; 
+  }
+
+  onLoop(cb: CB<void>) { 
+    this.loopCb = cb; 
+  }
+
+  getCurrentPosition(): RhythmPosition {
+    const beatDur = 60 / this.bpm;
+    const absBeat = this.audio.currentTime / beatDur;
+    const measure = Math.floor(absBeat / this.tsig) + 1;
+    const beat = (absBeat % this.tsig) + 1;
+    return { 
+      measure, 
+      beat: +beat.toFixed(3), 
+      absoluteBeat: absBeat 
+    };
+  }
+
+  getJudgmentWindow(measure: number, beat: number): JudgmentWindow {
+    const beatDurMs = 60000 / this.bpm;
+    const tgtBeatIdx = (measure - 1) * this.tsig + (beat - 1);
+    const tgtTimeMs = tgtBeatIdx * beatDurMs;
+    const nowMs = this.audio.currentTime * 1000;
+    return {
+      start: tgtTimeMs - 200,
+      end: tgtTimeMs + 200,
+      perfect: Math.abs(nowMs - tgtTimeMs) < 50
+    };
+  }
+
+  getTimeToNextBeat(): number {
+    const beatDuration = 60 / this.bpm;
+    const currentBeatProgress = (this.audio.currentTime % beatDuration) / beatDuration;
+    return beatDuration * (1 - currentBeatProgress);
+  }
+
+  getLoopCount(): number {
+    return this.loopCount;
+  }
+
+  /* ───────── internal ───────── */
+  private process() {
+    const pos = this.getCurrentPosition();
+
+    // ループ判定
+    const loopDur = (60 / this.bpm) * this.tsig * this.loopMeasures;
+    if (this.audio.currentTime >= loopDur - 0.03) {
+      this.audio.currentTime = 0;               // hard-seek
+      this.loopCount++;
+      this.loopCb?.();                          // notify
+      this.lastBeat = -1; 
+      this.lastMeasure = -1;
+      return;                                   // 今フレームは beat 判定しない
+    }
+
+    // beat change
+    const intBeat = Math.floor(pos.absoluteBeat);
+    if (intBeat !== this.lastBeat) {
+      this.lastBeat = intBeat;
+      this.beatCb?.(pos);
+    }
+
+    // measure change
+    const currentMeasure = Math.floor(pos.measure);
+    if (currentMeasure !== this.lastMeasure) {
+      this.lastMeasure = currentMeasure;
+      this.measureCb?.(currentMeasure);
+    }
+  }
+}

--- a/src/utils/RhythmManager.ts
+++ b/src/utils/RhythmManager.ts
@@ -65,9 +65,9 @@ export class RhythmManager {
 
   onBeat(cb: CB<RhythmPosition>) { 
     this.beatCb = (pos) => {
-      // Update rhythm store with current position
-      useRhythmStore.getState().setPos(pos);
-      if (cb) cb(pos);
+      useRhythmStore.getState().setPos(pos);       // ★ store 更新
+      useRhythmStore.getState().setLastAudioTime(this.audio.currentTime * 1000);
+      cb?.(pos);
     };
   }
 

--- a/src/utils/SyncMonitor.ts
+++ b/src/utils/SyncMonitor.ts
@@ -1,0 +1,92 @@
+export interface SyncStatus {
+  inSync: boolean;
+  drift: number; // ズレの量（ms）
+  correction?: number; // 補正量（ms）
+}
+
+export class SyncMonitor {
+  private syncCheckInterval = 1000; // 1秒ごとにチェック
+  private maxDrift = 50; // 最大許容ズレ（ms）
+  private lastCheckTime = 0;
+  private gameStartTime: number;
+  private musicStartTime: number;
+  
+  constructor(gameStartTime: number, musicStartTime: number) {
+    this.gameStartTime = gameStartTime;
+    this.musicStartTime = musicStartTime;
+  }
+  
+  /**
+   * 音楽とゲームの同期をチェック
+   */
+  checkSync(
+    audioCurrentTime: number,
+    gameCurrentTime: number,
+    bpm: number
+  ): SyncStatus {
+    // 音楽の経過時間（ms）
+    const musicElapsedMs = audioCurrentTime * 1000;
+    
+    // ゲームの経過時間（ms）
+    const gameElapsedMs = gameCurrentTime - this.gameStartTime;
+    
+    // ズレを計算
+    const drift = Math.abs(musicElapsedMs - gameElapsedMs);
+    
+    if (drift > this.maxDrift) {
+      // 補正が必要
+      const correction = musicElapsedMs - gameElapsedMs;
+      
+      return {
+        inSync: false,
+        drift,
+        correction
+      };
+    }
+    
+    return {
+      inSync: true,
+      drift
+    };
+  }
+  
+  /**
+   * 自動補正を適用
+   */
+  autoCorrect(currentOffset: number, correction: number, smoothFactor = 0.1): number {
+    // 徐々に補正を適用（急激な変化を避ける）
+    return currentOffset + (correction * smoothFactor);
+  }
+  
+  /**
+   * 同期チェックのタイミングかどうか
+   */
+  shouldCheckSync(currentTime: number): boolean {
+    if (currentTime - this.lastCheckTime >= this.syncCheckInterval) {
+      this.lastCheckTime = currentTime;
+      return true;
+    }
+    return false;
+  }
+  
+  /**
+   * デバッグ情報を取得
+   */
+  getDebugInfo(audioTime: number, gameTime: number): {
+    musicTime: number;
+    gameTime: number;
+    drift: number;
+    status: string;
+  } {
+    const musicElapsedMs = audioTime * 1000;
+    const gameElapsedMs = gameTime - this.gameStartTime;
+    const drift = Math.abs(musicElapsedMs - gameElapsedMs);
+    
+    return {
+      musicTime: musicElapsedMs,
+      gameTime: gameElapsedMs,
+      drift,
+      status: drift <= this.maxDrift ? 'SYNC' : 'DRIFT'
+    };
+  }
+}

--- a/supabase/migrations/20250729150337_add_rhythm_mode_to_fantasy_stages.sql
+++ b/supabase/migrations/20250729150337_add_rhythm_mode_to_fantasy_stages.sql
@@ -1,0 +1,44 @@
+-- Add rhythm mode columns to fantasy_stages table
+ALTER TABLE fantasy_stages
+  ADD COLUMN game_type VARCHAR(10) DEFAULT 'quiz' CHECK (game_type IN ('quiz', 'rhythm')),
+  ADD COLUMN rhythm_pattern VARCHAR(20) CHECK (rhythm_pattern IN ('random', 'progression') OR rhythm_pattern IS NULL),
+  ADD COLUMN bpm INTEGER DEFAULT 120,
+  ADD COLUMN time_signature INTEGER DEFAULT 4 CHECK (time_signature IN (3, 4)),
+  ADD COLUMN loop_measures INTEGER DEFAULT 8,
+  ADD COLUMN chord_progression_data JSONB,
+  ADD COLUMN mp3_url VARCHAR(255) DEFAULT '/demo-1.mp3';
+
+-- Update existing data to set game_type as 'quiz'
+UPDATE fantasy_stages SET game_type = 'quiz' WHERE game_type IS NULL;
+
+-- Make game_type NOT NULL after setting defaults
+ALTER TABLE fantasy_stages ALTER COLUMN game_type SET NOT NULL;
+
+-- Add sample rhythm type stages
+INSERT INTO fantasy_stages (
+  stage_number, name, description, max_hp, enemy_count, enemy_hp,
+  min_damage, max_damage, enemy_gauge_seconds, mode, allowed_chords,
+  monster_icon, show_sheet_music, show_guide, game_type, rhythm_pattern,
+  bpm, time_signature, loop_measures, chord_progression_data
+) VALUES
+-- Rhythm type (random pattern)
+('R-1', 'リズムの洞窟', 'リズムに合わせてコードを演奏しよう！', 5, 10, 1,
+ 1, 1, 4.0, 'single', '["C", "G", "Am", "F"]'::jsonb,
+ 'fa-drum', true, true, 'rhythm', 'random', 120, 4, 8, NULL),
+
+-- Rhythm type (progression pattern)
+('R-2', 'ハーモニーの神殿', '定番進行をマスターしよう！', 5, 16, 1,
+ 1, 1, 4.0, 'progression', '["C", "G", "Am", "F"]'::jsonb,
+ 'fa-music', true, true, 'rhythm', 'progression', 120, 4, 8,
+ '{
+   "chords": [
+     {"chord": "C", "measure": 1, "beat": 1.0},
+     {"chord": "G", "measure": 2, "beat": 1.0},
+     {"chord": "Am", "measure": 3, "beat": 1.0},
+     {"chord": "F", "measure": 4, "beat": 1.0},
+     {"chord": "C", "measure": 5, "beat": 1.0},
+     {"chord": "Am", "measure": 6, "beat": 1.0},
+     {"chord": "Dm", "measure": 7, "beat": 1.0},
+     {"chord": "G", "measure": 8, "beat": 1.0}
+   ]
+ }'::jsonb);

--- a/tests/utils/ProgressionManager.test.ts
+++ b/tests/utils/ProgressionManager.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { ProgressionManager, ChordProgressionData } from '@/utils/ProgressionManager';
+
+describe('ProgressionManager', () => {
+  const sampleProgression: ChordProgressionData = {
+    chords: [
+      { chord: 'C', measure: 1, beat: 1 },
+      { chord: 'G', measure: 2, beat: 1 },
+      { chord: 'Am', measure: 3, beat: 1 },
+      { chord: 'F', measure: 4, beat: 1 },
+      { chord: 'C', measure: 5, beat: 1 },
+      { chord: 'Am', measure: 6, beat: 1 },
+      { chord: 'Dm', measure: 7, beat: 1 },
+      { chord: 'G', measure: 8, beat: 1 }
+    ]
+  };
+
+  describe('getInitialChords', () => {
+    it('returns first 4 chords for columns A-D', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      const initialChords = manager.getInitialChords();
+
+      expect(initialChords).toHaveLength(4);
+      expect(initialChords[0]).toEqual({
+        questionNumber: 1,
+        chord: 'C',
+        timing: { measure: 1, beat: 1, cycleNumber: 0 },
+        column: 'A'
+      });
+      expect(initialChords[1]).toEqual({
+        questionNumber: 2,
+        chord: 'G',
+        timing: { measure: 2, beat: 1, cycleNumber: 0 },
+        column: 'B'
+      });
+      expect(initialChords[2]).toEqual({
+        questionNumber: 3,
+        chord: 'Am',
+        timing: { measure: 3, beat: 1, cycleNumber: 0 },
+        column: 'C'
+      });
+      expect(initialChords[3]).toEqual({
+        questionNumber: 4,
+        chord: 'F',
+        timing: { measure: 4, beat: 1, cycleNumber: 0 },
+        column: 'D'
+      });
+    });
+  });
+
+  describe('getNextChordForColumn', () => {
+    it('follows the replenishment table correctly', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords(); // Initialize
+
+      // Defeat monster in column A (question 1)
+      const nextA = manager.getNextChordForColumn('A');
+      expect(nextA.questionNumber).toBe(5);
+      expect(nextA.chord).toBe('C'); // index 4
+      expect(nextA.column).toBe('A');
+
+      // Defeat monster in column B (question 2)
+      const nextB = manager.getNextChordForColumn('B');
+      expect(nextB.questionNumber).toBe(6);
+      expect(nextB.chord).toBe('Am'); // index 5
+      expect(nextB.column).toBe('B');
+
+      // Defeat monster in column C (question 3)
+      const nextC = manager.getNextChordForColumn('C');
+      expect(nextC.questionNumber).toBe(7);
+      expect(nextC.chord).toBe('Dm'); // index 6
+      expect(nextC.column).toBe('C');
+
+      // Defeat monster in column D (question 4)
+      const nextD = manager.getNextChordForColumn('D');
+      expect(nextD.questionNumber).toBe(8);
+      expect(nextD.chord).toBe('G'); // index 7
+      expect(nextD.column).toBe('D');
+    });
+
+    it('handles wraparound correctly when exceeding chord count', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords();
+
+      // Defeat all initial monsters
+      manager.getNextChordForColumn('A'); // 5
+      manager.getNextChordForColumn('B'); // 6
+      manager.getNextChordForColumn('C'); // 7
+      manager.getNextChordForColumn('D'); // 8
+
+      // Next set should wrap around
+      const next = manager.getNextChordForColumn('A');
+      expect(next.questionNumber).toBe(9);
+      expect(next.chord).toBe('C'); // index 0 (wraparound)
+      expect(next.timing.cycleNumber).toBe(1); // Second cycle
+    });
+
+    it('maintains correct column offsets in subsequent sets', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords();
+
+      // Skip some defeats to test offset calculation
+      manager.getNextChordForColumn('A'); // 5
+      manager.getNextChordForColumn('C'); // 7
+
+      // Now defeat B - should get question 10 (not 6)
+      const nextB = manager.getNextChordForColumn('B');
+      expect(nextB.questionNumber).toBe(10);
+      expect(nextB.chord).toBe('G'); // index 1 in second cycle
+    });
+  });
+
+  describe('timing calculations', () => {
+    it('calculates absolute measure correctly for wrapped chords', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords();
+
+      // Go through 8 chords to complete first cycle
+      for (let i = 0; i < 8; i++) {
+        manager.getNextChordForColumn(['A', 'B', 'C', 'D'][i % 4]);
+      }
+
+      // Next chord should be in cycle 1
+      const wrapped = manager.getNextChordForColumn('A');
+      expect(wrapped.timing.cycleNumber).toBe(1);
+      expect(wrapped.timing.measure).toBe(9); // 1 + 1 * 8
+    });
+  });
+
+  describe('state management', () => {
+    it('tracks answered count correctly', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords();
+
+      const initialState = manager.getState();
+      expect(initialState.answeredCount).toBe(0);
+
+      manager.getNextChordForColumn('A');
+      manager.getNextChordForColumn('B');
+
+      const updatedState = manager.getState();
+      expect(updatedState.answeredCount).toBe(2);
+    });
+
+    it('maintains column assignments correctly', () => {
+      const manager = new ProgressionManager(sampleProgression, 8);
+      manager.getInitialChords();
+
+      manager.getNextChordForColumn('A');
+      manager.getNextChordForColumn('C');
+
+      const state = manager.getState();
+      expect(state.columnAssignments.get('A')).toBe(5);
+      expect(state.columnAssignments.get('B')).toBe(2); // unchanged
+      expect(state.columnAssignments.get('C')).toBe(7);
+      expect(state.columnAssignments.get('D')).toBe(4); // unchanged
+    });
+  });
+});

--- a/tests/utils/RhythmManager.test.ts
+++ b/tests/utils/RhythmManager.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RhythmManager } from '@/utils/RhythmManager';
+
+describe('RhythmManager', () => {
+  let rhythmManager: RhythmManager;
+  let mockAudio: any;
+
+  beforeEach(() => {
+    // AudioオブジェクトのモックCommon用の型定義が必要です
+    mockAudio = {
+      currentTime: 0,
+      volume: 1,
+      loop: false,
+      play: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn(),
+    };
+
+    // globalのAudioをモック
+    global.Audio = vi.fn(() => mockAudio) as any;
+
+    rhythmManager = new RhythmManager({
+      audioUrl: '/demo-1.mp3',
+      bpm: 120,
+      timeSignature: 4,
+      loopMeasures: 8,
+      volume: 0.7
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getCurrentPosition', () => {
+    it('calculates beat and measure correctly at start', () => {
+      mockAudio.currentTime = 0;
+      const pos = rhythmManager.getCurrentPosition();
+      
+      expect(pos.measure).toBe(1);
+      expect(pos.beat).toBeCloseTo(1, 2);
+      expect(pos.absoluteBeat).toBe(0);
+    });
+
+    it('calculates beat and measure correctly after 1 beat (120 BPM = 0.5s per beat)', () => {
+      mockAudio.currentTime = 0.5;
+      const pos = rhythmManager.getCurrentPosition();
+      
+      expect(pos.measure).toBe(1);
+      expect(pos.beat).toBeCloseTo(2, 2);
+      expect(pos.absoluteBeat).toBe(1);
+    });
+
+    it('calculates measure correctly after 4 beats', () => {
+      mockAudio.currentTime = 2; // 4 beats at 120 BPM
+      const pos = rhythmManager.getCurrentPosition();
+      
+      expect(pos.measure).toBe(2);
+      expect(pos.beat).toBeCloseTo(1, 2);
+      expect(pos.absoluteBeat).toBe(4);
+    });
+  });
+
+  describe('getJudgmentWindow', () => {
+    it('returns correct judgment window for first beat', () => {
+      mockAudio.currentTime = 0;
+      const window = rhythmManager.getJudgmentWindow(1, 1);
+      
+      expect(window.start).toBe(-200);
+      expect(window.end).toBe(200);
+      expect(window.perfect).toBe(false); // currentTime is not close enough
+    });
+
+    it('returns correct judgment window for later beats', () => {
+      // BPM 120 = 500ms per beat
+      const window = rhythmManager.getJudgmentWindow(2, 3);
+      
+      // (1-1)*4 + (3-1) = 2 beats = 1000ms
+      const expectedTime = ((1 * 4) + 2) * 500;
+      expect(window.start).toBe(expectedTime - 200);
+      expect(window.end).toBe(expectedTime + 200);
+    });
+
+    it('detects perfect timing', () => {
+      mockAudio.currentTime = 0.5; // exactly 1 beat at 120 BPM
+      const window = rhythmManager.getJudgmentWindow(1, 2);
+      
+      expect(window.perfect).toBe(true);
+    });
+  });
+
+  describe('getTimeToNextBeat', () => {
+    it('calculates time to next beat correctly', () => {
+      mockAudio.currentTime = 0.3; // 300ms into first beat
+      const timeToNext = rhythmManager.getTimeToNextBeat();
+      
+      // At 120 BPM, beat duration is 0.5s
+      expect(timeToNext).toBeCloseTo(0.2, 2);
+    });
+
+    it('returns full beat duration at exact beat', () => {
+      mockAudio.currentTime = 0.5; // exactly on beat
+      const timeToNext = rhythmManager.getTimeToNextBeat();
+      
+      expect(timeToNext).toBeCloseTo(0.5, 2);
+    });
+  });
+
+  describe('audio control', () => {
+    it('starts audio playback', () => {
+      rhythmManager.start();
+      
+      expect(mockAudio.play).toHaveBeenCalled();
+      expect(mockAudio.currentTime).toBe(0);
+    });
+
+    it('starts audio playback with offset', () => {
+      rhythmManager.start(2.5);
+      
+      expect(mockAudio.play).toHaveBeenCalled();
+      expect(mockAudio.currentTime).toBe(2.5);
+    });
+
+    it('stops audio playback', () => {
+      rhythmManager.start();
+      rhythmManager.stop();
+      
+      expect(mockAudio.pause).toHaveBeenCalled();
+    });
+  });
+
+  describe('volume control', () => {
+    it('sets volume correctly', () => {
+      expect(mockAudio.volume).toBe(0.7);
+    });
+
+    it('uses default volume when not specified', () => {
+      const rm = new RhythmManager({
+        audioUrl: '/demo-1.mp3',
+        bpm: 120,
+        timeSignature: 4,
+        loopMeasures: 8
+      });
+      
+      expect(mockAudio.volume).toBe(0.7); // default
+    });
+  });
+});

--- a/tests/utils/SyncMonitor.test.ts
+++ b/tests/utils/SyncMonitor.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SyncMonitor } from '@/utils/SyncMonitor';
+
+describe('SyncMonitor', () => {
+  let syncMonitor: SyncMonitor;
+  const gameStartTime = 1000;
+  const musicStartTime = 1000;
+  
+  beforeEach(() => {
+    syncMonitor = new SyncMonitor(gameStartTime, musicStartTime);
+  });
+  
+  describe('checkSync', () => {
+    it('detects when in sync', () => {
+      // 音楽とゲームが同期している
+      const audioTime = 2.0; // 2秒経過
+      const gameTime = 3000; // 開始から2秒後
+      
+      const status = syncMonitor.checkSync(audioTime, gameTime, 120);
+      
+      expect(status.inSync).toBe(true);
+      expect(status.drift).toBe(0);
+      expect(status.correction).toBeUndefined();
+    });
+    
+    it('detects drift when out of sync', () => {
+      // 音楽が100ms遅れている
+      const audioTime = 1.9; // 1.9秒
+      const gameTime = 3000; // 2秒
+      
+      const status = syncMonitor.checkSync(audioTime, gameTime, 120);
+      
+      expect(status.inSync).toBe(false);
+      expect(status.drift).toBe(100);
+      expect(status.correction).toBe(-100); // ゲームを遅くする必要
+    });
+    
+    it('allows small drift within tolerance', () => {
+      // 30msのズレ（許容範囲内）
+      const audioTime = 2.03;
+      const gameTime = 3000;
+      
+      const status = syncMonitor.checkSync(audioTime, gameTime, 120);
+      
+      expect(status.inSync).toBe(true);
+      expect(status.drift).toBe(30);
+    });
+  });
+  
+  describe('autoCorrect', () => {
+    it('applies smooth correction', () => {
+      const currentOffset = 0;
+      const correction = 100;
+      
+      const newOffset = syncMonitor.autoCorrect(currentOffset, correction);
+      
+      expect(newOffset).toBe(10); // 100 * 0.1
+    });
+    
+    it('applies custom smooth factor', () => {
+      const currentOffset = 50;
+      const correction = 200;
+      
+      const newOffset = syncMonitor.autoCorrect(currentOffset, correction, 0.25);
+      
+      expect(newOffset).toBe(100); // 50 + (200 * 0.25)
+    });
+  });
+  
+  describe('shouldCheckSync', () => {
+    it('returns true after interval', () => {
+      const firstTime = 5000;
+      const secondTime = 6100; // 1.1秒後
+      
+      expect(syncMonitor.shouldCheckSync(firstTime)).toBe(true);
+      expect(syncMonitor.shouldCheckSync(secondTime)).toBe(true);
+    });
+    
+    it('returns false within interval', () => {
+      const firstTime = 5000;
+      const secondTime = 5500; // 0.5秒後
+      
+      expect(syncMonitor.shouldCheckSync(firstTime)).toBe(true);
+      expect(syncMonitor.shouldCheckSync(secondTime)).toBe(false);
+    });
+  });
+  
+  describe('getDebugInfo', () => {
+    it('provides correct debug information', () => {
+      const audioTime = 2.5; // 2.5秒
+      const gameTime = 3400; // 開始から2.4秒
+      
+      const debugInfo = syncMonitor.getDebugInfo(audioTime, gameTime);
+      
+      expect(debugInfo.musicTime).toBe(2500);
+      expect(debugInfo.gameTime).toBe(2400);
+      expect(debugInfo.drift).toBe(100);
+      expect(debugInfo.status).toBe('DRIFT');
+    });
+    
+    it('shows SYNC status when within tolerance', () => {
+      const audioTime = 2.0;
+      const gameTime = 3020; // 20msのズレ
+      
+      const debugInfo = syncMonitor.getDebugInfo(audioTime, gameTime);
+      
+      expect(debugInfo.drift).toBe(20);
+      expect(debugInfo.status).toBe('SYNC');
+    });
+  });
+});


### PR DESCRIPTION
Fix attack gauge not moving in rhythm mode by synchronizing game timing with audio.

The attack gauge was not progressing due to timing discrepancies between `performance.now()` and audio playback. This PR establishes `rhythmStore` as the single source of truth for game time, ensuring the gauge updates correctly based on audio time. It also addresses a timing race by setting `startAt` earlier during the Ready phase.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f43be55-af66-4183-8e32-ef52084911b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f43be55-af66-4183-8e32-ef52084911b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>