### PR TITLE
Add rhythm mode with judgment window

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,14 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  mp3Url?: string;
+  chordProgressionData?: {
+    chords: {
+      beat: number;
+      chord: string;
+      measure: number;
+    }[];
+  };
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyRhythmEngine.tsx
+++ b/src/components/fantasy/FantasyRhythmEngine.tsx
@@ -1,0 +1,323 @@
+/**
+ * ファンタジーリズムエンジン
+ * リズムモードのゲームロジックとステート管理を担当
+ */
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { devLog } from '@/utils/logger';
+import { resolveChord } from '@/utils/chord-utils';
+import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';
+import { useTimeStore } from '@/stores/timeStore';
+import { note as parseNote } from 'tonal';
+import { FantasyStage } from './FantasyGameEngine';
+
+// ===== 型定義 =====
+
+interface ChordDefinition {
+  id: string;
+  displayName: string;
+  notes: number[];
+  noteNames: string[];
+  quality: string;
+  root: string;
+}
+
+interface RhythmChordEvent {
+  chord: ChordDefinition;
+  measure: number;
+  beat: number;
+  timingMs: number; // 曲の開始からのミリ秒
+  window: {
+    start: number;
+    end: number;
+  };
+  status: 'pending' | 'success' | 'miss';
+}
+
+interface RhythmGameState {
+  isActive: boolean;
+  currentChordEvents: RhythmChordEvent[];
+  nextChordEvents: RhythmChordEvent[];
+  playerHp: number;
+  enemiesDefeated: number;
+  totalEnemies: number;
+  score: number;
+  combo: number;
+  maxCombo: number;
+  isGameOver: boolean;
+  gameResult: 'clear' | 'gameover' | null;
+}
+
+interface RhythmEngineProps {
+  stage: FantasyStage;
+  isActive: boolean;
+  currentInput: number[];
+  onGameStateChange: (state: RhythmGameState) => void;
+  onChordComplete: (chordId: string) => void;
+  onMiss: () => void;
+  onInputClear: () => void;
+  displayOpts: DisplayOpts;
+}
+
+// 判定ウィンドウの設定（前後200ms）
+const JUDGMENT_WINDOW_MS = 200;
+
+export const FantasyRhythmEngine: React.FC<RhythmEngineProps> = ({
+  stage,
+  isActive,
+  currentInput,
+  onGameStateChange,
+  onChordComplete,
+  onMiss,
+  onInputClear,
+  displayOpts
+}) => {
+  const [gameState, setGameState] = useState<RhythmGameState>({
+    isActive: false,
+    currentChordEvents: [],
+    nextChordEvents: [],
+    playerHp: stage?.maxHp || 5,
+    enemiesDefeated: 0,
+    totalEnemies: stage?.enemyCount || 10,
+    score: 0,
+    combo: 0,
+    maxCombo: 0,
+    isGameOver: false,
+    gameResult: null
+  });
+
+  const { currentMeasure, isCountIn, startAt, readyDuration, bpm } = useTimeStore();
+  const chordQueueRef = useRef<RhythmChordEvent[]>([]);
+  const processedEventsRef = useRef<Set<string>>(new Set());
+  const lastGeneratedMeasureRef = useRef<number>(0);
+
+  // BPMから1拍のミリ秒を計算
+  const beatMs = useMemo(() => 60000 / bpm, [bpm]);
+
+  // チャートデータからチードイベントを生成
+  const generateChordEvent = useCallback((chordId: string, measure: number, beat: number): RhythmChordEvent => {
+    const chordDef = resolveChord(chordId);
+    if (!chordDef) {
+      throw new Error(`Invalid chord: ${chordId}`);
+    }
+    
+    const displayName = toDisplayChordName(chordDef.root, chordDef.quality, displayOpts);
+    
+    // 曲開始からのタイミングを計算（カウントイン後を基準に）
+    const measuresFromStart = measure - 1;
+    const beatsFromStart = measuresFromStart * (stage?.timeSignature || 4) + (beat - 1);
+    const timingMs = beatsFromStart * beatMs;
+    
+    // MIDIノート番号に変換
+    const notesNumbers = chordDef.notes.map((note, index) => {
+      // ルート音は3オクターブ、その他は4オクターブ
+      const octave = index === 0 ? 3 : 4;
+      return parseNote(`${note}${octave}`).midi || 60;
+    });
+    
+    return {
+      chord: {
+        id: chordId,
+        displayName,
+        notes: notesNumbers,
+        noteNames: chordDef.notes,
+        quality: chordDef.quality,
+        root: chordDef.root
+      },
+      measure,
+      beat,
+      timingMs,
+      window: {
+        start: timingMs - JUDGMENT_WINDOW_MS,
+        end: timingMs + JUDGMENT_WINDOW_MS
+      },
+      status: 'pending'
+    };
+  }, [beatMs, stage?.timeSignature, displayOpts]);
+
+  // チードイベントの生成（ランダムまたはプログレッション）
+  const generateChordEvents = useCallback(() => {
+    if (!stage || !isActive) return;
+
+    const events: RhythmChordEvent[] = [];
+
+    if (stage.chordProgressionData?.chords) {
+      // プログレッションモード
+      const progressionChords = stage.chordProgressionData.chords;
+      
+      // 現在の小節から次の数小節分のイベントを生成
+      for (let m = currentMeasure; m <= currentMeasure + 4; m++) {
+        for (const chord of progressionChords) {
+          // ループを考慮した小節番号の計算
+          const loopedMeasure = ((m - 1) % stage.measureCount) + 1;
+          
+          if (chord.measure === loopedMeasure) {
+            const eventKey = `${loopedMeasure}-${chord.beat}-${chord.chord}`;
+            if (!processedEventsRef.current.has(eventKey)) {
+              events.push(generateChordEvent(chord.chord, m, chord.beat));
+              processedEventsRef.current.add(eventKey);
+            }
+          }
+        }
+      }
+    } else {
+      // ランダムモード（1小節に1回）
+      for (let m = currentMeasure; m <= currentMeasure + 4; m++) {
+        if (m > lastGeneratedMeasureRef.current) {
+          const randomChord = stage.allowedChords[Math.floor(Math.random() * stage.allowedChords.length)];
+          events.push(generateChordEvent(randomChord, m, 1));
+          lastGeneratedMeasureRef.current = m;
+        }
+      }
+    }
+
+    chordQueueRef.current = [...chordQueueRef.current, ...events];
+  }, [stage, isActive, currentMeasure, generateChordEvent]);
+
+  // 現在時刻の取得
+  const getCurrentTime = useCallback(() => {
+    if (!startAt || isCountIn) return 0;
+    return performance.now() - startAt - readyDuration;
+  }, [startAt, readyDuration, isCountIn]);
+
+  // 判定処理
+  const judgeInput = useCallback(() => {
+    if (!isActive || currentInput.length === 0) return;
+
+    const currentTime = getCurrentTime();
+    const activeEvents = gameState.currentChordEvents.filter(e => e.status === 'pending');
+
+    for (const event of activeEvents) {
+      // 判定ウィンドウ内かチェック
+      if (currentTime >= event.window.start && currentTime <= event.window.end) {
+        // 入力されたコードが正解かチェック
+        const inputNotes = [...currentInput].sort((a, b) => a - b);
+        const targetNotes = [...event.chord.notes].sort((a, b) => a - b);
+        
+        if (inputNotes.length === targetNotes.length &&
+            inputNotes.every((note, index) => note === targetNotes[index])) {
+          // 正解
+          event.status = 'success';
+          onChordComplete(event.chord.id);
+          onInputClear(); // 入力をクリア
+          
+          setGameState(prev => ({
+            ...prev,
+            enemiesDefeated: prev.enemiesDefeated + 1,
+            score: prev.score + 100 * (prev.combo + 1),
+            combo: prev.combo + 1,
+            maxCombo: Math.max(prev.maxCombo, prev.combo + 1)
+          }));
+          
+          devLog.debug('fantasy-rhythm', 'Chord hit!', { chord: event.chord.id, time: currentTime });
+          break;
+        }
+      }
+    }
+  }, [isActive, currentInput, getCurrentTime, gameState.currentChordEvents, onChordComplete, onInputClear]);
+
+  // ミス判定処理
+  const checkMissedEvents = useCallback(() => {
+    if (!isActive) return;
+
+    const currentTime = getCurrentTime();
+    const updatedEvents = gameState.currentChordEvents.map(event => {
+      if (event.status === 'pending' && currentTime > event.window.end) {
+        // ミス
+        onMiss();
+        
+        setGameState(prev => ({
+          ...prev,
+          playerHp: Math.max(0, prev.playerHp - 1),
+          combo: 0
+        }));
+        
+        devLog.debug('fantasy-rhythm', 'Chord missed!', { chord: event.chord.id, time: currentTime });
+        
+        return { ...event, status: 'miss' as const };
+      }
+      return event;
+    });
+
+    // アクティブなイベントを更新
+    const activeEvents = updatedEvents.filter(e => 
+      e.timingMs > currentTime - 2000 && // 2秒前まで表示
+      e.timingMs < currentTime + 4000    // 4秒先まで表示
+    );
+
+    setGameState(prev => ({
+      ...prev,
+      currentChordEvents: activeEvents
+    }));
+  }, [isActive, getCurrentTime, gameState.currentChordEvents, onMiss]);
+
+  // ゲーム終了判定
+  useEffect(() => {
+    if (gameState.playerHp <= 0 && !gameState.isGameOver) {
+      setGameState(prev => ({
+        ...prev,
+        isGameOver: true,
+        gameResult: 'gameover'
+      }));
+    } else if (gameState.enemiesDefeated >= gameState.totalEnemies && !gameState.isGameOver) {
+      setGameState(prev => ({
+        ...prev,
+        isGameOver: true,
+        gameResult: 'clear'
+      }));
+    }
+  }, [gameState.playerHp, gameState.enemiesDefeated, gameState.totalEnemies, gameState.isGameOver]);
+
+  // ゲーム状態の初期化
+  useEffect(() => {
+    if (isActive && stage) {
+      setGameState({
+        isActive: true,
+        currentChordEvents: [],
+        nextChordEvents: [],
+        playerHp: stage.maxHp,
+        enemiesDefeated: 0,
+        totalEnemies: stage.enemyCount,
+        score: 0,
+        combo: 0,
+        maxCombo: 0,
+        isGameOver: false,
+        gameResult: null
+      });
+      processedEventsRef.current.clear();
+      lastGeneratedMeasureRef.current = 0;
+    }
+  }, [isActive, stage]);
+
+  // チードイベントの生成タイミング
+  useEffect(() => {
+    if (isActive && !isCountIn && currentMeasure > 0) {
+      generateChordEvents();
+    }
+  }, [isActive, isCountIn, currentMeasure, generateChordEvents]);
+
+  // 入力判定
+  useEffect(() => {
+    judgeInput();
+  }, [currentInput, judgeInput]);
+
+  // ミス判定の定期チェック
+  useEffect(() => {
+    if (!isActive) return;
+
+    const interval = setInterval(() => {
+      checkMissedEvents();
+    }, 16); // 60fps
+
+    return () => clearInterval(interval);
+  }, [isActive, checkMissedEvents]);
+
+  // 親コンポーネントへの状態通知
+  useEffect(() => {
+    onGameStateChange(gameState);
+  }, [gameState, onGameStateChange]);
+
+  return null; // このコンポーネントは描画しない（ロジックのみ）
+};
+
+export default FantasyRhythmEngine;

--- a/src/components/fantasy/FantasyRhythmLane.tsx
+++ b/src/components/fantasy/FantasyRhythmLane.tsx
@@ -1,0 +1,141 @@
+/**
+ * ファンタジーリズムレーン
+ * 太鼓の達人風のノーツ表示UIコンポーネント
+ */
+
+import React, { useMemo } from 'react';
+import { useTimeStore } from '@/stores/timeStore';
+
+interface ChordNote {
+  chord: {
+    id: string;
+    displayName: string;
+  };
+  measure: number;
+  beat: number;
+  timingMs: number;
+  status: 'pending' | 'success' | 'miss';
+}
+
+interface RhythmLaneProps {
+  chordEvents: ChordNote[];
+  laneWidth?: number;
+  noteSpeed?: number; // ピクセル/秒
+  bpm?: number;
+  combo?: number;
+}
+
+const JUDGMENT_LINE_POSITION = 150; // 判定ラインの位置（左から）
+const NOTE_SIZE = 60; // ノーツのサイズ
+
+export const FantasyRhythmLane: React.FC<RhythmLaneProps> = ({
+  chordEvents,
+  laneWidth = 800,
+  noteSpeed = 300,
+  bpm = 120,
+  combo = 0
+}) => {
+  const { startAt, readyDuration, isCountIn } = useTimeStore();
+  
+  // 現在の経過時間を計算
+  const currentTime = useMemo(() => {
+    if (!startAt || isCountIn) return 0;
+    return performance.now() - startAt - readyDuration;
+  }, [startAt, readyDuration, isCountIn]);
+
+  // ノーツの位置を計算
+  const notePositions = useMemo(() => {
+    return chordEvents.map(event => {
+      const timeUntilNote = event.timingMs - currentTime;
+      const xPosition = JUDGMENT_LINE_POSITION + (timeUntilNote / 1000) * noteSpeed;
+      
+      return {
+        ...event,
+        x: xPosition,
+        visible: xPosition > -NOTE_SIZE && xPosition < laneWidth
+      };
+    });
+  }, [chordEvents, currentTime, noteSpeed, laneWidth]);
+
+  return (
+    <div className="relative w-full h-32 overflow-hidden bg-gray-900 rounded-lg">
+      {/* レーン背景 */}
+      <div className="absolute inset-0 bg-gradient-to-r from-gray-800 to-gray-900 opacity-50" />
+      
+      {/* レーンライン */}
+      <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-gray-600" />
+      <div className="absolute top-1/2 left-0 right-0 h-0.5 bg-gray-700 -translate-y-1/2" />
+      
+      {/* 判定ライン */}
+      <div 
+        className="absolute top-0 bottom-0 w-1 bg-yellow-400"
+        style={{ left: `${JUDGMENT_LINE_POSITION}px` }}
+      >
+        {/* 判定エリアの円 */}
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+          <div className="w-20 h-20 rounded-full border-4 border-yellow-400 bg-yellow-400/20" />
+          <div className="absolute inset-0 w-20 h-20 rounded-full border-2 border-yellow-300 animate-pulse" />
+        </div>
+      </div>
+      
+      {/* ノーツ */}
+      {notePositions.map((note, index) => {
+        if (!note.visible) return null;
+        
+        const noteColor = note.status === 'success' ? 'bg-green-500' : 
+                         note.status === 'miss' ? 'bg-red-500' : 
+                         'bg-blue-500';
+        
+        const noteOpacity = note.status === 'success' ? 'opacity-50' :
+                           note.status === 'miss' ? 'opacity-30' :
+                           'opacity-100';
+        
+        return (
+          <div
+            key={`${note.chord.id}-${note.measure}-${note.beat}-${index}`}
+            className={`absolute top-1/2 -translate-y-1/2 transition-all duration-100 ${noteOpacity}`}
+            style={{
+              left: `${note.x - NOTE_SIZE / 2}px`,
+              width: `${NOTE_SIZE}px`,
+              height: `${NOTE_SIZE}px`
+            }}
+          >
+            {/* ノーツの円 */}
+            <div className={`w-full h-full rounded-full ${noteColor} shadow-lg relative`}>
+              {/* 内側の円 */}
+              <div className="absolute inset-2 rounded-full bg-white/20" />
+              
+              {/* コード名 */}
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-white font-bold text-lg drop-shadow-md">
+                  {note.chord.displayName}
+                </span>
+              </div>
+              
+              {/* 成功/失敗エフェクト */}
+              {note.status === 'success' && (
+                <div className="absolute inset-0 rounded-full animate-ping bg-green-400" />
+              )}
+              {note.status === 'miss' && (
+                <div className="absolute inset-0 rounded-full animate-ping bg-red-400" />
+              )}
+            </div>
+          </div>
+        );
+      })}
+      
+      {/* スコア表示エリア（左上） */}
+      <div className="absolute top-2 left-2 text-white">
+        <div className="text-xs opacity-70">COMBO</div>
+        <div className="text-xl font-bold">{combo}</div>
+      </div>
+      
+      {/* BPM表示（右上） */}
+      <div className="absolute top-2 right-2 text-white text-xs opacity-70">
+        BPM {bpm}
+      </div>
+    </div>
+  );
+};
+
+export default FantasyRhythmLane;

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -299,6 +299,29 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモード表示 */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-xs bg-yellow-600 text-white px-2 py-1 rounded">
+                リズムモード
+              </span>
+              {stage.chordProgressionData ? (
+                <span className="text-xs bg-blue-600 text-white px-2 py-1 rounded">
+                  コード進行
+                </span>
+              ) : (
+                <span className="text-xs bg-green-600 text-white px-2 py-1 rounded">
+                  ランダム
+                </span>
+              )}
+              {stage.bpm && (
+                <span className="text-xs text-gray-400">
+                  BPM {stage.bpm}
+                </span>
+              )}
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -635,7 +635,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;
@@ -648,6 +648,13 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: {
+    chords: {
+      beat: number;
+      chord: string;
+      measure: number;
+    }[];
+  };
 }
 
 export interface LessonContext {

--- a/supabase/migrations/20250201000000_add_rhythm_mode.sql
+++ b/supabase/migrations/20250201000000_add_rhythm_mode.sql
@@ -1,0 +1,122 @@
+-- Add rhythm mode columns to fantasy_stages table
+ALTER TABLE fantasy_stages
+ADD COLUMN IF NOT EXISTS bpm integer DEFAULT 120,
+ADD COLUMN IF NOT EXISTS measure_count integer DEFAULT 8,
+ADD COLUMN IF NOT EXISTS time_signature integer DEFAULT 4,
+ADD COLUMN IF NOT EXISTS count_in_measures integer DEFAULT 1,
+ADD COLUMN IF NOT EXISTS mp3_url varchar,
+ADD COLUMN IF NOT EXISTS chord_progression_data jsonb;
+
+-- Update mode constraint to include 'rhythm'
+ALTER TABLE fantasy_stages 
+DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
+
+ALTER TABLE fantasy_stages
+ADD CONSTRAINT fantasy_stages_mode_check 
+CHECK (mode IN ('single', 'progression', 'rhythm'));
+
+-- Add comments for new columns
+COMMENT ON COLUMN fantasy_stages.bpm IS 'BPM (beats per minute)';
+COMMENT ON COLUMN fantasy_stages.measure_count IS '小節数';
+COMMENT ON COLUMN fantasy_stages.time_signature IS '拍子 (例: 4=4/4拍子, 3=3/4拍子)';
+COMMENT ON COLUMN fantasy_stages.count_in_measures IS 'カウントイン小節数 (BGMループ開始前の小節数)';
+COMMENT ON COLUMN fantasy_stages.mp3_url IS 'MP3ファイルのURL';
+COMMENT ON COLUMN fantasy_stages.chord_progression_data IS 'リズムモード用のコード進行データ (JSON形式)';
+
+-- Insert sample rhythm mode stage
+INSERT INTO fantasy_stages (
+  stage_number,
+  name,
+  description,
+  max_hp,
+  question_count,
+  enemy_gauge_seconds,
+  mode,
+  allowed_chords,
+  show_sheet_music,
+  monster_icon,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  simultaneous_monster_count,
+  show_guide,
+  bpm,
+  measure_count,
+  time_signature,
+  count_in_measures,
+  mp3_url,
+  chord_progression_data
+) VALUES (
+  '4-1',
+  'リズムの洞窟',
+  'リズムに合わせてコードを演奏しよう！',
+  5,
+  10,
+  4,
+  'rhythm',
+  '["C", "G", "Am", "F"]'::jsonb,
+  true,
+  'fa-drum',
+  10,
+  1,
+  1,
+  1,
+  1,
+  true,
+  120,
+  8,
+  4,
+  1,
+  '/demo-1.mp3',
+  NULL
+);
+
+-- Insert sample chord progression rhythm mode stage
+INSERT INTO fantasy_stages (
+  stage_number,
+  name,
+  description,
+  max_hp,
+  question_count,
+  enemy_gauge_seconds,
+  mode,
+  allowed_chords,
+  show_sheet_music,
+  monster_icon,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  simultaneous_monster_count,
+  show_guide,
+  bpm,
+  measure_count,
+  time_signature,
+  count_in_measures,
+  mp3_url,
+  chord_progression_data
+) VALUES (
+  '4-2',
+  'リズムの神殿',
+  'コード進行パターンに挑戦！',
+  5,
+  16,
+  3,
+  'rhythm',
+  '["C", "G", "Am", "F", "Dm", "Em"]'::jsonb,
+  true,
+  'fa-music',
+  16,
+  1,
+  1,
+  1,
+  1,
+  true,
+  120,
+  8,
+  4,
+  1,
+  '/demo-2.mp3',
+  '{"chords": [{"beat": 1.0, "chord": "C", "measure": 1}, {"beat": 1.0, "chord": "G", "measure": 2}, {"beat": 1.0, "chord": "Am", "measure": 3}, {"beat": 1.0, "chord": "F", "measure": 4}, {"beat": 1.0, "chord": "C", "measure": 5}, {"beat": 1.0, "chord": "Am", "measure": 6}, {"beat": 1.0, "chord": "Dm", "measure": 7}, {"beat": 1.0, "chord": "G", "measure": 8}]}'::jsonb
+);


### PR DESCRIPTION
Add Rhythm Mode to the fantasy game, introducing rhythm-based chord input and a lane-style UI.

This PR introduces a new 'Rhythm Mode' gameplay experience, distinct from the existing 'Quiz Mode'. It features a judgment window for chord input, a Taiko no Tatsujin-style scrolling lane UI, and supports both random and predefined chord progression patterns. The database schema has been extended to support rhythm-specific stage configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d345e1c-57cc-475f-92f0-a75dfec7ff12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d345e1c-57cc-475f-92f0-a75dfec7ff12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>