### PR TITLE
Add rhythm mode to fantasy game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "supabase": "^2.30.4",
         "tailwindcss": "^3.4.0",
         "ts-prune": "^0.10.3",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.2",
         "vite": "^5.0.8"
       },
       "engines": {
@@ -9302,9 +9302,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "supabase": "^2.30.4",
     "tailwindcss": "^3.4.0",
     "ts-prune": "^0.10.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "^5.0.8"
   },
   "engines": {

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,7 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chord_progression_data?: any; // リズムモード用コード進行データ
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import FantasyStageSelect from './FantasyStageSelect';
 import FantasyGameScreen from './FantasyGameScreen';
+import FantasyRhythmScreen from './FantasyRhythmScreen';
 import { FantasyStage } from './FantasyGameEngine';
 import { useAuthStore } from '@/stores/authStore';
 import { useGameStore } from '@/stores/gameStore';
@@ -108,7 +109,8 @@ const FantasyMain: React.FC = () => {
             bgmUrl: stage.bgm_url || stage.mp3_url,
             measureCount: stage.measure_count,
             countInMeasures: stage.count_in_measures,
-            timeSignature: stage.time_signature
+            timeSignature: stage.time_signature,
+            chord_progression_data: stage.chord_progression_data
           };
           devLog.debug('🎮 FantasyStage形式に変換:', fantasyStage);
           setCurrentStage(fantasyStage);
@@ -561,20 +563,36 @@ const FantasyMain: React.FC = () => {
   
   // ゲーム画面
   if (currentStage) {
-    return (
-      <FantasyGameScreen
-        // ▼▼▼ 追加 ▼▼▼
-        key={gameKey} // keyプロパティを渡す
-        // ▲▲▲ ここまで ▲▲▲
-        stage={currentStage}
-        autoStart={pendingAutoStart}   // ★
-        onGameComplete={handleGameComplete}
-        onBackToStageSelect={handleBackToStageSelect}
-        noteNameLang={settings.noteNameStyle === 'solfege' ? 'solfege' : 'en'}
-        simpleNoteName={settings.simpleDisplayMode}
-        lessonMode={isLessonMode}
-      />
-    );
+    // リズムモードかクイズモードかで分岐
+    if (currentStage.mode === 'rhythm') {
+      return (
+        <FantasyRhythmScreen
+          key={gameKey}
+          stage={currentStage}
+          autoStart={pendingAutoStart}
+          onGameComplete={handleGameComplete}
+          onBackToStageSelect={handleBackToStageSelect}
+          noteNameLang={settings.noteNameStyle === 'solfege' ? 'solfege' : 'en'}
+          simpleNoteName={settings.simpleDisplayMode}
+          lessonMode={isLessonMode}
+        />
+      );
+    } else {
+      return (
+        <FantasyGameScreen
+          // ▼▼▼ 追加 ▼▼▼
+          key={gameKey} // keyプロパティを渡す
+          // ▲▲▲ ここまで ▲▲▲
+          stage={currentStage}
+          autoStart={pendingAutoStart}   // ★
+          onGameComplete={handleGameComplete}
+          onBackToStageSelect={handleBackToStageSelect}
+          noteNameLang={settings.noteNameStyle === 'solfege' ? 'solfege' : 'en'}
+          simpleNoteName={settings.simpleDisplayMode}
+          lessonMode={isLessonMode}
+        />
+      );
+    }
   }
   
   // ステージ選択画面

--- a/src/components/fantasy/FantasyRhythmEngine.tsx
+++ b/src/components/fantasy/FantasyRhythmEngine.tsx
@@ -1,0 +1,374 @@
+/**
+ * ファンタジーリズムモードエンジン
+ * リズムゲームロジックとステート管理を担当
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useTimeStore } from '@/stores/timeStore';
+import { devLog } from '@/utils/logger';
+import { resolveChord } from '@/utils/chord-utils';
+import { type DisplayOpts } from '@/utils/display-note';
+import { note as parseNote } from 'tonal';
+import type { FantasyStage } from './FantasyGameEngine';
+
+// ===== 型定義 =====
+
+interface ChordDefinition {
+  id: string;
+  displayName: string;
+  notes: number[];
+  noteNames: string[];
+  quality: string;
+  root: string;
+}
+
+interface RhythmChordData {
+  chord: string;
+  measure: number;
+  beat: number;
+}
+
+interface RhythmMonster {
+  id: string;
+  position: 'A' | 'B' | 'C' | 'D';
+  currentHp: number;
+  maxHp: number;
+  chordData: RhythmChordData;
+  chordDefinition: ChordDefinition;
+  lastAttackTime: number;
+  gaugeProgress: number; // 0-100%
+  displayStartTime: number; // 表示開始時刻
+}
+
+interface RhythmGameState {
+  isActive: boolean;
+  playerHp: number;
+  score: number;
+  correctCount: number;
+  totalCount: number;
+  activeMonsters: RhythmMonster[];
+  inputBuffer: number[];
+  lastInputTime: number;
+  chordProgressionData: RhythmChordData[] | null;
+  currentChordIndex: number;
+  monsterIdCounter: number;
+}
+
+const JUDGMENT_WINDOW_MS = 200; // 判定ウィンドウ (前後200ms)
+const GAUGE_DURATION_MS = 1000; // ゲージが0%から80%まで進む時間
+
+// ===== ユーティリティ関数 =====
+
+const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDefinition | null => {
+  const resolved = resolveChord(chordId, 4, displayOpts);
+  if (!resolved) {
+    devLog.debug(`⚠️ 未定義のリズムコード: ${chordId}`);
+    return null;
+  }
+
+  const midiNotes = resolved.notes.map(noteName => {
+    const noteObj = parseNote(noteName + '4');
+    return noteObj && typeof noteObj.midi === 'number' ? noteObj.midi : 60;
+  });
+
+  return {
+    id: chordId,
+    displayName: resolved.displayName,
+    notes: midiNotes,
+    noteNames: resolved.notes,
+    quality: resolved.quality,
+    root: resolved.root
+  };
+};
+
+// ===== リズムモードエンジン =====
+
+export const useFantasyRhythmEngine = (
+  stage: FantasyStage,
+  displayOpts?: DisplayOpts,
+  onChordCorrect?: (chord: ChordDefinition, damage: number, monsterId: string) => void,
+  onChordIncorrect?: (expectedChord: ChordDefinition) => void,
+  onEnemyAttack?: (monsterId: string) => void,
+  onGameComplete?: (result: 'clear' | 'gameover') => void
+) => {
+  const [gameState, setGameState] = useState<RhythmGameState>({
+    isActive: false,
+    playerHp: stage?.maxHp || 5,
+    score: 0,
+    correctCount: 0,
+    totalCount: 0,
+    activeMonsters: [],
+    inputBuffer: [],
+    lastInputTime: 0,
+    chordProgressionData: null,
+    currentChordIndex: 0,
+    monsterIdCounter: 0
+  });
+
+  const timeStore = useTimeStore();
+  const processedChordsRef = useRef<Set<string>>(new Set());
+
+  // コード進行データの読み込み
+  useEffect(() => {
+    if (stage?.chord_progression_data) {
+      setGameState(prev => ({
+        ...prev,
+        chordProgressionData: stage.chord_progression_data.chords || []
+      }));
+    }
+  }, [stage]);
+
+  // ランダムコード生成
+  const generateRandomChord = useCallback(() => {
+    if (!stage?.allowedChords || stage.allowedChords.length === 0) return null;
+    const randomIndex = Math.floor(Math.random() * stage.allowedChords.length);
+    return stage.allowedChords[randomIndex];
+  }, [stage]);
+
+  // モンスター生成
+  const spawnMonster = useCallback((chordData: RhythmChordData, position: 'A' | 'B' | 'C' | 'D') => {
+    const chordDef = getChordDefinition(chordData.chord, displayOpts);
+    if (!chordDef) return null;
+
+    const monster: RhythmMonster = {
+      id: `rhythm-monster-${gameState.monsterIdCounter}`,
+      position,
+      currentHp: stage?.enemyHp || 1,
+      maxHp: stage?.enemyHp || 1,
+      chordData,
+      chordDefinition: chordDef,
+      lastAttackTime: 0,
+      gaugeProgress: 0,
+      displayStartTime: performance.now()
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      monsterIdCounter: prev.monsterIdCounter + 1
+    }));
+
+    return monster;
+  }, [stage, displayOpts, gameState.monsterIdCounter]);
+
+  // タイミング判定
+  const checkTiming = useCallback((inputTime: number, targetMeasure: number, targetBeat: number): boolean => {
+    const timingInfo = timeStore.getCurrentTimingInfo();
+    
+    // カウントイン中は判定しない
+    if (timingInfo.isInCountIn) return false;
+    
+    // 目標タイミングの計算
+    const msPerBeat = 60000 / timeStore.bpm;
+    const targetBeatsFromStart = (targetMeasure - 1) * timeStore.timeSignature + (targetBeat - 1);
+    const targetTimeMs = timeStore.readyDuration + targetBeatsFromStart * msPerBeat;
+    
+    // 現在時刻との差分
+    const currentTimeMs = timingInfo.currentTime;
+    const timeDiff = Math.abs(currentTimeMs - targetTimeMs);
+    
+    return timeDiff <= JUDGMENT_WINDOW_MS;
+  }, [timeStore]);
+
+  // 入力処理
+  const handleInput = useCallback((noteNumber: number) => {
+    const now = performance.now();
+    
+    setGameState(prev => {
+      const newBuffer = [...prev.inputBuffer, noteNumber];
+      
+      // アクティブなモンスターをチェック
+      const updatedMonsters = [...prev.activeMonsters];
+      let hitFound = false;
+      
+      for (let i = 0; i < updatedMonsters.length; i++) {
+        const monster = updatedMonsters[i];
+        
+        // タイミング判定
+        if (checkTiming(now, monster.chordData.measure, monster.chordData.beat)) {
+          // コード判定
+          const sortedBuffer = [...newBuffer].sort((a, b) => a - b);
+          const sortedTarget = [...monster.chordDefinition.notes].sort((a, b) => a - b);
+          
+          if (sortedBuffer.length === sortedTarget.length &&
+              sortedBuffer.every((note, idx) => note === sortedTarget[idx])) {
+            // 正解
+            hitFound = true;
+            
+            // ダメージ処理
+                          const damage = stage?.minDamage || 1;
+            monster.currentHp -= damage;
+            
+            if (monster.currentHp <= 0) {
+              // モンスター撃破
+              updatedMonsters.splice(i, 1);
+              i--;
+            }
+            
+            // コールバック
+            if (onChordCorrect) {
+              onChordCorrect(monster.chordDefinition, damage, monster.id);
+            }
+            
+            break;
+          }
+        }
+      }
+      
+      if (hitFound) {
+        // 正解時の処理
+        return {
+          ...prev,
+          activeMonsters: updatedMonsters,
+          inputBuffer: [],
+          lastInputTime: now,
+          correctCount: prev.correctCount + 1,
+          score: prev.score + 100
+        };
+      } else if (now - prev.lastInputTime > JUDGMENT_WINDOW_MS) {
+        // 判定ウィンドウを超えた場合はバッファリセット
+        return {
+          ...prev,
+          inputBuffer: [],
+          lastInputTime: now
+        };
+      } else {
+        // バッファ更新
+        return {
+          ...prev,
+          inputBuffer: newBuffer,
+          lastInputTime: now
+        };
+      }
+    });
+  }, [checkTiming, stage, onChordCorrect]);
+
+  // ゲームループ
+  useEffect(() => {
+    if (!gameState.isActive || !timeStore.startAt) return;
+    
+    const updateLoop = () => {
+      const timingInfo = timeStore.getCurrentTimingInfo();
+      
+      // カウントイン中はスキップ
+      if (timingInfo.isInCountIn) return;
+      
+      setGameState(prev => {
+        const updatedState = { ...prev };
+        const now = performance.now();
+        
+        // モンスターのゲージ更新と攻撃判定
+        updatedState.activeMonsters = prev.activeMonsters.map(monster => {
+          const elapsedTime = now - monster.displayStartTime;
+          const progress = Math.min(100, (elapsedTime / GAUGE_DURATION_MS) * 80);
+          
+          // 80%到達で攻撃判定
+          if (progress >= 80 && monster.lastAttackTime === 0) {
+            // 判定ウィンドウ内に正解がなければ攻撃
+            const targetTime = monster.displayStartTime + GAUGE_DURATION_MS;
+            if (now > targetTime + JUDGMENT_WINDOW_MS) {
+              monster.lastAttackTime = now;
+              updatedState.playerHp -= 1;
+              
+              if (onEnemyAttack) {
+                onEnemyAttack(monster.id);
+              }
+            }
+          }
+          
+          return {
+            ...monster,
+            gaugeProgress: progress
+          };
+        });
+        
+        // プレイヤーHP確認
+        if (updatedState.playerHp <= 0 && onGameComplete) {
+          onGameComplete('gameover');
+          updatedState.isActive = false;
+        }
+        
+        // 新しいモンスターの生成（コードプログレッションモード）
+        if (prev.chordProgressionData && prev.activeMonsters.length < 4) {
+          const positions: ('A' | 'B' | 'C' | 'D')[] = ['A', 'B', 'C', 'D'];
+          const occupiedPositions = prev.activeMonsters.map(m => m.position);
+          const availablePositions = positions.filter(p => !occupiedPositions.includes(p));
+          
+          if (availablePositions.length > 0) {
+            const nextChord = prev.chordProgressionData[prev.currentChordIndex];
+            if (nextChord && checkTiming(now, nextChord.measure, nextChord.beat)) {
+              const chordKey = `${nextChord.measure}-${nextChord.beat}`;
+              if (!processedChordsRef.current.has(chordKey)) {
+                processedChordsRef.current.add(chordKey);
+                const newMonster = spawnMonster(nextChord, availablePositions[0]);
+                if (newMonster) {
+                  updatedState.activeMonsters.push(newMonster);
+                  updatedState.currentChordIndex = (prev.currentChordIndex + 1) % prev.chordProgressionData.length;
+                }
+              }
+            }
+          }
+        }
+        
+        // ランダムモードでのモンスター生成
+        if (!prev.chordProgressionData && prev.activeMonsters.length === 0) {
+          const currentMeasure = timingInfo.measureFromStart;
+          const chordKey = `random-${currentMeasure}`;
+          
+          if (!processedChordsRef.current.has(chordKey) && currentMeasure > 0) {
+            processedChordsRef.current.add(chordKey);
+            const randomChord = generateRandomChord();
+            if (randomChord) {
+              const chordData: RhythmChordData = {
+                chord: randomChord,
+                measure: currentMeasure,
+                beat: 1
+              };
+              const newMonster = spawnMonster(chordData, 'A');
+              if (newMonster) {
+                updatedState.activeMonsters.push(newMonster);
+              }
+            }
+          }
+        }
+        
+        return updatedState;
+      });
+    };
+    
+    const intervalId = setInterval(updateLoop, 16); // 60fps
+    
+    return () => clearInterval(intervalId);
+  }, [gameState.isActive, timeStore, checkTiming, spawnMonster, generateRandomChord, onEnemyAttack, onGameComplete]);
+
+  // ゲーム開始
+  const startGame = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      isActive: true,
+      playerHp: stage?.maxHp || 5,
+      score: 0,
+      correctCount: 0,
+      totalCount: 0,
+      activeMonsters: [],
+      inputBuffer: [],
+      lastInputTime: 0,
+      currentChordIndex: 0
+    }));
+    processedChordsRef.current.clear();
+  }, [stage]);
+
+  // ゲーム停止
+  const stopGame = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      isActive: false
+    }));
+  }, []);
+
+  return {
+    gameState,
+    handleInput,
+    startGame,
+    stopGame
+  };
+};

--- a/src/components/fantasy/FantasyRhythmScreen.tsx
+++ b/src/components/fantasy/FantasyRhythmScreen.tsx
@@ -1,0 +1,305 @@
+/**
+ * ファンタジーリズムモード画面
+ * リズムゲームのUI表示を担当
+ */
+
+import React, { useEffect, useState, useRef } from 'react';
+import { useFantasyRhythmEngine } from './FantasyRhythmEngine';
+// import FantasyPIXIRenderer from './FantasyPIXIRenderer'; // 未使用のため削除
+import { FantasyStage } from './FantasyGameEngine';
+import MidiController from '@/utils/MidiController';
+import { bgmManager } from '@/utils/BGMManager';
+import { useTimeStore } from '@/stores/timeStore';
+import { devLog } from '@/utils/logger';
+import { type DisplayOpts } from '@/utils/display-note';
+
+interface FantasyRhythmScreenProps {
+  stage: FantasyStage;
+  autoStart?: boolean;
+  onGameComplete: (result: 'clear' | 'gameover', score: number, correct: number, total: number) => void;
+  onBackToStageSelect: () => void;
+  noteNameLang?: 'en' | 'solfege';
+  simpleNoteName?: boolean;
+  lessonMode?: boolean;
+}
+
+const FantasyRhythmScreen: React.FC<FantasyRhythmScreenProps> = ({
+  stage,
+  autoStart = false,
+  onGameComplete,
+  onBackToStageSelect,
+  noteNameLang = 'en',
+  simpleNoteName = false
+}) => {
+  const [isReady, setIsReady] = useState(false);
+  const [bgmVolume, setBgmVolume] = useState(0.7);
+  const timeStore = useTimeStore();
+  const midiControllerRef = useRef<MidiController | null>(null);
+  const animationFrameRef = useRef<number>();
+
+  // ディスプレイオプション
+  const displayOpts: DisplayOpts = {
+    lang: noteNameLang,
+    simple: simpleNoteName
+  };
+
+  // リズムエンジンの初期化
+  const {
+    gameState,
+    handleInput,
+    startGame,
+    stopGame
+  } = useFantasyRhythmEngine(
+    stage,
+    displayOpts,
+    // onChordCorrect
+    (chord, damage, _monsterId) => {
+      devLog.debug(`🎯 リズムモード正解: ${chord.displayName}, ダメージ: ${damage}`);
+    },
+    // onChordIncorrect
+    (expectedChord) => {
+      devLog.debug(`❌ リズムモード不正解: 期待 ${expectedChord.displayName}`);
+    },
+    // onEnemyAttack
+    (monsterId) => {
+      devLog.debug(`⚔️ モンスター攻撃: ${monsterId}`);
+    },
+    // onGameComplete
+    (result) => {
+      stopGame();
+      onGameComplete(result, gameState.score, gameState.correctCount, gameState.totalCount);
+    }
+  );
+
+  // BGM再生
+  useEffect(() => {
+    if (stage.bgmUrl && isReady) {
+      bgmManager.setRhythmMode(true);
+      bgmManager.play(
+        stage.bgmUrl,
+        stage.bpm,
+        stage.timeSignature || 4,
+        stage.measureCount || 8,
+        stage.countInMeasures || 0,
+        bgmVolume
+      );
+    }
+
+    return () => {
+      bgmManager.stop();
+    };
+  }, [stage, isReady, bgmVolume]);
+
+  // タイムストアの初期化
+  useEffect(() => {
+    if (isReady) {
+      timeStore.setRhythmMode(true);
+      timeStore.setStart(
+        stage.bpm,
+        stage.timeSignature || 4,
+        stage.measureCount || 8,
+        stage.countInMeasures || 0
+      );
+      startGame();
+    }
+
+    return () => {
+      timeStore.reset();
+    };
+  }, [isReady, stage, timeStore, startGame]);
+
+  // アニメーションループ
+  useEffect(() => {
+    if (!isReady) return;
+
+    const animate = () => {
+      timeStore.tick();
+      animationFrameRef.current = requestAnimationFrame(animate);
+    };
+
+    animationFrameRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isReady, timeStore]);
+
+  // MIDI初期化
+  useEffect(() => {
+    const initMidi = async () => {
+      try {
+        midiControllerRef.current = new MidiController({
+          onNoteOn: (note) => {
+            if (gameState.isActive) {
+              handleInput(note);
+            }
+          },
+          onNoteOff: () => {
+            // リズムモードではNoteOffは使用しない
+          }
+        });
+        await midiControllerRef.current.initialize();
+      } catch (error) {
+        devLog.debug('MIDI初期化エラー:', error);
+      }
+    };
+
+    initMidi();
+
+    return () => {
+      midiControllerRef.current?.disconnect();
+    };
+  }, [gameState.isActive, handleInput]);
+
+  // 自動開始
+  useEffect(() => {
+    if (autoStart && !isReady) {
+      setTimeout(() => setIsReady(true), 100);
+    }
+  }, [autoStart, isReady]);
+
+  // 現在のタイミング情報を取得
+  const timingInfo = timeStore.getCurrentTimingInfo();
+  const displayMeasure = timingInfo.isInCountIn ? '/' : String(timeStore.currentMeasure);
+  const displayBeat = timeStore.currentBeat;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 text-white">
+      {/* ヘッダー */}
+      <div className="absolute top-0 left-0 right-0 z-10 p-4">
+        <div className="flex justify-between items-start">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={onBackToStageSelect}
+              className="px-4 py-2 bg-gray-800 bg-opacity-50 rounded-lg hover:bg-opacity-70 transition-all"
+            >
+              ← 戻る
+            </button>
+            <div className="text-xl font-bold">
+              {stage.stageNumber} {stage.name}
+            </div>
+          </div>
+          
+          {/* タイミング表示 */}
+          <div className="bg-black bg-opacity-50 rounded-lg px-4 py-2">
+            <div className="text-lg font-mono">
+              M {displayMeasure} - B {displayBeat}
+            </div>
+          </div>
+        </div>
+
+        {/* プレイヤーステータス */}
+        <div className="mt-4 flex justify-between items-center">
+          <div className="flex items-center gap-2">
+            <span>HP:</span>
+            <div className="flex gap-1">
+              {Array.from({ length: stage.maxHp }).map((_, i) => (
+                <div
+                  key={i}
+                  className={`w-6 h-6 rounded ${
+                    i < gameState.playerHp ? 'bg-red-500' : 'bg-gray-600'
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+          
+          <div className="text-xl">
+            スコア: {gameState.score}
+          </div>
+        </div>
+      </div>
+
+      {/* ゲーム画面 */}
+      <div className="relative h-screen">
+        {/* モンスター表示エリア */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="grid grid-cols-4 gap-8 max-w-4xl w-full px-8">
+            {['A', 'B', 'C', 'D'].map((position) => {
+              const monster = gameState.activeMonsters.find(m => m.position === position);
+              return (
+                <div key={position} className="relative">
+                  <div className="bg-black bg-opacity-30 rounded-lg p-4 h-48 flex flex-col items-center justify-center">
+                    {monster ? (
+                      <>
+                        {/* モンスターアイコン */}
+                        <div className="text-4xl mb-2">👾</div>
+                        
+                        {/* コード名 */}
+                        <div className="text-xl font-bold mb-2">
+                          {monster.chordDefinition.displayName}
+                        </div>
+                        
+                        {/* タイミングゲージ */}
+                        <div className="w-full bg-gray-700 rounded-full h-4 relative overflow-hidden">
+                          <div
+                            className="absolute left-0 top-0 h-full bg-gradient-to-r from-green-500 to-yellow-500 transition-all duration-100"
+                            style={{ width: `${monster.gaugeProgress}%` }}
+                          />
+                          {/* 80%マーカー */}
+                          <div className="absolute top-0 bottom-0 w-1 bg-red-500" style={{ left: '80%' }} />
+                        </div>
+                        
+                        {/* HP */}
+                        <div className="mt-2 text-sm">
+                          HP: {monster.currentHp}/{monster.maxHp}
+                        </div>
+                      </>
+                    ) : (
+                      <div className="text-gray-500 text-center">
+                        <div className="text-2xl mb-2">-</div>
+                        <div className="text-sm">{position}列</div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 開始ボタン */}
+        {!isReady && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50">
+            <button
+              onClick={() => setIsReady(true)}
+              className="px-8 py-4 bg-purple-600 hover:bg-purple-500 rounded-lg text-2xl font-bold transition-all transform hover:scale-105"
+            >
+              ゲーム開始
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* BGM音量調整 */}
+      <div className="absolute bottom-4 right-4 bg-black bg-opacity-50 rounded-lg p-2">
+        <label className="flex items-center gap-2 text-sm">
+          <span>BGM:</span>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={bgmVolume * 100}
+            onChange={(e) => {
+              const volume = parseInt(e.target.value) / 100;
+              setBgmVolume(volume);
+              bgmManager.setVolume(volume);
+            }}
+            className="w-24"
+          />
+        </label>
+      </div>
+
+      {/* MIDI接続状態 (デバッグ用) */}
+      {process.env.NODE_ENV === 'development' && (
+        <div className="absolute bottom-4 left-4 text-xs opacity-50">
+          MIDI: {midiControllerRef.current ? 'Connected' : 'Disconnected'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FantasyRhythmScreen;

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+        mode: stage.mode as 'single' | 'progression' | 'rhythm',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,
@@ -170,7 +170,8 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
         countInMeasures: stage.count_in_measures,
-        timeSignature: stage.time_signature
+        timeSignature: stage.time_signature,
+        chord_progression_data: stage.chord_progression_data
       }));
       
       const convertedProgress: FantasyUserProgress = {
@@ -291,6 +292,15 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.name : "???"}
           </div>
+          
+                      {/* モードタイプ表示 */}
+            {unlocked && (
+              <div className="text-xs text-blue-300 mb-1">
+                {stage.mode === 'rhythm' ? 'リズムモード' : 'クイズモード'}
+                {stage.mode === 'rhythm' && stage.chord_progression_data ? ' (進行)' : ''}
+                {stage.mode === 'rhythm' && !stage.chord_progression_data ? ' (ランダム)' : ''}
+              </div>
+            )}
           
           {/* 説明文 */}
           <div className={cn(

--- a/src/components/fantasy/__tests__/FantasyRhythmMode.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyRhythmMode.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook, act } from '@testing-library/react';
+import { useFantasyRhythmEngine } from '../FantasyRhythmEngine';
+import { parseRhythmJson, generateDemoProgression } from '@/utils/rhythmJsonLoader';
+
+// モックステージデータ
+const mockStage = {
+  id: 'test-stage',
+  stageNumber: '1-1',
+  name: 'テストステージ',
+  description: 'テスト用',
+  maxHp: 5,
+  enemyGaugeSeconds: 4,
+  enemyCount: 10,
+  enemyHp: 1,
+  minDamage: 1,
+  maxDamage: 1,
+  mode: 'rhythm' as const,
+  allowedChords: ['C', 'G', 'Am', 'F'],
+  showSheetMusic: true,
+  showGuide: true,
+  monsterIcon: 'test',
+  simultaneousMonsterCount: 1,
+  bpm: 120,
+  measureCount: 8,
+  countInMeasures: 1,
+  timeSignature: 4
+};
+
+describe('FantasyRhythmEngine', () => {
+  it('エンジンが正しく初期化される', () => {
+    const { result } = renderHook(() => useFantasyRhythmEngine(mockStage));
+    
+    expect(result.current.gameState.isActive).toBe(false);
+    expect(result.current.gameState.playerHp).toBe(5);
+    expect(result.current.gameState.score).toBe(0);
+  });
+
+  it('ゲームが開始できる', () => {
+    const { result } = renderHook(() => useFantasyRhythmEngine(mockStage));
+    
+    act(() => {
+      result.current.startGame();
+    });
+    
+    expect(result.current.gameState.isActive).toBe(true);
+  });
+
+  it('入力バッファが正しく管理される', () => {
+    const { result } = renderHook(() => useFantasyRhythmEngine(mockStage));
+    
+    act(() => {
+      result.current.startGame();
+      result.current.handleInput(60); // C4
+    });
+    
+    expect(result.current.gameState.inputBuffer).toContain(60);
+  });
+});
+
+describe('rhythmJsonLoader', () => {
+  it('正しいJSONデータをパースできる', () => {
+    const jsonData = {
+      chords: [
+        { chord: 'C', measure: 1, beat: 1 },
+        { chord: 'G', measure: 2, beat: 1 }
+      ]
+    };
+    
+    const result = parseRhythmJson(jsonData);
+    expect(result).toHaveLength(2);
+    expect(result?.[0].chord).toBe('C');
+  });
+
+  it('無効なJSONデータを適切に処理する', () => {
+    const result = parseRhythmJson(null);
+    expect(result).toBeNull();
+  });
+
+  it('デモ進行を生成できる', () => {
+    const chords = ['C', 'G', 'Am', 'F'];
+    const result = generateDemoProgression(chords, 4, 4);
+    
+    expect(result).toHaveLength(4);
+    expect(result[0].measure).toBe(1);
+    expect(result[0].beat).toBe(1);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -638,6 +638,7 @@ export interface FantasyStage {
   mode: 'single' | 'progression';
   allowed_chords: string[];
   chord_progression?: string[];
+  chord_progression_data?: any; // リズムモード用JSONデータ
   show_sheet_music: boolean;
   show_guide: boolean;
   simultaneous_monster_count?: number;

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -5,6 +5,7 @@ class BGMManager {
   private loopBegin = 0
   private loopEnd = 0
   private timeUpdateHandler: (() => void) | null = null
+  private isRhythmMode = false
 
   play(
     url: string,
@@ -53,6 +54,14 @@ class BGMManager {
     }
   }
 
+  setRhythmMode(enabled: boolean) {
+    this.isRhythmMode = enabled
+  }
+
+  getCurrentTime(): number {
+    return this.audio?.currentTime ?? 0
+  }
+
   stop() {
     if (this.audio) {
       if (this.timeUpdateHandler) {
@@ -63,6 +72,7 @@ class BGMManager {
       this.audio.src = ''
       this.audio = null
     }
+    this.isRhythmMode = false
   }
 }
 

--- a/src/utils/rhythmJsonLoader.ts
+++ b/src/utils/rhythmJsonLoader.ts
@@ -1,0 +1,119 @@
+/**
+ * リズムモード用JSONローダー
+ * コード進行データの読み込みと検証を担当
+ */
+
+import { devLog } from '@/utils/logger';
+
+interface RhythmChordData {
+  chord: string;
+  measure: number;
+  beat: number;
+}
+
+interface RhythmJsonData {
+  chords: RhythmChordData[];
+}
+
+/**
+ * リズムモード用のJSONデータを読み込む
+ * @param jsonData - データベースから取得したJSON
+ * @returns パース済みのコード進行データ
+ */
+export const parseRhythmJson = (jsonData: unknown): RhythmChordData[] | null => {
+  if (!jsonData) {
+    devLog.debug('リズムJSON: データがnull');
+    return null;
+  }
+
+  try {
+    // すでにオブジェクトの場合はそのまま使用
+    const data: RhythmJsonData = typeof jsonData === 'string' ? JSON.parse(jsonData) : jsonData;
+    
+    if (!data.chords || !Array.isArray(data.chords)) {
+      devLog.debug('リズムJSON: chordsフィールドが無効');
+      return null;
+    }
+
+    // データ検証
+    const validatedChords: RhythmChordData[] = [];
+    
+    for (const chord of data.chords) {
+      if (!chord.chord || typeof chord.chord !== 'string') {
+        devLog.debug(`リズムJSON: 無効なコード名: ${chord.chord}`);
+        continue;
+      }
+      
+      if (typeof chord.measure !== 'number' || chord.measure < 1) {
+        devLog.debug(`リズムJSON: 無効な小節番号: ${chord.measure}`);
+        continue;
+      }
+      
+      if (typeof chord.beat !== 'number' || chord.beat < 1) {
+        devLog.debug(`リズムJSON: 無効な拍番号: ${chord.beat}`);
+        continue;
+      }
+      
+      validatedChords.push({
+        chord: chord.chord,
+        measure: chord.measure,
+        beat: chord.beat
+      });
+    }
+    
+    devLog.debug(`リズムJSON: ${validatedChords.length}個のコードを読み込み`);
+    return validatedChords;
+    
+  } catch (error) {
+    devLog.debug('リズムJSON: パースエラー', error);
+    return null;
+  }
+};
+
+/**
+ * デモ用のコード進行データを生成
+ * @param allowedChords - 使用可能なコードリスト
+ * @param measureCount - 小節数
+ * @param timeSignature - 拍子
+ * @returns デモ用コード進行データ
+ */
+export const generateDemoProgression = (
+  allowedChords: string[],
+  measureCount: number,
+  _timeSignature: number
+): RhythmChordData[] => {
+  const progression: RhythmChordData[] = [];
+  
+  // 各小節の1拍目にコードを配置
+  for (let measure = 1; measure <= measureCount; measure++) {
+    const chordIndex = (measure - 1) % allowedChords.length;
+    progression.push({
+      chord: allowedChords[chordIndex],
+      measure: measure,
+      beat: 1
+    });
+  }
+  
+  return progression;
+};
+
+/**
+ * サンプルJSON生成（デバッグ・テスト用）
+ * @returns サンプルのリズムJSON文字列
+ */
+export const generateSampleJson = (): string => {
+  const sampleData: RhythmJsonData = {
+    chords: [
+      { beat: 1.0, chord: "C", measure: 1 },
+      { beat: 1.0, chord: "G", measure: 2 },
+      { beat: 1.0, chord: "Am", measure: 3 },
+      { beat: 1.0, chord: "F", measure: 4 },
+      { beat: 1.0, chord: "C", measure: 5 },
+      { beat: 1.0, chord: "Am", measure: 6 },
+      { beat: 1.0, chord: "Dm", measure: 7 },
+      { beat: 1.0, chord: "G", measure: 8 }
+    ]
+  };
+  
+  return JSON.stringify(sampleData, null, 2);
+};


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add Rhythm Mode to Fantasy Mode with timing-based gameplay, and explicitly name the existing mode "Quiz Mode."

---
<a href="https://cursor.com/background-agent?bcId=bc-63700aa6-29d6-4770-ac4d-aab1f796cb00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63700aa6-29d6-4770-ac4d-aab1f796cb00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>