### PR TITLE
Add rhythm mode with judgment window

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -3,7 +3,7 @@
  * ゲームロジックとステート管理を担当
  */
 
-import React, { useState, useEffect, useCallback, useReducer, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { devLog } from '@/utils/logger';
 import { resolveChord } from '@/utils/chord-utils';
 import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,17 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chordProgressionData?: ChordProgressionData | null;
+}
+
+interface ChordProgressionData {
+  chords: ChordProgressionItem[];
+}
+
+interface ChordProgressionItem {
+  beat: number;
+  chord: string;
+  measure: number;
 }
 
 interface MonsterState {
@@ -91,6 +102,28 @@ interface FantasyGameState {
   simultaneousMonsterCount: number; // 同時表示数
   // ゲーム完了処理中フラグ
   isCompleting: boolean;
+  // リズムモード用
+  rhythmChords?: RhythmChord[];  // リズムモードで出題されるコード
+  currentRhythmIndex?: number;    // 現在のリズムコードインデックス
+  judgmentWindows?: JudgmentWindow[];  // 判定ウィンドウの配列
+}
+
+// リズムモードのコード情報
+interface RhythmChord {
+  chord: ChordDefinition;
+  measure: number;
+  beat: number;
+  timing: number;  // ミリ秒単位のタイミング
+  judged: boolean; // 判定済みかどうか
+}
+
+// 判定ウィンドウ
+interface JudgmentWindow {
+  chordId: string;
+  startTime: number;  // 判定開始時刻（ms）
+  endTime: number;    // 判定終了時刻（ms）
+  judged: boolean;    // 判定済みフラグ
+  success: boolean;   // 成功フラグ
 }
 
 interface FantasyGameEngineProps {
@@ -421,6 +454,9 @@ export const useFantasyGameEngine = ({
     const totalQuestions = totalEnemies * enemyHp;
     const simultaneousCount = stage.simultaneousMonsterCount || 1;
 
+    // リズムモードの場合、同時出現数は4で固定
+    const actualSimultaneousCount = stage.mode === 'rhythm' ? 4 : simultaneousCount;
+
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
     setStageMonsterIds(monsterIds);
@@ -472,7 +508,7 @@ export const useFantasyGameEngine = ({
     const monsterQueue = monsterIndices;
     
     // 初期モンスターを配置
-    const initialMonsterCount = Math.min(simultaneousCount, totalEnemies);
+    const initialMonsterCount = Math.min(actualSimultaneousCount, totalEnemies);
     const positions = assignPositions(initialMonsterCount);
     const activeMonsters: MonsterState[] = [];
     const usedChordIds: string[] = [];
@@ -485,7 +521,7 @@ export const useFantasyGameEngine = ({
     for (let i = 0; i < initialMonsterCount; i++) {
       const monsterIndex = monsterQueue.shift()!;
       // simultaneousMonsterCount === 1 のとき、0 番目のみ即生成。
-      if (i === 0 || simultaneousCount > 1) {
+      if (i === 0 || actualSimultaneousCount > 1) {
         const monster = createMonsterFromQueue(
           monsterIndex,
           positions[i],
@@ -504,6 +540,85 @@ export const useFantasyGameEngine = ({
     // 互換性のため最初のモンスターの情報を設定
     const firstMonster = activeMonsters[0];
     const firstChord = firstMonster ? firstMonster.chordTarget : null;
+
+    // リズムモード用の初期化
+    let rhythmChords: RhythmChord[] | undefined;
+    let judgmentWindows: JudgmentWindow[] | undefined;
+    
+    if (stage.mode === 'rhythm') {
+      const bpm = stage.bpm || 120;
+      const msPerBeat = 60000 / bpm;
+      const readyDuration = 2000; // Ready期間
+      const countInDuration = (stage.countInMeasures || 0) * (stage.timeSignature || 4) * msPerBeat;
+      const gameStartTime = readyDuration + countInDuration;
+      
+      if (stage.chordProgressionData?.chords) {
+        // コード進行パターン
+        rhythmChords = stage.chordProgressionData.chords.map((item, index) => {
+          const measureTime = (item.measure - 1) * (stage.timeSignature || 4) * msPerBeat;
+          const beatTime = (item.beat - 1) * msPerBeat;
+          const timing = gameStartTime + measureTime + beatTime;
+          
+          const chordDef = getChordDefinition(item.chord, displayOpts);
+          if (!chordDef) {
+            throw new Error(`Unknown chord: ${item.chord}`);
+          }
+          
+          return {
+            chord: chordDef,
+            measure: item.measure,
+            beat: item.beat,
+            timing,
+            judged: false
+          };
+        });
+        
+        // 判定ウィンドウを作成（前後200ms）
+        judgmentWindows = rhythmChords.map(rc => ({
+          chordId: rc.chord.id,
+          startTime: rc.timing - 200,
+          endTime: rc.timing + 200,
+          judged: false,
+          success: false
+        }));
+      } else {
+        // ランダムパターン - 各小節の1拍目にランダムにコードを配置
+        rhythmChords = [];
+        judgmentWindows = [];
+        
+        // 初期ループ分のコードを生成（後で動的に追加）
+        for (let measure = 1; measure <= (stage.measureCount || 8); measure++) {
+          const timing = gameStartTime + (measure - 1) * (stage.timeSignature || 4) * msPerBeat;
+          const randomChordId = stage.allowedChords[Math.floor(Math.random() * stage.allowedChords.length)];
+          const chordDef = getChordDefinition(randomChordId, displayOpts);
+          
+          if (chordDef) {
+            rhythmChords.push({
+              chord: chordDef,
+              measure,
+              beat: 1,
+              timing,
+              judged: false
+            });
+            
+            judgmentWindows.push({
+              chordId: chordDef.id,
+              startTime: timing - 200,
+              endTime: timing + 200,
+              judged: false,
+              success: false
+            });
+          }
+        }
+      }
+      
+      // リズムモードでは最初の4つのコードをモンスターに割り当て
+      activeMonsters.forEach((monster, index) => {
+        if (rhythmChords && index < rhythmChords.length) {
+          monster.chordTarget = rhythmChords[index].chord;
+        }
+      });
+    }
 
     const newState: FantasyGameState = {
       currentStage: stage,
@@ -531,9 +646,13 @@ export const useFantasyGameEngine = ({
       // マルチモンスター対応
       activeMonsters,
       monsterQueue,
-      simultaneousMonsterCount: simultaneousCount,
+      simultaneousMonsterCount: actualSimultaneousCount,
       // ゲーム完了処理中フラグ
-      isCompleting: false
+      isCompleting: false,
+      // リズムモード用
+      rhythmChords,
+      currentRhythmIndex: 0,
+      judgmentWindows
     };
 
     setGameState(newState);
@@ -562,6 +681,11 @@ export const useFantasyGameEngine = ({
   // 次の問題への移行（マルチモンスター対応）
   const proceedToNextQuestion = useCallback(() => {
     setGameState(prevState => {
+      // リズムモードは独自の進行管理を行うのでスキップ
+      if (prevState.currentStage?.mode === 'rhythm') {
+        return prevState;
+      }
+      
       const isComplete = prevState.enemiesDefeated >= prevState.totalEnemies;
       
       if (isComplete) {
@@ -746,7 +870,7 @@ export const useFantasyGameEngine = ({
   
   // 敵ゲージの更新（マルチモンスター対応）
   const updateEnemyGauge = useCallback(() => {
-    /* Ready 中はゲージ停止 */
+    // Ready 中は更新しない
     const timeState = useTimeStore.getState();
     if (timeState.startAt &&
         performance.now() - timeState.startAt < timeState.readyDuration) {
@@ -759,6 +883,159 @@ export const useFantasyGameEngine = ({
         return prevState;
       }
       
+      // リズムモードの場合は判定ウィンドウをチェック
+      if (prevState.currentStage.mode === 'rhythm' && prevState.judgmentWindows) {
+        const currentTime = performance.now() - (timeState.startAt || 0);
+        let updatedWindows = [...prevState.judgmentWindows];
+        let updatedRhythmChords = prevState.rhythmChords ? [...prevState.rhythmChords] : [];
+        let hasUpdate = false;
+        
+        // 新しいコードを追加する必要があるかチェック（無限ループ対応）
+        if (updatedRhythmChords.length > 0 && prevState.currentRhythmIndex !== undefined) {
+          const lastChord = updatedRhythmChords[updatedRhythmChords.length - 1];
+          const nextTiming = lastChord.timing + 2000; // 2秒先まで見る
+          
+          // 次のループのコードが必要な場合
+          if (currentTime + 2000 > lastChord.timing) {
+            const bpm = prevState.currentStage.bpm || 120;
+            const msPerBeat = 60000 / bpm;
+            const measureDuration = (prevState.currentStage.timeSignature || 4) * msPerBeat;
+            const loopDuration = (prevState.currentStage.measureCount || 8) * measureDuration;
+            
+            if (prevState.currentStage.chordProgressionData?.chords) {
+              // コード進行パターン - 次のループを追加
+              const baseTime = lastChord.timing + measureDuration;
+              const readyDuration = 2000; // Ready期間
+              const countInDuration = (prevState.currentStage.countInMeasures || 0) * (prevState.currentStage.timeSignature || 4) * msPerBeat;
+              const loopCount = Math.floor((baseTime - (readyDuration + countInDuration)) / loopDuration);
+              
+              prevState.currentStage.chordProgressionData.chords.forEach((item, index) => {
+                const measureTime = (item.measure - 1) * measureDuration;
+                const beatTime = (item.beat - 1) * msPerBeat;
+                const timing = baseTime + measureTime + beatTime - (loopCount * loopDuration);
+                
+                if (timing > lastChord.timing) {
+                  const chordDef = getChordDefinition(item.chord, displayOpts);
+                  if (chordDef) {
+                    updatedRhythmChords.push({
+                      chord: chordDef,
+                      measure: item.measure,
+                      beat: item.beat,
+                      timing,
+                      judged: false
+                    });
+                    
+                    updatedWindows.push({
+                      chordId: chordDef.id,
+                      startTime: timing - 200,
+                      endTime: timing + 200,
+                      judged: false,
+                      success: false
+                    });
+                  }
+                }
+              });
+            } else {
+              // ランダムパターン - 次の小節のコードを生成
+              const nextMeasure = (lastChord.measure % (prevState.currentStage.measureCount || 8)) + 1;
+              const timing = lastChord.timing + measureDuration;
+              const randomChordId = prevState.currentStage.allowedChords[
+                Math.floor(Math.random() * prevState.currentStage.allowedChords.length)
+              ];
+              const chordDef = getChordDefinition(randomChordId, displayOpts);
+              
+              if (chordDef) {
+                updatedRhythmChords.push({
+                  chord: chordDef,
+                  measure: nextMeasure,
+                  beat: 1,
+                  timing,
+                  judged: false
+                });
+                
+                updatedWindows.push({
+                  chordId: chordDef.id,
+                  startTime: timing - 200,
+                  endTime: timing + 200,
+                  judged: false,
+                  success: false
+                });
+              }
+            }
+          }
+        }
+        
+        // 判定ウィンドウをチェック
+        updatedWindows.forEach((window, index) => {
+          if (!window.judged && currentTime > window.endTime) {
+            // 判定ウィンドウを過ぎたら失敗扱い
+            window.judged = true;
+            window.success = false;
+            hasUpdate = true;
+            
+            // プレイヤーのHPを減少
+            const damage = Math.floor(Math.random() * 
+              (prevState.currentStage!.maxDamage - prevState.currentStage!.minDamage + 1)) + 
+              prevState.currentStage!.minDamage;
+            
+            // 敵の攻撃アニメーション（ランダムに1体選択）
+            const attackingMonster = prevState.activeMonsters[Math.floor(Math.random() * prevState.activeMonsters.length)];
+            if (attackingMonster) {
+              const { setEnrage } = useEnemyStore.getState();
+              setEnrage(attackingMonster.id, true);
+              setTimeout(() => setEnrage(attackingMonster.id, false), 500);
+              
+              // 攻撃エフェクトを発動
+              setTimeout(() => onEnemyAttack?.(attackingMonster.id), 0);
+            }
+            
+            // 次のコードに進む
+            if (prevState.rhythmChords && prevState.currentRhythmIndex !== undefined) {
+              const nextIndex = (prevState.currentRhythmIndex + 1) % prevState.rhythmChords.length;
+              const nextChords = prevState.rhythmChords.slice(nextIndex, nextIndex + 4);
+              
+              // モンスターに新しいコードを割り当て
+              const updatedMonsters = prevState.activeMonsters.map((monster, i) => {
+                if (nextChords[i]) {
+                  return {
+                    ...monster,
+                    chordTarget: nextChords[i].chord,
+                    correctNotes: []
+                  };
+                }
+                return monster;
+              });
+              
+              return {
+                ...prevState,
+                playerHp: Math.max(0, prevState.playerHp - damage),
+                judgmentWindows: updatedWindows,
+                rhythmChords: updatedRhythmChords,
+                currentRhythmIndex: nextIndex,
+                activeMonsters: updatedMonsters,
+                isGameOver: prevState.playerHp - damage <= 0,
+                gameResult: prevState.playerHp - damage <= 0 ? 'gameover' as const : null
+              };
+            }
+          }
+        });
+        
+        if (hasUpdate) {
+          onGameStateChange(prevState);
+          return prevState;
+        }
+        
+        // 新しいコードが追加された場合も状態を更新
+        if (updatedRhythmChords.length > (prevState.rhythmChords?.length || 0)) {
+          return {
+            ...prevState,
+            rhythmChords: updatedRhythmChords,
+            judgmentWindows: updatedWindows
+          };
+        }
+      }
+      
+      // クイズモードの既存のゲージ更新ロジック
       const incrementRate = 100 / (prevState.currentStage.enemyGaugeSeconds * 10); // 100ms間隔で更新
       
       // 各モンスターのゲージを更新
@@ -821,6 +1098,165 @@ export const useFantasyGameEngine = ({
       devLog.debug('🎹 ノート入力受信 (in updater):', { note, noteMod12: note % 12 });
 
       const noteMod12 = note % 12;
+      
+      // リズムモードの場合
+      if (prevState.currentStage?.mode === 'rhythm' && prevState.judgmentWindows && prevState.rhythmChords) {
+        const timeState = useTimeStore.getState();
+        const currentTime = performance.now() - (timeState.startAt || 0);
+        
+        // 現在のリズムインデックスから4つのアクティブなコードを取得
+        const startIdx = prevState.currentRhythmIndex || 0;
+        const activeRhythmChords = prevState.rhythmChords.slice(startIdx, startIdx + 4);
+        
+        // アクティブな判定ウィンドウをチェック
+        let windowFound = false;
+        for (let i = 0; i < 4 && startIdx + i < prevState.judgmentWindows.length; i++) {
+          const window = prevState.judgmentWindows[startIdx + i];
+          const rhythmChord = activeRhythmChords[i];
+          
+          if (!window.judged && 
+              currentTime >= window.startTime && 
+              currentTime <= window.endTime &&
+              rhythmChord) {
+            
+            // 対応するモンスターを見つける
+            const targetMonster = prevState.activeMonsters[i];
+            if (targetMonster) {
+              const targetNotes = [...new Set(targetMonster.chordTarget.notes.map(n => n % 12))];
+              
+              if (targetNotes.includes(noteMod12) && !targetMonster.correctNotes.includes(noteMod12)) {
+                windowFound = true;
+                const newCorrectNotes = [...targetMonster.correctNotes, noteMod12];
+                
+                // コードが完成したかチェック
+                if (newCorrectNotes.length === targetNotes.length) {
+                  // 判定成功
+                  const updatedWindows = [...prevState.judgmentWindows];
+                  updatedWindows[startIdx + i] = { ...window, judged: true, success: true };
+                  
+                  // モンスターにダメージ
+                  const damage = Math.floor(Math.random() * 
+                    (prevState.currentStage.maxDamage - prevState.currentStage.minDamage + 1)) + 
+                    prevState.currentStage.minDamage;
+                  
+                  targetMonster.currentHp -= damage;
+                  
+                  // 撃破チェック
+                  if (targetMonster.currentHp <= 0) {
+                    const newEnemiesDefeated = prevState.enemiesDefeated + 1;
+                    
+                    // 全敵撃破チェック
+                    if (newEnemiesDefeated >= prevState.totalEnemies) {
+                      const finalState = {
+                        ...prevState,
+                        enemiesDefeated: newEnemiesDefeated,
+                        isGameActive: false,
+                        isGameOver: true,
+                        gameResult: 'clear' as const,
+                        judgmentWindows: updatedWindows,
+                        score: prevState.score + 100
+                      };
+                      onGameComplete('clear', finalState);
+                      return finalState;
+                    }
+                    
+                    // 撃破したが、まだ敵が残っている場合
+                    const nextIndex = (startIdx + 1) % prevState.rhythmChords.length;
+                    const nextChords = prevState.rhythmChords.slice(nextIndex, nextIndex + 4);
+                    
+                    // モンスターに新しいコードを割り当て
+                    const updatedMonsters = prevState.activeMonsters.map((monster, idx) => {
+                      if (idx === i) {
+                        // 攻撃したモンスターの更新
+                        return {
+                          ...monster,
+                          currentHp: 0,
+                          correctNotes: monster.correctNotes
+                        };
+                      } else if (nextChords[idx]) {
+                        // 他のモンスターのコード更新
+                        return {
+                          ...monster,
+                          chordTarget: nextChords[idx].chord,
+                          correctNotes: []
+                        };
+                      }
+                      return monster;
+                    });
+                    
+                    // 正解時のコールバック
+                    onChordCorrect?.(targetMonster.chordTarget, false, damage, true, targetMonster.id);
+                    
+                    return {
+                      ...prevState,
+                      judgmentWindows: updatedWindows,
+                      currentRhythmIndex: nextIndex,
+                      activeMonsters: updatedMonsters,
+                      enemiesDefeated: newEnemiesDefeated,
+                      score: prevState.score + 100,
+                      correctAnswers: prevState.correctAnswers + 1
+                    };
+                  }
+                  
+                  // 次のコードに進む（モンスターは倒していない）
+                  const nextIndex = (startIdx + 1) % prevState.rhythmChords.length;
+                  const nextChords = prevState.rhythmChords.slice(nextIndex, nextIndex + 4);
+                  
+                  // モンスターに新しいコードを割り当て
+                  const updatedMonsters = prevState.activeMonsters.map((monster, idx) => {
+                    if (idx === i) {
+                      // 攻撃したモンスターの更新
+                      return {
+                        ...monster,
+                        currentHp: targetMonster.currentHp,
+                        correctNotes: targetMonster.currentHp > 0 ? [] : monster.correctNotes
+                      };
+                    } else if (nextChords[idx]) {
+                      // 他のモンスターのコード更新
+                      return {
+                        ...monster,
+                        chordTarget: nextChords[idx].chord,
+                        correctNotes: []
+                      };
+                    }
+                    return monster;
+                  });
+                  
+                  // 正解時のコールバック
+                  onChordCorrect?.(targetMonster.chordTarget, false, damage, targetMonster.currentHp <= 0, targetMonster.id);
+                  
+                  return {
+                    ...prevState,
+                    judgmentWindows: updatedWindows,
+                    currentRhythmIndex: nextIndex,
+                    activeMonsters: updatedMonsters,
+                    enemiesDefeated: targetMonster.currentHp <= 0 ? prevState.enemiesDefeated + 1 : prevState.enemiesDefeated,
+                    score: prevState.score + 100,
+                    correctAnswers: prevState.correctAnswers + 1
+                  };
+                } else {
+                  // まだコード未完成
+                  const updatedMonsters = prevState.activeMonsters.map((m, idx) => 
+                    idx === i ? { ...m, correctNotes: newCorrectNotes } : m
+                  );
+                  
+                  return {
+                    ...prevState,
+                    activeMonsters: updatedMonsters
+                  };
+                }
+              }
+            }
+          }
+        }
+        
+        // 判定ウィンドウ外の入力は無視
+        if (!windowFound) {
+          return prevState;
+        }
+      }
+      
+      // クイズモードの既存ロジック
       const completedMonsters: MonsterState[] = [];
       let hasAnyNoteChanged = false;
 

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression' | 'rhythm';
+  mode: 'single' | 'progression' | 'quiz' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -784,7 +784,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
               <div className="flex justify-center items-start w-full mx-auto gap-0" style={{ height: 'min(120px,22vw)' }}>
                 {gameState.activeMonsters
                   .sort((a, b) => a.position.localeCompare(b.position)) // 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'順でソート
-                  .map((monster) => {
+                  .map((monster, monsterIndex) => {
                     // モンスター数に応じて幅を動的に計算
                     const monsterCount = gameState.activeMonsters.length;
                     let widthPercent: string;
@@ -828,14 +828,65 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         className="flex-shrink-0 flex flex-col items-center"
                         style={{ width: widthPercent, maxWidth }} // 動的に幅を設定
                       >
-                      {/* コードネーム */}
-                      <div className={`text-yellow-300 font-bold text-center mb-1 truncate w-full ${
-                        monsterCount > 5 ? 'text-sm' : monsterCount > 3 ? 'text-base' : 'text-xl'
-                      }`}>
+                      {/* コード名 */}
+                      <div className={`font-bold ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'} mb-0.5`}>
                         {monster.chordTarget.displayName}
                       </div>
                       
-                      {/* ★★★ ここにヒント表示を追加 ★★★ */}
+                      {/* リズムモード用の判定サークル */}
+                      {stage.mode === 'rhythm' && gameState.rhythmChords && gameState.currentRhythmIndex !== undefined && (
+                        <div className="absolute inset-0 pointer-events-none">
+                          {(() => {
+                            // 現在のリズムコードインデックスを取得
+                            const rhythmIndex = gameState.currentRhythmIndex + monsterIndex;
+                            const rhythmChord = gameState.rhythmChords[rhythmIndex % gameState.rhythmChords.length];
+                            
+                            if (!rhythmChord) return null;
+                            
+                            // 現在時刻と判定タイミングまでの時間を計算
+                            const currentTime = performance.now() - (startAt || 0);
+                            const timeUntilJudgment = rhythmChord.timing - currentTime;
+                            const judgmentWindowSize = 400; // 判定ウィンドウの前後200ms
+                            
+                            // 判定ウィンドウ内かどうか
+                            const inWindow = Math.abs(timeUntilJudgment) <= 200;
+                            
+                            // サークルのサイズとアニメーション（1秒前から表示開始）
+                            const showCircle = timeUntilJudgment <= 1000 && timeUntilJudgment >= -200;
+                            const circleScale = showCircle ? Math.max(0, 1 - (timeUntilJudgment / 1000)) : 0;
+                            
+                            return showCircle ? (
+                              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+                                {/* 外側のサークル（アプローチサークル） */}
+                                <div 
+                                  className={`absolute rounded-full border-2 ${
+                                    inWindow ? 'border-green-400' : 'border-blue-400'
+                                  } transition-all duration-100`}
+                                  style={{
+                                    width: `${60 + (1 - circleScale) * 40}px`,
+                                    height: `${60 + (1 - circleScale) * 40}px`,
+                                    transform: 'translate(-50%, -50%)',
+                                    opacity: circleScale
+                                  }}
+                                />
+                                {/* 内側のサークル（判定サークル） */}
+                                <div 
+                                  className={`absolute rounded-full border-2 ${
+                                    inWindow ? 'border-green-400 bg-green-400/20' : 'border-gray-400'
+                                  }`}
+                                  style={{
+                                    width: '60px',
+                                    height: '60px',
+                                    transform: 'translate(-50%, -50%)'
+                                  }}
+                                />
+                              </div>
+                            ) : null;
+                          })()}
+                        </div>
+                      )}
+                      
+                      {/* コード構成音表示 */}
                       <div className={`mt-1 font-medium h-6 text-center ${
                         monsterCount > 5 ? 'text-xs' : 'text-sm'
                       }`}>
@@ -881,17 +932,19 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       )}
                       
                       {/* 行動ゲージ */}
-                      <div 
-                        ref={el => {
-                          if (el) gaugeRefs.current.set(monster.id, el);
-                        }}
-                        className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
-                      >
-                        <div
-                          className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
-                          style={{ width: `${monster.gauge}%` }}
-                        />
-                      </div>
+                      {stage.mode !== 'rhythm' && (
+                        <div 
+                          ref={el => {
+                            if (el) gaugeRefs.current.set(monster.id, el);
+                          }}
+                          className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
+                        >
+                          <div
+                            className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
+                            style={{ width: `${monster.gauge}%` }}
+                          />
+                        </div>
+                      )}
                       
                       {/* HPゲージ */}
                       <div className="w-full h-3 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative">

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -835,55 +835,61 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       
                       {/* リズムモード用の判定サークル */}
                       {stage.mode === 'rhythm' && gameState.rhythmChords && gameState.currentRhythmIndex !== undefined && (
-                        <div className="absolute inset-0 pointer-events-none">
-                          {(() => {
-                            // 現在のリズムコードインデックスを取得
-                            const rhythmIndex = gameState.currentRhythmIndex + monsterIndex;
-                            const rhythmChord = gameState.rhythmChords[rhythmIndex % gameState.rhythmChords.length];
-                            
-                            if (!rhythmChord) return null;
-                            
-                            // 現在時刻と判定タイミングまでの時間を計算
-                            const currentTime = performance.now() - (startAt || 0);
-                            const timeUntilJudgment = rhythmChord.timing - currentTime;
-                            const judgmentWindowSize = 400; // 判定ウィンドウの前後200ms
-                            
-                            // 判定ウィンドウ内かどうか
-                            const inWindow = Math.abs(timeUntilJudgment) <= 200;
-                            
-                            // サークルのサイズとアニメーション（1秒前から表示開始）
-                            const showCircle = timeUntilJudgment <= 1000 && timeUntilJudgment >= -200;
-                            const circleScale = showCircle ? Math.max(0, 1 - (timeUntilJudgment / 1000)) : 0;
-                            
-                            return showCircle ? (
-                              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-                                {/* 外側のサークル（アプローチサークル） */}
-                                <div 
-                                  className={`absolute rounded-full border-2 ${
-                                    inWindow ? 'border-green-400' : 'border-blue-400'
-                                  } transition-all duration-100`}
-                                  style={{
-                                    width: `${60 + (1 - circleScale) * 40}px`,
-                                    height: `${60 + (1 - circleScale) * 40}px`,
-                                    transform: 'translate(-50%, -50%)',
-                                    opacity: circleScale
-                                  }}
-                                />
-                                {/* 内側のサークル（判定サークル） */}
-                                <div 
-                                  className={`absolute rounded-full border-2 ${
-                                    inWindow ? 'border-green-400 bg-green-400/20' : 'border-gray-400'
-                                  }`}
-                                  style={{
-                                    width: '60px',
-                                    height: '60px',
-                                    transform: 'translate(-50%, -50%)'
-                                  }}
-                                />
-                              </div>
-                            ) : null;
-                          })()}
-                        </div>
+                        (() => {
+                          // 現在のリズムコードインデックスを取得
+                          const rhythmIndex = gameState.currentRhythmIndex + monsterIndex;
+                          const rhythmChord = gameState.rhythmChords[rhythmIndex % gameState.rhythmChords.length];
+                          
+                          if (!rhythmChord) return null;
+                          
+                          // 現在時刻と判定タイミングまでの時間を計算
+                          const currentTime = performance.now() - (startAt || 0);
+                          const timeUntilJudgment = rhythmChord.timing - currentTime;
+                          
+                          // 判定ウィンドウ内かどうか
+                          const inWindow = Math.abs(timeUntilJudgment) <= 200;
+                          
+                          // サークルのサイズとアニメーション（1秒前から表示開始）
+                          const showCircle = timeUntilJudgment <= 1000 && timeUntilJudgment >= -200;
+                          const circleScale = showCircle ? Math.max(0, 1 - (timeUntilJudgment / 1000)) : 0;
+                          
+                          return showCircle ? (
+                            <div className="absolute pointer-events-none" style={{
+                              top: '70%',  // コード名の下に配置
+                              left: '50%',
+                              transform: 'translate(-50%, -50%)',
+                              zIndex: 10
+                            }}>
+                              {/* 外側のサークル（アプローチサークル） */}
+                              <div 
+                                className={`absolute rounded-full border-2 ${
+                                  inWindow ? 'border-green-400' : 'border-blue-400'
+                                } transition-all duration-100`}
+                                style={{
+                                  width: `${60 + (1 - circleScale) * 40}px`,
+                                  height: `${60 + (1 - circleScale) * 40}px`,
+                                  left: '50%',
+                                  top: '50%',
+                                  transform: 'translate(-50%, -50%)',
+                                  opacity: circleScale
+                                }}
+                              />
+                              {/* 内側のサークル（判定サークル） */}
+                              <div 
+                                className={`absolute rounded-full border-2 ${
+                                  inWindow ? 'border-green-400 bg-green-400/20' : 'border-gray-400'
+                                }`}
+                                style={{
+                                  width: '60px',
+                                  height: '60px',
+                                  left: '50%',
+                                  top: '50%',
+                                  transform: 'translate(-50%, -50%)'
+                                }}
+                              />
+                            </div>
+                          ) : null;
+                        })()
                       )}
                       
                       {/* コード構成音表示 */}

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -381,7 +381,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression' | 'rhythm',
+        mode: nextStageData.mode as 'single' | 'progression' | 'quiz' | 'rhythm',
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -381,7 +381,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression',
+        mode: nextStageData.mode as 'single' | 'progression' | 'rhythm',
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,
@@ -392,7 +392,8 @@ const FantasyMain: React.FC = () => {
         bpm: nextStageData.bpm || 120,
         measureCount: nextStageData.measure_count,
         countInMeasures: nextStageData.count_in_measures,
-        timeSignature: nextStageData.time_signature
+        timeSignature: nextStageData.time_signature,
+        chordProgressionData: nextStageData.chord_progression_data || null
       };
 
       setGameResult(null);

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression' | 'rhythm',
+                  mode: stage.mode as 'single' | 'progression' | 'quiz' | 'rhythm',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+        mode: stage.mode as 'single' | 'progression' | 'rhythm',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,
@@ -170,7 +170,8 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
         countInMeasures: stage.count_in_measures,
-        timeSignature: stage.time_signature
+        timeSignature: stage.time_signature,
+        chordProgressionData: stage.chord_progression_data || null
       }));
       
       const convertedProgress: FantasyUserProgress = {
@@ -299,6 +300,18 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモード情報 */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="mt-2 flex gap-2 text-xs">
+              <span className="px-2 py-1 bg-purple-600/50 rounded-full text-purple-200">
+                リズムモード
+              </span>
+              <span className="px-2 py-1 bg-blue-600/50 rounded-full text-blue-200">
+                {stage.chordProgressionData ? 'コード進行' : 'ランダム'}
+              </span>
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/components/fantasy/__tests__/FantasyGameEngine.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyGameEngine.test.tsx
@@ -4,6 +4,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as PIXI from 'pixi.js';
 import FantasyGameEngine from '../FantasyGameEngine';
 import { getStageMonsterIds } from '@/data/monsters';
+import type { FantasyStage, FantasyGameState } from '@/types';
 
 // Mock PIXI.js
 vi.mock('pixi.js', () => ({
@@ -34,7 +35,7 @@ vi.mock('@/utils/logger', () => ({
 }));
 
 describe('FantasyGameEngine - Monster Image Preloading', () => {
-  const mockStage = {
+  const mockStage: FantasyStage = {
     id: 'test-stage',
     stageNumber: '1-1',
     name: 'Test Stage',
@@ -173,5 +174,64 @@ describe('FantasyGameEngine - Monster Image Preloading', () => {
 
     // Component should still render even if image loading fails
     expect(container).toBeTruthy();
+  });
+});
+
+describe('FantasyGameEngine - Rhythm Mode', () => {
+  const mockRhythmStage: FantasyStage = {
+    id: 'rhythm-test',
+    stageNumber: '1-1',
+    name: 'Rhythm Test Stage',
+    description: 'Test rhythm mode',
+    maxHp: 10,
+    enemyGaugeSeconds: 10,
+    enemyCount: 10,
+    enemyHp: 5,
+    minDamage: 1,
+    maxDamage: 2,
+    mode: 'rhythm' as const,
+    allowedChords: ['C', 'G', 'Am', 'F'],
+    showSheetMusic: true,
+    showGuide: true,
+    monsterIcon: 'test-icon',
+    simultaneousMonsterCount: 4,
+    bpm: 120,
+    measureCount: 8,
+    countInMeasures: 1,
+    timeSignature: 4,
+    chordProgressionData: {
+      chords: [
+        { beat: 1, chord: 'C', measure: 1 },
+        { beat: 1, chord: 'G', measure: 2 },
+        { beat: 1, chord: 'Am', measure: 3 },
+        { beat: 1, chord: 'F', measure: 4 }
+      ]
+    }
+  };
+
+  test('initializes rhythm mode with judgment windows', () => {
+    let gameState: FantasyGameState | null = null;
+    
+    render(
+      <FantasyGameEngine
+        stage={mockRhythmStage}
+        onGameStateChange={(state) => { gameState = state; }}
+        onChordCorrect={vi.fn()}
+        onChordIncorrect={vi.fn()}
+        onGameComplete={vi.fn()}
+        onEnemyAttack={vi.fn()}
+        displayOpts={{ lang: 'en', simple: false }}
+      />
+    );
+    
+    // Check that rhythm chords and judgment windows are created
+    expect(gameState).toBeTruthy();
+    expect(gameState?.rhythmChords).toBeDefined();
+    expect(gameState?.rhythmChords?.length).toBeGreaterThan(0);
+    expect(gameState?.judgmentWindows).toBeDefined();
+    expect(gameState?.judgmentWindows?.length).toBe(gameState?.rhythmChords?.length);
+    
+    // Check that 4 monsters are created for rhythm mode
+    expect(gameState?.activeMonsters.length).toBe(4);
   });
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,6 @@
 // Setup file for tests
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
@@ -19,7 +20,7 @@ Object.defineProperty(window, 'matchMedia', {
 // Mock IntersectionObserver
 global.IntersectionObserver = class IntersectionObserver {
   constructor() {}
-  disconnect() {}
   observe() {}
   unobserve() {}
-};
+  disconnect() {}
+} as any;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -635,7 +635,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;
@@ -648,6 +648,18 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: ChordProgressionData | null;
+}
+
+// Rhythm mode chord progression data structure
+export interface ChordProgressionData {
+  chords: ChordProgressionItem[];
+}
+
+export interface ChordProgressionItem {
+  beat: number;
+  chord: string;
+  measure: number;
 }
 
 export interface LessonContext {


### PR DESCRIPTION
Add 'quiz' mode to fantasy stage mode types to align with the new game mode structure.

The task involved introducing a new "rhythm mode" and reclassifying existing modes as "quiz mode". This PR updates the mode type definition to explicitly include 'quiz', allowing the existing 'single' and 'progression' modes to be categorized under 'quiz', while 'rhythm' mode handles the new rhythm-specific gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-08e44806-874b-4731-85f6-06ef2034a4db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08e44806-874b-4731-85f6-06ef2034a4db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>