### PR TITLE
Fix rhythm mode not activating

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -346,7 +346,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     rhythmEngineRef,
     updateRhythmMonsters
   } = useFantasyGameEngine({
-    stage: null, // ★★★ change
+    stage: stage, // ★★★ change from null to stage
     onGameStateChange: handleGameStateChange,
     onChordCorrect: handleChordCorrect,
     onChordIncorrect: handleChordIncorrect,

--- a/src/components/fantasy/FantasyRhythmEngine.tsx
+++ b/src/components/fantasy/FantasyRhythmEngine.tsx
@@ -249,6 +249,7 @@ export const FantasyRhythmEngine = forwardRef<
 
   // 判定処理（外部から呼び出される）
   const judge = useCallback((chordId: string, inputTime: number) => {
+    // inputTimeは既にゲーム時間として渡されている
     devLog.debug('🎵 Judge called:', {
       chordId,
       inputTime,
@@ -311,9 +312,11 @@ FantasyRhythmEngine.displayName = 'FantasyRhythmEngine';
 
 // 判定関数をエクスポート
 export const useRhythmJudge = (rhythmEngine: React.RefObject<{ judge: (chordId: string, inputTime: number) => RhythmJudgment | null }>) => {
+  const { startAt, readyDuration } = useTimeStore();
+  
   return useCallback((chordId: string) => {
     if (!rhythmEngine.current) return null;
-    const inputTime = performance.now();
+    const inputTime = performance.now() - (startAt || 0) - readyDuration;
     return rhythmEngine.current.judge(chordId, inputTime);
-  }, [rhythmEngine]);
+  }, [rhythmEngine, startAt, readyDuration]);
 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable Fantasy rhythm mode by fixing `isRhythmMode` detection, correctly passing stage data, and implementing rhythm-specific gauge updates.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `isRhythmMode` flag was always `false` due to `stage: null` being passed to `useFantasyGameEngine`, which prevented all rhythm-specific logic (monster updates, judgment window, and gauge progression) from executing. This PR ensures the mode is correctly activated and its features function as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-f11cd2ed-aea6-4edf-875f-01ee8fdaff8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f11cd2ed-aea6-4edf-875f-01ee8fdaff8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>