### PR TITLE
Add rhythm mode based on documentation

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -8,9 +8,15 @@ import { devLog } from '@/utils/logger';
 import { resolveChord } from '@/utils/chord-utils';
 import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';
 import { useGlobalTimeStore } from '@/stores/globalTimeStore';
-import { useEnemyStore } from '@/stores/enemyStore';
-import { MONSTERS, getStageMonsterIds } from '@/data/monsters';
-import * as PIXI from 'pixi.js';
+import * as Tone from 'tone';
+import FantasySoundManager from '@/utils/FantasySoundManager';
+
+// Rhythm entry type (measure is 1-based, beat may be fractional)
+type RhythmEntry = {
+  chord: string;
+  measure: number;
+  beat: number;
+};
 
 // ===== 型定義 =====
 
@@ -95,6 +101,10 @@ interface FantasyGameState {
   simultaneousMonsterCount: number; // 同時表示数
   // ゲーム完了処理中フラグ
   isCompleting: boolean;
+  /* ===== Rhythm ===== */
+  currentTime: number;
+  isPlaying: boolean;
+  rhythmData: RhythmEntry[];
 }
 
 interface FantasyGameEngineProps {
@@ -416,10 +426,63 @@ export const useFantasyGameEngine = ({
     monsterQueue: [],
     simultaneousMonsterCount: 1,
     // ゲーム完了処理中フラグ
-    isCompleting: false
+    isCompleting: false,
+    currentTime: 0,
+    isPlaying: false,
+    rhythmData: []
   });
   
   const [enemyGaugeTimer, setEnemyGaugeTimer] = useState<NodeJS.Timeout | null>(null);
+
+  // ===== Rhythm helpers =====
+  const loadRhythmData = useCallback(async (path?: string): Promise<RhythmEntry[]> => {
+    if (!path) return [];
+    try {
+      const res = await fetch(path);
+      if (!res.ok) throw new Error(`Failed to load rhythm data: ${res.status}`);
+      const json = await res.json();
+      return Array.isArray(json) ? (json as RhythmEntry[]) : [];
+    } catch (err) {
+      console.error('[Rhythm] loadRhythmData error', err);
+      return [];
+    }
+  }, []);
+
+  const initializeMusic = useCallback(async (mp3Url?: string, bpm?: number, timeSig?: number, loopMeasures?: number) => {
+    if (!mp3Url) return;
+    try {
+      await Tone.start();
+      const player = new Tone.Player(mp3Url).toDestination();
+      // BPM / Time Signature
+      Tone.Transport.bpm.value = bpm || 120;
+      if (timeSig) {
+        Tone.Transport.timeSignature = timeSig;
+      }
+      player.sync().start(0);
+      if (loopMeasures && loopMeasures > 0) {
+        const beatsPerMeasure = timeSig || 4;
+        const loopEnd = `${loopMeasures}m`;
+        Tone.Transport.loop = true;
+        Tone.Transport.loopStart = 0;
+        Tone.Transport.loopEnd = loopEnd;
+      } else {
+        Tone.Transport.loop = false;
+      }
+      Tone.Transport.start();
+
+      // Update global time every animation frame
+      const update = () => {
+        globalTime.setCurrentTime(Tone.Transport.seconds * 1000);
+        if (Tone.Transport.state === 'started') {
+          rafId = requestAnimationFrame(update);
+        }
+      };
+      let rafId = requestAnimationFrame(update);
+      globalTime.setIsPlaying(true);
+    } catch (e) {
+      console.error('[Rhythm] initializeMusic error', e);
+    }
+  }, [globalTime]);
   
   // ゲーム初期化
   const initializeGame = useCallback(async (stage: FantasyStage) => {
@@ -430,6 +493,8 @@ export const useFantasyGameEngine = ({
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
     const simultaneousCount = stage.simultaneousMonsterCount || 1;
+
+    const isRhythmMode = stage.game_type === 'rhythm';
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -543,7 +608,12 @@ export const useFantasyGameEngine = ({
       isCompleting: false
     };
 
-    setGameState(newState);
+    setGameState({
+      ...newState,
+      rhythmData: loadedRhythmData,
+      isPlaying: isRhythmMode,
+      currentTime: 0
+    });
     onGameStateChange(newState);
 
     devLog.debug('✅ ゲーム初期化完了:', {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -305,6 +305,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     onChordIncorrect: handleChordIncorrect,
     onGameComplete: handleGameCompleteCallback,
     onEnemyAttack: handleEnemyAttack,
+    onTimingSuccess: () => {},
+    onTimingFailure: () => {},
     displayOpts: { lang: 'en', simple: false } // コードネーム表示は常に英語、簡易表記OFF
   });
   

--- a/src/stores/globalTimeStore.ts
+++ b/src/stores/globalTimeStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+/**
+ * グローバルタイムストア
+ * Rhythm モードおよび Quiz モード共通で音楽再生のタイムラインを管理する。
+ * 単位はミリ秒で扱い、必要に応じて呼び出し側で秒変換してください。
+ */
+export type GlobalTimeState = {
+  /** 現在までの累積再生時間 (ms) */
+  currentTime: number;
+  /** トランスポートが再生中か */
+  isPlaying: boolean;
+  /** ループ開始時間 (ms)。ループしない場合は 0 */
+  loopStartTime: number;
+  /** タイムラインを更新 */
+  setCurrentTime: (timeMs: number) => void;
+  /** 再生/停止を更新 */
+  setIsPlaying: (playing: boolean) => void;
+  /** ループ開始位置を更新 */
+  setLoopStart: (timeMs: number) => void;
+  /** 全ての値をリセット */
+  reset: () => void;
+};
+
+export const useGlobalTimeStore = create<GlobalTimeState>(set => ({
+  currentTime: 0,
+  isPlaying: false,
+  loopStartTime: 0,
+  setCurrentTime: (timeMs: number) => set({ currentTime: timeMs }),
+  setIsPlaying: (playing: boolean) => set({ isPlaying: playing }),
+  setLoopStart: (timeMs: number) => set({ loopStartTime: timeMs }),
+  reset: () => set({ currentTime: 0, isPlaying: false, loopStartTime: 0 })
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -641,6 +641,21 @@ export interface FantasyStage {
   show_guide: boolean;
   simultaneous_monster_count?: number;
   monster_icon?: string;
+  // ===== リズムタイプ関連フィールド =====
+  /** ゲームタイプ: quiz | rhythm */
+  game_type?: 'quiz' | 'rhythm';
+  /** リズムタイプ時のパターン: random | progression */
+  rhythm_pattern?: 'random' | 'progression';
+  /** テンポ (BPM) */
+  bpm?: number;
+  /** 拍子 (3 または 4) */
+  time_signature?: number;
+  /** ループ開始小節 (例: 8) */
+  loop_measures?: number;
+  /** MP3ファイル URL */
+  mp3_url?: string;
+  /** リズムデータ(JSON)へのパス */
+  rhythm_data?: string;
 }
 
 export interface LessonContext {


### PR DESCRIPTION
Add foundational elements for Rhythm Mode, including stage extensions and global time management.

This PR lays the groundwork for the new Rhythm Mode by extending the `FantasyStage` interface with rhythm-specific fields and introducing a global time store for synchronized music playback. It also prepares the `FantasyGameEngine` for rhythm-based timing callbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7140b27-97a9-4375-8a0a-b7bcc31db767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7140b27-97a9-4375-8a0a-b7bcc31db767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>