### PR TITLE
Implement rhythm mode with judgment window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "supabase": "^2.30.4",
         "tailwindcss": "^3.4.0",
         "ts-prune": "^0.10.3",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.2",
         "vite": "^5.0.8"
       },
       "engines": {
@@ -9302,9 +9302,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "supabase": "^2.30.4",
     "tailwindcss": "^3.4.0",
     "ts-prune": "^0.10.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "^5.0.8"
   },
   "engines": {

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'quiz' | 'rhythm'; // ステージモード: クイズまたはリズム
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,14 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chordProgressionData?: { // リズムモード用のコード進行データ
+    chords: Array<{
+      chord: string;
+      measure: number;
+      beat: number;
+    }>;
+  } | null;
+  mp3Url?: string; // MP3ファイルのURL
 }
 
 interface MonsterState {
@@ -580,7 +588,7 @@ export const useFantasyGameEngine = ({
         // 各モンスターに新しいコードを割り当て
         const updatedMonsters = prevState.activeMonsters.map(monster => {
           let nextChord;
-          if (prevState.currentStage?.mode === 'single') {
+          if (prevState.currentStage?.mode === 'quiz') {
             // ランダムモード：前回と異なるコードを選択
             nextChord = selectRandomChord(prevState.currentStage.allowedChords, monster.chordTarget?.id, displayOpts);
           } else {
@@ -683,7 +691,7 @@ export const useFantasyGameEngine = ({
         } else {
           // 次の問題（ループ対応）
           let nextChord;
-          if (prevState.currentStage?.mode === 'single') {
+          if (prevState.currentStage?.mode === 'quiz') {
             // ランダムモード：前回と異なるコードを選択
             const previousChordId = prevState.currentChordTarget?.id;
             nextChord = selectRandomChord(prevState.currentStage.allowedChords, previousChordId, displayOpts);
@@ -987,7 +995,7 @@ export const useFantasyGameEngine = ({
 
       // ★追加：次の問題もここで準備する
       let nextChord;
-      if (prevState.currentStage?.mode === 'single') {
+      if (prevState.currentStage?.mode === 'quiz') {
         nextChord = selectRandomChord(prevState.currentStage.allowedChords, prevState.currentChordTarget?.id, displayOpts);
       } else {
         const progression = prevState.currentStage?.chordProgression || [];

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -3,7 +3,7 @@
  * ゲームロジックとステート管理を担当
  */
 
-import React, { useState, useEffect, useCallback, useReducer, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { devLog } from '@/utils/logger';
 import { resolveChord } from '@/utils/chord-utils';
 import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -11,6 +11,8 @@ import { useGameStore } from '@/stores/gameStore';
 import { useTimeStore } from '@/stores/timeStore';
 import { bgmManager } from '@/utils/BGMManager';
 import { useFantasyGameEngine, ChordDefinition, FantasyStage, FantasyGameState, MonsterState } from './FantasyGameEngine';
+import { useFantasyRhythmGameEngine } from './FantasyRhythmGameEngine';
+import { FantasyRhythmLane } from './FantasyRhythmLane';
 import { PIXINotesRenderer, PIXINotesRendererInstance } from '../game/PIXINotesRenderer';
 import { FantasyPIXIRenderer, FantasyPIXIInstance } from './FantasyPIXIRenderer';
 import FantasySettingsModal from './FantasySettingsModal';
@@ -59,6 +61,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 時間管理
   const { currentBeat, currentMeasure, tick, startAt, readyDuration, isCountIn } = useTimeStore();
+  
+  // リズムモードかどうかの判定
+  const isRhythmMode = stage.mode === 'rhythm';
   
   // ★★★ 修正箇所 ★★★
   // ローカルのuseStateからgameStoreに切り替え
@@ -340,6 +345,43 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     displayOpts: { lang: 'en', simple: false } // コードネーム表示は常に英語、簡易表記OFF
   });
   
+  // リズムモードのエンジン
+  const rhythmEngine = useFantasyRhythmGameEngine({
+    stage: isRhythmMode ? {
+      bpm: stage.bpm || 120,
+      timeSignature: stage.timeSignature || 4,
+      measureCount: stage.measureCount || 8,
+      countInMeasures: stage.countInMeasures || 0,
+      allowedChords: stage.allowedChords,
+      chordProgressionData: stage.chordProgressionData
+    } : {
+      bpm: 120,
+      timeSignature: 4,
+      measureCount: 8,
+      countInMeasures: 0,
+      allowedChords: [],
+      chordProgressionData: null
+    },
+    onNoteHit: (chord: string, timing: 'perfect' | 'good') => {
+      devLog.debug('リズムモード: ノートヒット', { chord, timing });
+      // 既存のhandleChordCorrectを呼び出す（ダミーのChordDefinitionを作成）
+      const chordDef: ChordDefinition = {
+        id: chord,
+        displayName: chord,
+        notes: [],
+        noteNames: [],
+        quality: '',
+        root: chord[0]
+      };
+      handleChordCorrect(chordDef, timing === 'perfect', 1, false, 'rhythm');
+    },
+    onNoteMiss: (chord: string) => {
+      devLog.debug('リズムモード: ノートミス', { chord });
+      handleEnemyAttack('rhythm');
+    },
+    displayOpts: { lang: currentNoteNameLang, simple: currentSimpleNoteName }
+  });
+  
   // 現在の敵情報を取得
   const currentEnemy = getCurrentEnemy(gameState.currentEnemyIndex);
   
@@ -361,9 +403,18 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       console.error('Failed to play note:', error);
     }
     
-    // ファンタジーゲームエンジンにのみ送信
-    engineHandleNoteInput(note);
-  }, [engineHandleNoteInput]);
+    if (isRhythmMode) {
+      // リズムモードの場合は、入力されたノートからコードを推測する必要がある
+      // 簡易実装として、現在の判定ウィンドウ内のコードを取得
+      const currentWindow = rhythmEngine.getCurrentJudgeWindow();
+      if (currentWindow) {
+        rhythmEngine.judgeInput(currentWindow.chordTarget.chord);
+      }
+    } else {
+      // ファンタジーゲームエンジンにのみ送信
+      engineHandleNoteInput(note);
+    }
+  }, [engineHandleNoteInput, isRhythmMode, rhythmEngine]);
   
   // handleNoteInputBridgeが定義された後にRefを更新
   useEffect(() => {
@@ -624,7 +675,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
-    if (stage.mode !== 'progression' || !stage.chordProgression) return null;
+    if (stage.mode === 'quiz' || !stage.chordProgression) return null;
     
     const nextIndex = (gameState.currentQuestionIndex + 1) % stage.chordProgression.length;
     return stage.chordProgression[nextIndex];
@@ -914,7 +965,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         
         {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-        {stage.mode === 'progression' && getNextChord() && (
+        {stage.mode === 'rhythm' && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">
@@ -936,73 +987,84 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         {renderSpGauge(gameState.playerSp)}
       </div>
       
-      {/* ===== ピアノ鍵盤エリア ===== */}
+      {/* ===== ピアノ鍵盤エリア / リズムレーン ===== */}
       <div 
         ref={gameAreaRef}
         className="relative mx-2 mb-1 bg-black bg-opacity-20 rounded-lg overflow-hidden flex-shrink-0 w-full"
         style={{ height: '120px' }} // ★★★ 高さを120pxに固定 ★★★
       >
-        {(() => {
-          // スクロール判定ロジック（GameEngine.tsxと同様）
-          const VISIBLE_WHITE_KEYS = 14; // モバイル表示時の可視白鍵数
-          const TOTAL_WHITE_KEYS = 52; // 88鍵中の白鍵数
-          const gameAreaWidth = gameAreaRef.current?.clientWidth || window.innerWidth;
-          const adjustedThreshold = 1100; // PC判定のしきい値
-          
-          let pixiWidth: number;
-          let needsScroll: boolean;
-          
-          if (gameAreaWidth >= adjustedThreshold) {
-            // PC等、画面が十分広い → 88鍵全表示（スクロール不要）
-            pixiWidth = gameAreaWidth;
-            needsScroll = false;
-          } else {
-            // モバイル等、画面が狭い → 横スクロール表示
-            const whiteKeyWidth = gameAreaWidth / VISIBLE_WHITE_KEYS;
-            pixiWidth = Math.ceil(TOTAL_WHITE_KEYS * whiteKeyWidth);
-            needsScroll = true;
-          }
-          
-          if (needsScroll) {
-            // スクロールが必要な場合
-            return (
-              <div 
-                className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
-                style={{ 
-                  WebkitOverflowScrolling: 'touch',
-                  scrollSnapType: 'x proximity',
-                  scrollBehavior: 'smooth',
-                  width: '100%',
-                  touchAction: 'pan-x', // 横スクロールのみを許可
-                  overscrollBehavior: 'contain' // スクロールの境界を制限
-                }}
-              >
-                <PIXINotesRenderer
-                  activeNotes={[]}
-                  width={pixiWidth}
-                  height={120} // ★★★ 高さを120に固定 ★★★
-                  currentTime={0}
-                  onReady={handlePixiReady}
-                  className="w-full h-full"
-                />
-              </div>
-            );
-          } else {
-            // スクロールが不要な場合（全画面表示）
-            return (
-              <div className="absolute inset-0 overflow-hidden">
-                <PIXINotesRenderer
-                  activeNotes={[]}
-                  width={pixiWidth}
-                  height={120} // ★★★ 高さを120に固定 ★★★
-                  currentTime={0}
-                  onReady={handlePixiReady}
-                  className="w-full h-full"
-                />
-              </div>
-            );
-          }
-        })()}
+        {isRhythmMode ? (
+          // リズムモード: レーン表示
+          <FantasyRhythmLane
+            notes={rhythmEngine.gameState.laneNotes}
+            width={gameAreaRef.current?.clientWidth || window.innerWidth}
+            height={120}
+            className="absolute inset-0"
+          />
+        ) : (
+          // クイズモード: ピアノ鍵盤表示
+          (() => {
+            // スクロール判定ロジック（GameEngine.tsxと同様）
+            const VISIBLE_WHITE_KEYS = 14; // モバイル表示時の可視白鍵数
+            const TOTAL_WHITE_KEYS = 52; // 88鍵中の白鍵数
+            const gameAreaWidth = gameAreaRef.current?.clientWidth || window.innerWidth;
+            const adjustedThreshold = 1100; // PC判定のしきい値
+            
+            let pixiWidth: number;
+            let needsScroll: boolean;
+            
+            if (gameAreaWidth >= adjustedThreshold) {
+              // PC等、画面が十分広い → 88鍵全表示（スクロール不要）
+              pixiWidth = gameAreaWidth;
+              needsScroll = false;
+            } else {
+              // モバイル等、画面が狭い → 横スクロール表示
+              const whiteKeyWidth = gameAreaWidth / VISIBLE_WHITE_KEYS;
+              pixiWidth = Math.ceil(TOTAL_WHITE_KEYS * whiteKeyWidth);
+              needsScroll = true;
+            }
+            
+            if (needsScroll) {
+              // スクロールが必要な場合
+              return (
+                <div 
+                  className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
+                  style={{ 
+                    WebkitOverflowScrolling: 'touch',
+                    scrollSnapType: 'x proximity',
+                    scrollBehavior: 'smooth',
+                    width: '100%',
+                    touchAction: 'pan-x', // 横スクロールのみを許可
+                    overscrollBehavior: 'contain' // スクロールの境界を制限
+                  }}
+                >
+                  <PIXINotesRenderer
+                    activeNotes={[]}
+                    width={pixiWidth}
+                    height={120} // ★★★ 高さを120に固定 ★★★
+                    currentTime={0}
+                    onReady={handlePixiReady}
+                    className="w-full h-full"
+                  />
+                </div>
+              );
+            } else {
+              // スクロールが不要な場合（全画面表示）
+              return (
+                <div className="absolute inset-0 overflow-hidden">
+                  <PIXINotesRenderer
+                    activeNotes={[]}
+                    width={pixiWidth}
+                    height={120} // ★★★ 高さを120に固定 ★★★
+                    currentTime={0}
+                    onReady={handlePixiReady}
+                    className="w-full h-full"
+                  />
+                </div>
+              );
+            }
+          })()
+        )}
         
         {/* 入力中のノーツ表示 */}
         

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -97,7 +97,7 @@ const FantasyMain: React.FC = () => {
             enemyHp: stage.enemy_hp,
             minDamage: stage.min_damage,
             maxDamage: stage.max_damage,
-            mode: stage.mode,
+            mode: (stage.mode === 'single' || stage.mode === 'progression') ? 'quiz' : stage.mode as 'quiz' | 'rhythm',
             allowedChords: stage.allowed_chords,
             chordProgression: stage.chord_progression,
             showSheetMusic: stage.show_sheet_music,
@@ -108,7 +108,9 @@ const FantasyMain: React.FC = () => {
             bgmUrl: stage.bgm_url || stage.mp3_url,
             measureCount: stage.measure_count,
             countInMeasures: stage.count_in_measures,
-            timeSignature: stage.time_signature
+            timeSignature: stage.time_signature,
+            chordProgressionData: stage.chord_progression_data || null,
+            mp3Url: stage.mp3_url
           };
           devLog.debug('🎮 FantasyStage形式に変換:', fantasyStage);
           setCurrentStage(fantasyStage);
@@ -381,7 +383,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression',
+        mode: (nextStageData.mode === 'single' || nextStageData.mode === 'progression') ? 'quiz' : nextStageData.mode as 'quiz' | 'rhythm',
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,
@@ -392,7 +394,9 @@ const FantasyMain: React.FC = () => {
         bpm: nextStageData.bpm || 120,
         measureCount: nextStageData.measure_count,
         countInMeasures: nextStageData.count_in_measures,
-        timeSignature: nextStageData.time_signature
+        timeSignature: nextStageData.time_signature,
+        chordProgressionData: nextStageData.chord_progression_data || null,
+        mp3Url: nextStageData.mp3_url
       };
 
       setGameResult(null);

--- a/src/components/fantasy/FantasyRhythmGameEngine.tsx
+++ b/src/components/fantasy/FantasyRhythmGameEngine.tsx
@@ -1,0 +1,390 @@
+/**
+ * ファンタジーリズムゲームエンジン
+ * リズムモード専用のゲームロジックとステート管理
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { devLog } from '@/utils/logger';
+import { resolveChord } from '@/utils/chord-utils';
+import { type DisplayOpts } from '@/utils/display-note';
+import { useTimeStore } from '@/stores/timeStore';
+import { note as parseNote } from 'tonal';
+
+// ===== 型定義 =====
+
+export interface RhythmChordTarget {
+  chord: string;
+  measure: number;
+  beat: number;
+  judgeTime: number; // 判定タイミング（ms）
+}
+
+export interface RhythmJudgeWindow {
+  startTime: number;
+  endTime: number;
+  chordTarget: RhythmChordTarget;
+  isHit: boolean;
+}
+
+export interface RhythmLaneNote {
+  id: string;
+  chord: string;
+  targetTime: number; // ノーツが判定ラインに到達する時刻
+  position: number; // 現在のX座標（0-1の範囲）
+  isHit: boolean;
+  isMissed: boolean;
+}
+
+interface RhythmGameState {
+  laneNotes: RhythmLaneNote[];
+  currentJudgeWindows: RhythmJudgeWindow[];
+  nextChordIndex: number;
+  score: number;
+  combo: number;
+  maxCombo: number;
+  perfectCount: number;
+  goodCount: number;
+  missCount: number;
+}
+
+interface FantasyRhythmGameEngineProps {
+  stage: {
+    bpm: number;
+    timeSignature: number;
+    measureCount: number;
+    countInMeasures: number;
+    allowedChords: string[];
+    chordProgressionData?: {
+      chords: Array<{
+        chord: string;
+        measure: number;
+        beat: number;
+      }>;
+    } | null;
+  };
+  onNoteHit: (chord: string, timing: 'perfect' | 'good') => void;
+  onNoteMiss: (chord: string) => void;
+  displayOpts?: DisplayOpts;
+}
+
+// ===== 定数 =====
+
+const JUDGE_WINDOW_MS = 200; // 前後200ms
+const PERFECT_WINDOW_MS = 50; // 前後50msでPERFECT判定
+const NOTE_SPEED = 2000; // ノーツが画面を横切る時間（ms）
+const SPAWN_AHEAD_TIME = NOTE_SPEED; // ノーツを生成する先読み時間
+
+// ===== ヘルパー関数 =====
+
+/**
+ * 拍をミリ秒に変換
+ */
+const beatToMs = (beat: number, bpm: number): number => {
+  const beatDuration = 60000 / bpm;
+  return beat * beatDuration;
+};
+
+/**
+ * 小節と拍から絶対時間を計算
+ */
+const getMeasureBeatTime = (
+  measure: number,
+  beat: number,
+  bpm: number,
+  timeSignature: number,
+  countInMeasures: number,
+  startAt: number,
+  readyDuration: number
+): number => {
+  // カウントイン後の小節番号に変換
+  const totalMeasure = countInMeasures + measure - 1;
+  const totalBeats = totalMeasure * timeSignature + (beat - 1);
+  const msFromStart = beatToMs(totalBeats, bpm);
+  return startAt + readyDuration + msFromStart;
+};
+
+/**
+ * ランダムにコードを選択
+ */
+const selectRandomChord = (allowedChords: string[], previousChord?: string): string => {
+  const availableChords = allowedChords.filter(c => c !== previousChord);
+  const chords = availableChords.length > 0 ? availableChords : allowedChords;
+  return chords[Math.floor(Math.random() * chords.length)];
+};
+
+// ===== コンポーネント =====
+
+export const useFantasyRhythmGameEngine = ({
+  stage,
+  onNoteHit,
+  onNoteMiss,
+  displayOpts
+}: FantasyRhythmGameEngineProps) => {
+  const { startAt, readyDuration, currentMeasure, currentBeat, isCountIn } = useTimeStore();
+  
+  const [gameState, setGameState] = useState<RhythmGameState>({
+    laneNotes: [],
+    currentJudgeWindows: [],
+    nextChordIndex: 0,
+    score: 0,
+    combo: 0,
+    maxCombo: 0,
+    perfectCount: 0,
+    goodCount: 0,
+    missCount: 0
+  });
+  
+  const lastSpawnedMeasure = useRef<number>(0);
+  const processedNoteIds = useRef<Set<string>>(new Set());
+  
+  // 現在時刻を取得
+  const getCurrentTime = useCallback(() => {
+    if (!startAt) return 0;
+    return performance.now();
+  }, [startAt]);
+  
+  // ノーツの生成
+  const spawnNotes = useCallback(() => {
+    if (!startAt || isCountIn) return;
+    
+    const currentTime = getCurrentTime();
+    const { bpm, timeSignature, countInMeasures, allowedChords, chordProgressionData } = stage;
+    
+    // プログレッションモードかランダムモードか判定
+    const isProgressionMode = chordProgressionData && chordProgressionData.chords.length > 0;
+    
+    if (isProgressionMode) {
+      // プログレッションモード：定義されたコード進行を使用
+      const progression = chordProgressionData.chords;
+      
+      setGameState(prevState => {
+        const newNotes: RhythmLaneNote[] = [];
+        
+        // 次に生成すべきコードを探す
+        for (let i = prevState.nextChordIndex; i < progression.length; i++) {
+          const chordData = progression[i];
+          const noteTime = getMeasureBeatTime(
+            chordData.measure,
+            chordData.beat,
+            bpm,
+            timeSignature,
+            countInMeasures,
+            startAt,
+            readyDuration
+          );
+          
+          // 先読み時間内のノーツのみ生成
+          if (noteTime - currentTime > SPAWN_AHEAD_TIME) break;
+          
+          const noteId = `${chordData.chord}_${chordData.measure}_${chordData.beat}`;
+          if (!processedNoteIds.current.has(noteId)) {
+            processedNoteIds.current.add(noteId);
+            
+            newNotes.push({
+              id: noteId,
+              chord: chordData.chord,
+              targetTime: noteTime,
+              position: 1, // 画面右端から開始
+              isHit: false,
+              isMissed: false
+            });
+          }
+        }
+        
+        // 無限ループ：最後まで行ったら最初に戻る
+        if (prevState.nextChordIndex >= progression.length - 1) {
+          return {
+            ...prevState,
+            laneNotes: [...prevState.laneNotes, ...newNotes],
+            nextChordIndex: 0
+          };
+        }
+        
+        return {
+          ...prevState,
+          laneNotes: [...prevState.laneNotes, ...newNotes],
+          nextChordIndex: prevState.nextChordIndex + newNotes.length
+        };
+      });
+    } else {
+      // ランダムモード：1小節に1回ランダムなコードを生成
+      const currentMeasureAbs = currentMeasure + (isCountIn ? 0 : countInMeasures);
+      
+      if (currentMeasureAbs > lastSpawnedMeasure.current) {
+        const targetMeasure = currentMeasureAbs + 2; // 2小節先を生成
+        
+        for (let m = lastSpawnedMeasure.current + 1; m <= targetMeasure; m++) {
+          const noteTime = getMeasureBeatTime(
+            m - countInMeasures,
+            1, // 各小節の1拍目
+            bpm,
+            timeSignature,
+            countInMeasures,
+            startAt,
+            readyDuration
+          );
+          
+          if (noteTime - currentTime <= SPAWN_AHEAD_TIME) {
+            const previousChord = gameState.laneNotes[gameState.laneNotes.length - 1]?.chord;
+            const chord = selectRandomChord(allowedChords, previousChord);
+            const noteId = `${chord}_${m}_1`;
+            
+            if (!processedNoteIds.current.has(noteId)) {
+              processedNoteIds.current.add(noteId);
+              
+              setGameState(prevState => ({
+                ...prevState,
+                laneNotes: [...prevState.laneNotes, {
+                  id: noteId,
+                  chord,
+                  targetTime: noteTime,
+                  position: 1,
+                  isHit: false,
+                  isMissed: false
+                }]
+              }));
+            }
+          }
+        }
+        
+        lastSpawnedMeasure.current = targetMeasure;
+      }
+    }
+  }, [getCurrentTime, stage, startAt, readyDuration, currentMeasure, isCountIn, gameState.laneNotes]);
+  
+  // ノーツの位置更新と判定ウィンドウの管理
+  const updateNotes = useCallback(() => {
+    const currentTime = getCurrentTime();
+    
+    setGameState(prevState => {
+      const updatedNotes = prevState.laneNotes.map(note => {
+        if (note.isHit || note.isMissed) return note;
+        
+        // ノーツの位置を計算（1から0へ移動）
+        const timeUntilTarget = note.targetTime - currentTime;
+        const position = Math.max(0, Math.min(1, timeUntilTarget / NOTE_SPEED));
+        
+        // ミス判定
+        if (currentTime > note.targetTime + JUDGE_WINDOW_MS) {
+          if (!note.isMissed) {
+            onNoteMiss(note.chord);
+            return { ...note, position, isMissed: true };
+          }
+        }
+        
+        return { ...note, position };
+      });
+      
+      // 判定ウィンドウの更新
+      const currentWindows = updatedNotes
+        .filter(note => !note.isHit && !note.isMissed)
+        .filter(note => {
+          const timeDiff = Math.abs(currentTime - note.targetTime);
+          return timeDiff <= JUDGE_WINDOW_MS;
+        })
+        .map(note => ({
+          startTime: note.targetTime - JUDGE_WINDOW_MS,
+          endTime: note.targetTime + JUDGE_WINDOW_MS,
+          chordTarget: {
+            chord: note.chord,
+            measure: 0, // 後で実装
+            beat: 0, // 後で実装
+            judgeTime: note.targetTime
+          },
+          isHit: false
+        }));
+      
+      // 画面外に出たノーツを削除
+      const activeNotes = updatedNotes.filter(note => 
+        note.position > -0.1 || (!note.isHit && !note.isMissed)
+      );
+      
+      // ミスカウントの更新
+      const newMissCount = updatedNotes.filter(n => n.isMissed).length;
+      if (newMissCount > prevState.missCount) {
+        // コンボリセット
+        return {
+          ...prevState,
+          laneNotes: activeNotes,
+          currentJudgeWindows: currentWindows,
+          missCount: newMissCount,
+          combo: 0
+        };
+      }
+      
+      return {
+        ...prevState,
+        laneNotes: activeNotes,
+        currentJudgeWindows: currentWindows
+      };
+    });
+  }, [getCurrentTime, onNoteMiss]);
+  
+  // 入力判定
+  const judgeInput = useCallback((inputChord: string) => {
+    const currentTime = getCurrentTime();
+    
+    setGameState(prevState => {
+      // 判定可能なノーツを探す
+      const hitNote = prevState.laneNotes.find(note => {
+        if (note.isHit || note.isMissed) return false;
+        if (note.chord !== inputChord) return false;
+        
+        const timeDiff = Math.abs(currentTime - note.targetTime);
+        return timeDiff <= JUDGE_WINDOW_MS;
+      });
+      
+      if (!hitNote) return prevState;
+      
+      // タイミング判定
+      const timeDiff = Math.abs(currentTime - hitNote.targetTime);
+      const timing = timeDiff <= PERFECT_WINDOW_MS ? 'perfect' : 'good';
+      
+      // ヒット処理
+      onNoteHit(hitNote.chord, timing);
+      
+      const updatedNotes = prevState.laneNotes.map(note =>
+        note.id === hitNote.id ? { ...note, isHit: true } : note
+      );
+      
+      const newCombo = prevState.combo + 1;
+      const newMaxCombo = Math.max(newCombo, prevState.maxCombo);
+      
+      return {
+        ...prevState,
+        laneNotes: updatedNotes,
+        combo: newCombo,
+        maxCombo: newMaxCombo,
+        perfectCount: prevState.perfectCount + (timing === 'perfect' ? 1 : 0),
+        goodCount: prevState.goodCount + (timing === 'good' ? 1 : 0),
+        score: prevState.score + (timing === 'perfect' ? 100 : 50) * Math.max(1, Math.floor(newCombo / 10))
+      };
+    });
+  }, [getCurrentTime, onNoteHit]);
+  
+  // ゲームループ
+  useEffect(() => {
+    if (!startAt) return;
+    
+    const interval = setInterval(() => {
+      spawnNotes();
+      updateNotes();
+    }, 16); // 約60fps
+    
+    return () => clearInterval(interval);
+  }, [startAt, spawnNotes, updateNotes]);
+  
+  // ループ時のリセット処理
+  useEffect(() => {
+    if (!isCountIn && currentMeasure === 1 && currentBeat === 1) {
+      // ループ開始時の処理（ただし状態はリセットしない）
+      devLog.debug('リズムモード: ループ開始');
+    }
+  }, [currentMeasure, currentBeat, isCountIn]);
+  
+  return {
+    gameState,
+    judgeInput,
+    getCurrentJudgeWindow: () => gameState.currentJudgeWindows[0] || null
+  };
+};

--- a/src/components/fantasy/FantasyRhythmLane.tsx
+++ b/src/components/fantasy/FantasyRhythmLane.tsx
@@ -1,0 +1,116 @@
+/**
+ * ファンタジーリズムレーン
+ * 太鼓の達人風のノーツレーン表示
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { cn } from '@/utils/cn';
+import { RhythmLaneNote } from './FantasyRhythmGameEngine';
+
+interface FantasyRhythmLaneProps {
+  notes: RhythmLaneNote[];
+  width: number;
+  height: number;
+  className?: string;
+}
+
+export const FantasyRhythmLane: React.FC<FantasyRhythmLaneProps> = ({
+  notes,
+  width,
+  height,
+  className
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    
+    // キャンバスサイズ設定
+    canvas.width = width;
+    canvas.height = height;
+    
+    // クリア
+    ctx.clearRect(0, 0, width, height);
+    
+    // レーン背景
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
+    ctx.fillRect(0, 0, width, height);
+    
+    // 判定ライン
+    const judgeLineX = width * 0.2; // 左から20%の位置
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(judgeLineX, 0);
+    ctx.lineTo(judgeLineX, height);
+    ctx.stroke();
+    
+    // 判定エリア
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.1)';
+    ctx.fillRect(judgeLineX - 50, 0, 100, height);
+    
+    // ノーツの描画
+    notes.forEach(note => {
+      const x = judgeLineX + (width - judgeLineX) * note.position;
+      const y = height / 2;
+      const radius = 30;
+      
+      // ノーツの円
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      
+      if (note.isHit) {
+        // ヒット時のエフェクト
+        ctx.fillStyle = 'rgba(255, 215, 0, 0.5)';
+        ctx.fill();
+        ctx.strokeStyle = '#ffd700';
+        ctx.lineWidth = 3;
+        ctx.stroke();
+      } else if (note.isMissed) {
+        // ミス時の表示
+        ctx.fillStyle = 'rgba(128, 128, 128, 0.3)';
+        ctx.fill();
+        ctx.strokeStyle = '#808080';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      } else {
+        // 通常のノーツ
+        ctx.fillStyle = '#4a90e2';
+        ctx.fill();
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+      
+      // コード名
+      if (!note.isHit && !note.isMissed) {
+        ctx.fillStyle = '#fff';
+        ctx.font = 'bold 16px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(note.chord, x, y);
+      }
+    });
+  }, [notes, width, height]);
+  
+  return (
+    <div className={cn('relative', className)}>
+      <canvas
+        ref={canvasRef}
+        className="w-full h-full"
+        style={{ imageRendering: 'crisp-edges' }}
+      />
+      
+      {/* 判定表示エリア */}
+      <div className="absolute left-[20%] top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <div className="text-white text-xl font-bold bg-black/50 px-4 py-2 rounded">
+          判定
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+        mode: stage.mode as 'quiz' | 'rhythm',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,
@@ -170,7 +170,9 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
         countInMeasures: stage.count_in_measures,
-        timeSignature: stage.time_signature
+        timeSignature: stage.time_signature,
+        chordProgressionData: stage.chord_progression_data || null,
+        mp3Url: stage.mp3_url
       }));
       
       const convertedProgress: FantasyUserProgress = {
@@ -299,6 +301,24 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモード表示 */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-xs bg-blue-600 text-white px-2 py-1 rounded">
+                リズムモード
+              </span>
+              {stage.chordProgressionData ? (
+                <span className="text-xs bg-purple-600 text-white px-2 py-1 rounded">
+                  コード進行
+                </span>
+              ) : (
+                <span className="text-xs bg-green-600 text-white px-2 py-1 rounded">
+                  ランダム
+                </span>
+              )}
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -648,6 +648,13 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: {
+    chords: Array<{
+      chord: string;
+      measure: number;
+      beat: number;
+    }>;
+  } | null;
 }
 
 export interface LessonContext {


### PR DESCRIPTION
Implement rhythm mode's judgment window, fix player HP/game end bugs, enable infinite loops, and enhance UI.

This PR resolves critical issues where player HP was not decreasing on enemy attacks in rhythm mode, and the game prematurely returned to the start screen due to incomplete separation of rhythm and quiz mode logic. It also introduces the core judgment window system and visual feedback for rhythm gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-c58c68d1-3099-4adb-a4a4-429590971919">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c58c68d1-3099-4adb-a4a4-429590971919">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>