### PR TITLE
Add rhythm mode with judgment window

### DIFF
--- a/src/components/fantasy/FantasyRhythmEngine.tsx
+++ b/src/components/fantasy/FantasyRhythmEngine.tsx
@@ -1,0 +1,291 @@
+/**
+ * ファンタジーリズムエンジン
+ * リズムモード専用のゲームロジックとタイミング判定を担当
+ */
+
+import React, { useCallback, useEffect, useMemo, useState, forwardRef, useImperativeHandle } from 'react';
+import { useTimeStore } from '@/stores/timeStore';
+import { devLog } from '@/utils/logger';
+
+// 判定ウィンドウの定数
+const JUDGMENT_WINDOW_MS = 200; // 前後200ms
+
+export interface RhythmJudgment {
+  targetTime: number;  // 判定タイミング（ms）
+  chordId: string;     // 判定対象のコード
+  judged: boolean;     // 判定済みフラグ
+  result: 'perfect' | 'good' | 'miss' | null;  // 判定結果
+  position: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H';  // 列位置（最大8体対応）
+}
+
+export interface RhythmChordSchedule {
+  chordId: string;
+  measure: number;
+  beat: number;
+  targetTime: number;  // 演奏タイミング（ms）
+  position: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H';  // 列位置（最大8体対応）
+}
+
+interface RhythmEngineProps {
+  isActive: boolean;
+  bpm: number;
+  timeSignature: number;
+  measureCount: number;
+  countInMeasures: number;
+  chordProgressionData?: {
+    chords: Array<{
+      measure: number;
+      beat: number;
+      chord: string;
+    }>;
+  } | null;
+  allowedChords: string[];
+  simultaneousMonsterCount: number;
+  onJudgment: (judgment: RhythmJudgment) => void;
+  onChordSchedule: (schedule: RhythmChordSchedule[]) => void;
+}
+
+export const FantasyRhythmEngine = forwardRef<
+  { judge: (chordId: string, inputTime: number) => RhythmJudgment | null },
+  RhythmEngineProps
+>(({
+  isActive,
+  bpm,
+  timeSignature,
+  measureCount,
+  countInMeasures,
+  chordProgressionData,
+  allowedChords,
+  simultaneousMonsterCount,
+  onJudgment,
+  onChordSchedule
+}, ref) => {
+  const { currentMeasure, currentBeat, isCountIn, startAt, readyDuration } = useTimeStore();
+  const [activeJudgments, setActiveJudgments] = useState<RhythmJudgment[]>([]);
+  const [chordSchedule, setChordSchedule] = useState<RhythmChordSchedule[]>([]);
+  const [currentChordIndex, setCurrentChordIndex] = useState(0);
+
+  // 拍子に基づいて使用する列位置を決定
+  const positions = useMemo(() => {
+    const allPositions: ('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H')[] = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+    // 拍子数か同時出現数の小さい方を使用（最大8）
+    const columnCount = Math.min(timeSignature, simultaneousMonsterCount, 8);
+    return allPositions.slice(0, columnCount);
+  }, [timeSignature, simultaneousMonsterCount]);
+
+  // BPMから各種時間を計算
+  const msPerBeat = useMemo(() => 60000 / bpm, [bpm]);
+  const msPerMeasure = useMemo(() => msPerBeat * timeSignature, [msPerBeat, timeSignature]);
+
+  // 現在時刻を取得
+  const getCurrentGameTime = useCallback(() => {
+    if (!startAt) return 0;
+    return performance.now() - startAt - readyDuration;
+  }, [startAt, readyDuration]);
+
+  // コード進行パターンの場合のスケジュール生成
+  const generateProgressionSchedule = useCallback(() => {
+    if (!chordProgressionData?.chords || chordProgressionData.chords.length === 0) {
+      return [];
+    }
+
+    const schedule: RhythmChordSchedule[] = [];
+    const chords = chordProgressionData.chords;
+    
+    // 無限ループのため、先読みで十分な量のスケジュールを生成
+    const currentTime = getCurrentGameTime();
+    const lookAheadTime = currentTime + 10000; // 10秒先まで生成
+    
+    let loopCount = 0;
+    while (true) {
+      for (let i = 0; i < chords.length; i++) {
+        const chord = chords[i];
+        const actualMeasure = loopCount * measureCount + chord.measure;
+        
+        // カウントイン後の時間を計算
+        const measureTime = (actualMeasure - 1 + countInMeasures) * msPerMeasure;
+        const beatTime = (chord.beat - 1) * msPerBeat;
+        const targetTime = measureTime + beatTime;
+        
+        if (targetTime > lookAheadTime) {
+          return schedule;
+        }
+        
+        // 既に過ぎた時間はスキップ
+        if (targetTime < currentTime - 1000) {
+          continue;
+        }
+        
+        schedule.push({
+          chordId: chord.chord,
+          measure: actualMeasure,
+          beat: chord.beat,
+          targetTime,
+          position: positions[i % positions.length]
+        });
+      }
+      loopCount++;
+    }
+  }, [chordProgressionData, getCurrentGameTime, measureCount, countInMeasures, msPerMeasure, msPerBeat, positions]);
+
+  // ランダムパターンの場合のスケジュール生成
+  const generateRandomSchedule = useCallback(() => {
+    const schedule: RhythmChordSchedule[] = [];
+    const currentTime = getCurrentGameTime();
+    const lookAheadTime = currentTime + 10000; // 10秒先まで生成
+    
+    // カウントイン後から開始
+    const startMeasure = isCountIn ? currentMeasure : Math.max(1, currentMeasure);
+    
+    for (let m = startMeasure; m <= measureCount + 10; m++) {
+      // 各小節の1拍目にコードを配置
+      const actualMeasure = ((m - 1) % measureCount) + 1;
+      const measureTime = (m - 1 + countInMeasures) * msPerMeasure;
+      
+      if (measureTime > lookAheadTime) {
+        break;
+      }
+      
+      if (measureTime < currentTime - 1000) {
+        continue;
+      }
+      
+      // ランダムにコードを選択
+      const chordId = allowedChords[Math.floor(Math.random() * allowedChords.length)];
+      
+      schedule.push({
+        chordId,
+        measure: actualMeasure,
+        beat: 1,
+        targetTime: measureTime,
+        position: 'A' // ランダムパターンでは1体のみなので常にA列
+      });
+    }
+    
+    return schedule;
+  }, [getCurrentGameTime, isCountIn, currentMeasure, measureCount, countInMeasures, msPerMeasure, allowedChords]);
+
+  // スケジュールの更新
+  useEffect(() => {
+    if (!isActive || !startAt) return;
+    
+    const newSchedule = chordProgressionData 
+      ? generateProgressionSchedule()
+      : generateRandomSchedule();
+    
+    setChordSchedule(newSchedule);
+    onChordSchedule(newSchedule);
+  }, [isActive, startAt, currentMeasure, chordProgressionData, generateProgressionSchedule, generateRandomSchedule, onChordSchedule]);
+
+  // 判定ウィンドウのチェック
+  useEffect(() => {
+    if (!isActive || !startAt) return;
+    
+    const checkJudgmentWindow = () => {
+      const currentTime = getCurrentGameTime();
+      
+      // アクティブな判定を更新
+      const newActiveJudgments: RhythmJudgment[] = [];
+      
+      chordSchedule.forEach(schedule => {
+        const timeDiff = Math.abs(currentTime - schedule.targetTime);
+        
+        // 判定ウィンドウ内かチェック
+        if (timeDiff <= JUDGMENT_WINDOW_MS) {
+          // 既存の判定を探す
+          const existingJudgment = activeJudgments.find(
+            j => j.chordId === schedule.chordId && j.targetTime === schedule.targetTime
+          );
+          
+          if (!existingJudgment) {
+            // 新しい判定を作成
+            const judgment: RhythmJudgment = {
+              targetTime: schedule.targetTime,
+              chordId: schedule.chordId,
+              judged: false,
+              result: null,
+              position: schedule.position
+            };
+            newActiveJudgments.push(judgment);
+            onJudgment(judgment);
+          } else {
+            newActiveJudgments.push(existingJudgment);
+          }
+        }
+        
+        // 判定ウィンドウを過ぎた未判定のものはミス判定
+        if (currentTime > schedule.targetTime + JUDGMENT_WINDOW_MS) {
+          const existingJudgment = activeJudgments.find(
+            j => j.chordId === schedule.chordId && j.targetTime === schedule.targetTime && !j.judged
+          );
+          
+          if (existingJudgment) {
+            existingJudgment.judged = true;
+            existingJudgment.result = 'miss';
+            onJudgment(existingJudgment);
+          }
+        }
+      });
+      
+      setActiveJudgments(newActiveJudgments);
+    };
+    
+    const interval = setInterval(checkJudgmentWindow, 16); // 60FPS
+    
+    return () => clearInterval(interval);
+  }, [isActive, startAt, chordSchedule, activeJudgments, getCurrentGameTime, onJudgment]);
+
+  // 判定処理（外部から呼び出される）
+  const judge = useCallback((chordId: string, inputTime: number) => {
+    const judgment = activeJudgments.find(j => j.chordId === chordId && !j.judged);
+    
+    if (!judgment) {
+      devLog.debug('No active judgment found for chord:', chordId);
+      return null;
+    }
+    
+    const timeDiff = Math.abs(inputTime - judgment.targetTime);
+    
+    if (timeDiff <= JUDGMENT_WINDOW_MS) {
+      judgment.judged = true;
+      judgment.result = timeDiff <= 50 ? 'perfect' : 'good';
+      onJudgment(judgment);
+      return judgment;
+    }
+    
+    return null;
+  }, [activeJudgments, onJudgment]);
+
+  // refを通じてjudgeメソッドを公開
+  useImperativeHandle(ref, () => ({
+    judge
+  }), [judge]);
+
+  // デバッグ情報
+  useEffect(() => {
+    if (!isActive) return;
+    
+    const debugInterval = setInterval(() => {
+      devLog.debug('Rhythm Engine State:', {
+        currentMeasure,
+        currentBeat,
+        isCountIn,
+        activeJudgments: activeJudgments.length,
+        upcomingChords: chordSchedule.filter(s => s.targetTime > getCurrentGameTime()).length
+      });
+    }, 1000);
+    
+    return () => clearInterval(debugInterval);
+  }, [isActive, currentMeasure, currentBeat, isCountIn, activeJudgments, chordSchedule, getCurrentGameTime]);
+
+  return null;
+});
+
+// 判定関数をエクスポート
+export const useRhythmJudge = (rhythmEngine: React.RefObject<{ judge: (chordId: string, inputTime: number) => RhythmJudgment | null }>) => {
+  return useCallback((chordId: string) => {
+    if (!rhythmEngine.current) return null;
+    const inputTime = performance.now();
+    return rhythmEngine.current.judge(chordId, inputTime);
+  }, [rhythmEngine]);
+};

--- a/src/components/fantasy/FantasyRhythmGauge.tsx
+++ b/src/components/fantasy/FantasyRhythmGauge.tsx
@@ -1,0 +1,78 @@
+/**
+ * ファンタジーリズムゲージ
+ * リズムモードのタイミング表示UI
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { cn } from '@/utils/cn';
+import { useTimeStore } from '@/stores/timeStore';
+import { RhythmChordSchedule } from './FantasyRhythmEngine';
+
+interface FantasyRhythmGaugeProps {
+  schedule: RhythmChordSchedule[];
+  currentTime: number;
+  position: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H';
+  chordId: string;
+}
+
+export const FantasyRhythmGauge: React.FC<FantasyRhythmGaugeProps> = ({
+  schedule,
+  currentTime,
+  position,
+  chordId
+}) => {
+  const [gaugeProgress, setGaugeProgress] = useState(0);
+  const { startAt, readyDuration } = useTimeStore();
+
+  // 現在のスケジュール項目を見つける
+  const currentScheduleItem = useMemo(() => {
+    return schedule.find(item => 
+      item.position === position && 
+      item.chordId === chordId &&
+      item.targetTime > currentTime - 1000 // 1秒前まで
+    );
+  }, [schedule, position, chordId, currentTime]);
+
+  // ゲージの進行を計算
+  useEffect(() => {
+    if (!currentScheduleItem || !startAt) {
+      setGaugeProgress(0);
+      return;
+    }
+
+    const updateGauge = () => {
+      const now = performance.now() - startAt - readyDuration;
+      const timeUntilTarget = currentScheduleItem.targetTime - now;
+      
+      // 1秒前から0%、ターゲットタイムで80%になるように計算
+      const progress = Math.max(0, Math.min(80, (1000 - timeUntilTarget) / 1000 * 80));
+      setGaugeProgress(progress);
+    };
+
+    const interval = setInterval(updateGauge, 16); // 60fps
+    updateGauge(); // 初回実行
+
+    return () => clearInterval(interval);
+  }, [currentScheduleItem, startAt, readyDuration]);
+
+  // スケジュールがない場合は非表示
+  if (!currentScheduleItem) {
+    return null;
+  }
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 h-1 bg-gray-700">
+      {/* 80%地点のマーカー */}
+      <div className="absolute left-[80%] top-0 bottom-0 w-0.5 bg-yellow-400 z-10" />
+      
+      {/* 進行ゲージ */}
+      <div 
+        className={cn(
+          "h-full transition-all duration-100",
+          gaugeProgress >= 70 && gaugeProgress <= 90 ? "bg-green-400" : "bg-blue-400"
+        )}
+        style={{ width: `${gaugeProgress}%` }}
+      />
+    </div>
+  );
+};

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -299,6 +299,18 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモード表示 */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-xs bg-purple-500 text-white px-2 py-1 rounded">
+                リズムモード
+              </span>
+              <span className="text-xs bg-blue-500 text-white px-2 py-1 rounded">
+                {stage.chordProgressionData ? 'コード進行' : 'ランダム'}
+              </span>
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/components/fantasy/__tests__/FantasyRhythmEngine.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyRhythmEngine.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FantasyRhythmEngine } from '../FantasyRhythmEngine';
+
+// Mock the timeStore
+jest.mock('@/stores/timeStore', () => ({
+  useTimeStore: () => ({
+    currentMeasure: 1,
+    currentBeat: 1,
+    isCountIn: false,
+    startAt: performance.now(),
+    readyDuration: 2000
+  })
+}));
+
+// Mock devLog to avoid console spam during tests
+jest.mock('@/utils/logger', () => ({
+  devLog: {
+    debug: jest.fn()
+  }
+}));
+
+describe('FantasyRhythmEngine', () => {
+  const defaultProps = {
+    isActive: true,
+    bpm: 120,
+    timeSignature: 4,
+    measureCount: 8,
+    countInMeasures: 1,
+    chordProgressionData: null,
+    allowedChords: ['C', 'G', 'Am', 'F'],
+    simultaneousMonsterCount: 1,
+    onJudgment: jest.fn(),
+    onChordSchedule: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { container } = render(<FantasyRhythmEngine {...defaultProps} />);
+    expect(container).toBeTruthy();
+  });
+
+  it('calls onChordSchedule when active', () => {
+    const onChordSchedule = jest.fn();
+    render(
+      <FantasyRhythmEngine
+        {...defaultProps}
+        onChordSchedule={onChordSchedule}
+      />
+    );
+
+    // Component should generate schedule when active
+    expect(onChordSchedule).toHaveBeenCalled();
+  });
+
+  it('supports chord progression data', () => {
+    const onChordSchedule = jest.fn();
+    const chordProgressionData = {
+      chords: [
+        { measure: 1, beat: 1, chord: 'C' },
+        { measure: 2, beat: 1, chord: 'G' },
+        { measure: 3, beat: 1, chord: 'Am' },
+        { measure: 4, beat: 1, chord: 'F' }
+      ]
+    };
+
+    render(
+      <FantasyRhythmEngine
+        {...defaultProps}
+        chordProgressionData={chordProgressionData}
+        onChordSchedule={onChordSchedule}
+      />
+    );
+
+    // Should create schedule based on progression data
+    expect(onChordSchedule).toHaveBeenCalled();
+    const scheduleCall = onChordSchedule.mock.calls[0][0];
+    expect(scheduleCall).toBeInstanceOf(Array);
+    expect(scheduleCall.length).toBeGreaterThan(0);
+  });
+
+  it('adjusts positions based on time signature', () => {
+    const onChordSchedule = jest.fn();
+    
+    // Test with 3/4 time signature
+    render(
+      <FantasyRhythmEngine
+        {...defaultProps}
+        timeSignature={3}
+        simultaneousMonsterCount={4}
+        chordProgressionData={{
+          chords: [
+            { measure: 1, beat: 1, chord: 'C' },
+            { measure: 1, beat: 2, chord: 'G' },
+            { measure: 1, beat: 3, chord: 'Am' }
+          ]
+        }}
+        onChordSchedule={onChordSchedule}
+      />
+    );
+
+    const scheduleCall = onChordSchedule.mock.calls[0][0];
+    const positions = scheduleCall.map((item: any) => item.position);
+    
+    // Should only use positions A, B, C for 3/4 time
+    expect(positions.every((pos: string) => ['A', 'B', 'C'].includes(pos))).toBe(true);
+  });
+
+  it('does not generate schedule when inactive', () => {
+    const onChordSchedule = jest.fn();
+    render(
+      <FantasyRhythmEngine
+        {...defaultProps}
+        isActive={false}
+        onChordSchedule={onChordSchedule}
+      />
+    );
+
+    // Should not call onChordSchedule when inactive
+    expect(onChordSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -635,7 +635,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';  // rhythm モードを追加
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;
@@ -648,6 +648,18 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: ChordProgressionData | null;  // リズムモード用のコード進行データ
+}
+
+// リズムモード用のコード進行データ
+export interface ChordProgressionData {
+  chords: ChordProgressionItem[];
+}
+
+export interface ChordProgressionItem {
+  measure: number;  // 小節番号
+  beat: number;     // 拍番号（1拍目の裏なら1.5、3拍目の16分音符4つ目なら3.75）
+  chord: string;    // コード名
 }
 
 export interface LessonContext {

--- a/supabase/migrations/20250801000001_add_rhythm_mode.sql
+++ b/supabase/migrations/20250801000001_add_rhythm_mode.sql
@@ -1,0 +1,122 @@
+-- Add rhythm mode support to fantasy_stages table
+
+-- 1. Update the mode check constraint to include 'rhythm'
+ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
+ALTER TABLE fantasy_stages ADD CONSTRAINT fantasy_stages_mode_check 
+  CHECK (mode IN ('single', 'progression', 'rhythm'));
+
+-- 2. Add chord_progression_data column if it doesn't exist
+ALTER TABLE fantasy_stages 
+  ADD COLUMN IF NOT EXISTS chord_progression_data jsonb DEFAULT NULL;
+
+-- 3. Add comment for the new column
+COMMENT ON COLUMN fantasy_stages.chord_progression_data IS 'リズムモード用のコード進行データ (JSON形式)';
+
+-- 4. Ensure all required columns exist with proper defaults
+ALTER TABLE fantasy_stages 
+  ADD COLUMN IF NOT EXISTS mp3_url varchar,
+  ADD COLUMN IF NOT EXISTS measure_count integer DEFAULT 8 CHECK (measure_count > 0),
+  ADD COLUMN IF NOT EXISTS bpm integer DEFAULT 120 CHECK (bpm > 0),
+  ADD COLUMN IF NOT EXISTS time_signature integer DEFAULT 4 CHECK (time_signature > 0 AND time_signature <= 16),
+  ADD COLUMN IF NOT EXISTS count_in_measures integer DEFAULT 1 CHECK (count_in_measures >= 0);
+
+-- 5. Add comments for the new columns
+COMMENT ON COLUMN fantasy_stages.mp3_url IS 'BGM音源のURL';
+COMMENT ON COLUMN fantasy_stages.measure_count IS '小節数';
+COMMENT ON COLUMN fantasy_stages.bpm IS 'BPM (Beats Per Minute)';
+COMMENT ON COLUMN fantasy_stages.time_signature IS '拍子 (例: 4=4/4拍子, 3=3/4拍子)';
+COMMENT ON COLUMN fantasy_stages.count_in_measures IS 'カウントイン小節数 (BGMループ開始前の小節数)';
+
+-- 6. Add sample rhythm mode stage
+INSERT INTO fantasy_stages (
+  stage_number,
+  name,
+  description,
+  mode,
+  max_hp,
+  enemy_gauge_seconds,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  allowed_chords,
+  show_sheet_music,
+  show_guide,
+  simultaneous_monster_count,
+  monster_icon,
+  mp3_url,
+  measure_count,
+  bpm,
+  time_signature,
+  count_in_measures,
+  chord_progression_data
+) VALUES (
+  '4-1',
+  'リズムの洞窟',
+  'リズムに合わせてコードを演奏しよう！',
+  'rhythm',
+  5,
+  4.0,
+  10,
+  1,
+  1,
+  1,
+  '["C", "G", "Am", "F"]'::jsonb,
+  true,
+  true,
+  1,
+  'fa-drum',
+  '/demo-1.mp3',
+  8,
+  120,
+  4,
+  1,
+  NULL
+) ON CONFLICT (stage_number) DO NOTHING;
+
+-- 7. Add sample rhythm mode stage with chord progression
+INSERT INTO fantasy_stages (
+  stage_number,
+  name,
+  description,
+  mode,
+  max_hp,
+  enemy_gauge_seconds,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  allowed_chords,
+  show_sheet_music,
+  show_guide,
+  simultaneous_monster_count,
+  monster_icon,
+  mp3_url,
+  measure_count,
+  bpm,
+  time_signature,
+  count_in_measures,
+  chord_progression_data
+) VALUES (
+  '4-2',
+  'リズムの森',
+  'コード進行に合わせて演奏しよう！',
+  'rhythm',
+  5,
+  4.0,
+  8,
+  1,
+  1,
+  1,
+  '["C", "G", "Am", "F", "Dm"]'::jsonb,
+  true,
+  true,
+  4,
+  'fa-music',
+  '/demo-1.mp3',
+  8,
+  120,
+  4,
+  1,
+  '{"chords": [{"beat": 1.0, "chord": "C", "measure": 1}, {"beat": 1.0, "chord": "G", "measure": 2}, {"beat": 1.0, "chord": "Am", "measure": 3}, {"beat": 1.0, "chord": "F", "measure": 4}, {"beat": 1.0, "chord": "C", "measure": 5}, {"beat": 1.0, "chord": "Am", "measure": 6}, {"beat": 1.0, "chord": "Dm", "measure": 7}, {"beat": 1.0, "chord": "G", "measure": 8}]}'::jsonb
+) ON CONFLICT (stage_number) DO NOTHING;


### PR DESCRIPTION
Add a new 'Rhythm Mode' to the fantasy game to introduce timing-based chord input, featuring both random and progression patterns with a judgment window.

This mode expands gameplay beyond the existing 'Quiz Mode' by requiring players to hit chords within a precise ±200ms timing window, synchronized with the BGM. It supports two distinct challenge types: random chord generation per measure and predefined chord progressions loaded from JSON, each with specific monster appearance rules and a new timing gauge UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-08be3e3d-f867-4584-a904-a9a4eac6f46f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08be3e3d-f867-4584-a904-a9a4eac6f46f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>