### PR TITLE
Fix lessons page reference error

### DIFF
--- a/src/components/lesson/LessonPage.tsx
+++ b/src/components/lesson/LessonPage.tsx
@@ -60,12 +60,6 @@ const LessonPage: React.FC = () => {
   }, [open, profile, selectedCourse]);
 
   useEffect(() => {
-    if (open && profile) {
-      loadData();
-    }
-  }, [open, profile, loadData]);
-
-  useEffect(() => {
     if (selectedCourse) {
       loadLessons(selectedCourse.id);
     }
@@ -183,6 +177,12 @@ const LessonPage: React.FC = () => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (open && profile) {
+      loadData();
+    }
+  }, [open, profile]);
 
   const loadLessons = async (courseId: string) => {
     try {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Relocate `useEffect` hook to ensure `loadData` is defined before use.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `ReferenceError: Cannot access 'N' before initialization` occurred because the `loadData` function, defined with `const`, was referenced in a `useEffect` dependency array before its declaration. Moving the `useEffect` hook that calls `loadData` to after its definition resolves this error on the lessons page.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba4001b5-8863-4925-b8c3-0500cb50be3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba4001b5-8863-4925-b8c3-0500cb50be3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>