### PR TITLE
Fix monster image preload error and ensure code quality

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,42 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.+(ts|tsx|js)',
+    '**/?(*.)+(spec|test).+(ts|tsx|js)'
+  ],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
+      tsconfig: {
+        jsx: 'react-jsx',
+      }
+    }]
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '\\.(jpg|jpeg|png|gif|webp|svg|mp3|mp4|wav|ogg)$': '<rootDir>/__mocks__/fileMock.js'
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/*.stories.{ts,tsx}',
+    '!src/**/__tests__/**'
+  ],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/',
+    '/public/'
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  globals: {
+    'import.meta': {
+      env: {
+        BASE_URL: '/'
+      }
+    }
+  }
+};

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -423,8 +423,11 @@ export const useFantasyGameEngine = ({
     // モンスター画像をプリロード
     try {
       // バンドルが既に存在する場合は削除
-      if (PIXI.Assets.resolver.bundles.has('stageMonsters')) {
+      // PIXI v7では unloadBundle が失敗しても問題ないため、try-catchで保護
+      try {
         await PIXI.Assets.unloadBundle('stageMonsters');
+      } catch {
+        // バンドルが存在しない場合は無視
       }
 
       // バンドル用のアセットマッピングを作成

--- a/src/components/fantasy/__tests__/FantasyGameEngine.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyGameEngine.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as PIXI from 'pixi.js';
+import FantasyGameEngine from '../FantasyGameEngine';
+import { getStageMonsterIds } from '@/data/monsters';
+
+// Mock PIXI.js
+vi.mock('pixi.js', () => ({
+  Assets: {
+    unloadBundle: vi.fn(),
+    addBundle: vi.fn(),
+    loadBundle: vi.fn(),
+    get: vi.fn(),
+    resolver: undefined, // Simulate the case where resolver is undefined
+  },
+  Texture: vi.fn(),
+}));
+
+// Mock monster data
+vi.mock('@/data/monsters', () => ({
+  getStageMonsterIds: vi.fn(() => ['monster_01', 'monster_02', 'monster_03']),
+  MONSTERS: {},
+}));
+
+// Mock devLog
+vi.mock('@/utils/logger', () => ({
+  devLog: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe('FantasyGameEngine - Monster Image Preloading', () => {
+  const mockStage = {
+    id: 'test-stage',
+    stageNumber: '1-1',
+    name: 'Test Stage',
+    description: 'Test Description',
+    maxHp: 100,
+    enemyGaugeSeconds: 10,
+    enemyCount: 3,
+    enemyHp: 50,
+    minDamage: 10,
+    maxDamage: 20,
+    mode: 'single' as const,
+    allowedChords: ['C', 'G', 'Am'],
+    showSheetMusic: true,
+    showGuide: true,
+    monsterIcon: 'dragon',
+    simultaneousMonsterCount: 1,
+  };
+
+  const mockCallbacks = {
+    onGameEnd: vi.fn(),
+    onChordCorrect: vi.fn(),
+    onChordIncorrect: vi.fn(),
+    onPlayerDamage: vi.fn(),
+    onEnemyDeath: vi.fn(),
+    onEnemyAttack: vi.fn(),
+    onKeyPress: vi.fn(),
+    onKeyRelease: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset PIXI mocks
+    (PIXI.Assets.unloadBundle as any).mockResolvedValue(undefined);
+    (PIXI.Assets.addBundle as any).mockReturnValue(undefined);
+    (PIXI.Assets.loadBundle as any).mockResolvedValue(undefined);
+    (PIXI.Assets.get as any).mockReturnValue({ texture: 'mock-texture' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle monster image preloading when PIXI.Assets.resolver is undefined', async () => {
+    const { container } = render(
+      <FantasyGameEngine
+        stage={mockStage}
+        currentSongId="test-song"
+        onGameEnd={mockCallbacks.onGameEnd}
+        onChordCorrect={mockCallbacks.onChordCorrect}
+        onChordIncorrect={mockCallbacks.onChordIncorrect}
+        onPlayerDamage={mockCallbacks.onPlayerDamage}
+        onEnemyDeath={mockCallbacks.onEnemyDeath}
+        onEnemyAttack={mockCallbacks.onEnemyAttack}
+        onKeyPress={mockCallbacks.onKeyPress}
+        onKeyRelease={mockCallbacks.onKeyRelease}
+      />
+    );
+
+    // Wait for component to initialize
+    await waitFor(() => {
+      expect(getStageMonsterIds).toHaveBeenCalledWith(mockStage.enemyCount);
+    });
+
+    // Verify that unloadBundle is called (but doesn't crash even if resolver is undefined)
+    expect(PIXI.Assets.unloadBundle).toHaveBeenCalledWith('stageMonsters');
+
+    // Verify that addBundle and loadBundle are called with correct parameters
+    expect(PIXI.Assets.addBundle).toHaveBeenCalledWith('stageMonsters', {
+      'monster_01': expect.stringContaining('monster_icons/monster_01.png'),
+      'monster_02': expect.stringContaining('monster_icons/monster_02.png'),
+      'monster_03': expect.stringContaining('monster_icons/monster_03.png'),
+    });
+
+    expect(PIXI.Assets.loadBundle).toHaveBeenCalledWith('stageMonsters');
+
+    // Verify that textures are retrieved
+    expect(PIXI.Assets.get).toHaveBeenCalledWith('monster_01');
+    expect(PIXI.Assets.get).toHaveBeenCalledWith('monster_02');
+    expect(PIXI.Assets.get).toHaveBeenCalledWith('monster_03');
+
+    expect(container).toBeTruthy();
+  });
+
+  it('should handle errors gracefully when unloadBundle fails', async () => {
+    // Mock unloadBundle to throw an error
+    (PIXI.Assets.unloadBundle as any).mockRejectedValue(new Error('Bundle not found'));
+
+    const { container } = render(
+      <FantasyGameEngine
+        stage={mockStage}
+        currentSongId="test-song"
+        onGameEnd={mockCallbacks.onGameEnd}
+        onChordCorrect={mockCallbacks.onChordCorrect}
+        onChordIncorrect={mockCallbacks.onChordIncorrect}
+        onPlayerDamage={mockCallbacks.onPlayerDamage}
+        onEnemyDeath={mockCallbacks.onEnemyDeath}
+        onEnemyAttack={mockCallbacks.onEnemyAttack}
+        onKeyPress={mockCallbacks.onKeyPress}
+        onKeyRelease={mockCallbacks.onKeyRelease}
+      />
+    );
+
+    await waitFor(() => {
+      expect(PIXI.Assets.unloadBundle).toHaveBeenCalledWith('stageMonsters');
+    });
+
+    // Verify that the component still continues to load even after unloadBundle fails
+    expect(PIXI.Assets.addBundle).toHaveBeenCalled();
+    expect(PIXI.Assets.loadBundle).toHaveBeenCalled();
+
+    expect(container).toBeTruthy();
+  });
+
+  it('should handle complete failure of monster image loading', async () => {
+    // Mock loadBundle to throw an error
+    (PIXI.Assets.loadBundle as any).mockRejectedValue(new Error('Network error'));
+
+    const { container } = render(
+      <FantasyGameEngine
+        stage={mockStage}
+        currentSongId="test-song"
+        onGameEnd={mockCallbacks.onGameEnd}
+        onChordCorrect={mockCallbacks.onChordCorrect}
+        onChordIncorrect={mockCallbacks.onChordIncorrect}
+        onPlayerDamage={mockCallbacks.onPlayerDamage}
+        onEnemyDeath={mockCallbacks.onEnemyDeath}
+        onEnemyAttack={mockCallbacks.onEnemyAttack}
+        onKeyPress={mockCallbacks.onKeyPress}
+        onKeyRelease={mockCallbacks.onKeyRelease}
+      />
+    );
+
+    await waitFor(() => {
+      expect(PIXI.Assets.loadBundle).toHaveBeenCalledWith('stageMonsters');
+    });
+
+    // Component should still render even if image loading fails
+    expect(container).toBeTruthy();
+  });
+});

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -244,6 +244,7 @@ export class PIXINotesRendererInstance {
   private effectsContainer!: PIXI.Container;
   private hitLineContainer!: PIXI.Container;
   private pianoContainer!: PIXI.Container;
+  private particles!: PIXI.Container; // パーティクル用コンテナ
   
   private noteSprites: Map<string, NoteSprite> = new Map();
 
@@ -2898,7 +2899,7 @@ export class PIXINotesRendererInstance {
     log.info('🎹 handleKeyPress called', { 
       midiNote, 
       hasOnKeyPress: !!this.onKeyPress,
-      destroyed: this.destroyed
+      destroyed: this.isDestroyed
     });
     
     // アクティブキープレス状態に追加

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,25 @@
+// Setup file for tests
+import '@testing-library/jest-dom';
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock IntersectionObserver
+global.IntersectionObserver = class IntersectionObserver {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+};

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -518,7 +518,7 @@ export const useAuthStore = create<AuthState & AuthActions>()(
 
         if (data.session) {
           set(state => {
-            state.user = data.session.user;
+            state.user = data.session!.user;
             state.loading = false;
             state.error = null;
           });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true,
+    reporters: ['verbose'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/setupTests.ts',
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  define: {
+    'import.meta.env.BASE_URL': JSON.stringify('/'),
+  },
+});


### PR DESCRIPTION
Fixes monster image preloading error by gracefully handling undefined PIXI.Assets.resolver.bundles and resolves related TypeScript issues.

The `TypeError: Cannot read properties of undefined (reading 'has')` occurred when `PIXI.Assets.resolver.bundles` was accessed before being fully initialized or if the bundle didn't exist. The fix wraps the `unloadBundle` call in a try-catch block to prevent crashes. Additionally, missing class properties, incorrect property names, and potential null issues were addressed to ensure type safety and CI compliance.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4c61dd5-7efd-4f25-9bac-c9b553352c79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4c61dd5-7efd-4f25-9bac-c9b553352c79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>