### PR TITLE
Add rhythm mode with judgment window

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,14 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  mp3Url?: string;
+  chordProgressionData?: {
+    chords: Array<{
+      measure: number;
+      beat: number;
+      chord: string;
+    }>;
+  };
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -14,6 +14,7 @@ import { useFantasyGameEngine, ChordDefinition, FantasyStage, FantasyGameState, 
 import { PIXINotesRenderer, PIXINotesRendererInstance } from '../game/PIXINotesRenderer';
 import { FantasyPIXIRenderer, FantasyPIXIInstance } from './FantasyPIXIRenderer';
 import FantasySettingsModal from './FantasySettingsModal';
+import RhythmMode from './RhythmMode';
 import type { DisplayOpts } from '@/utils/display-note';
 import { toDisplayName } from '@/utils/display-note';
 import { note as parseNote } from 'tonal';
@@ -654,10 +655,32 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // ★ マウント時 autoStart なら即開始
   useEffect(() => {
-    if (autoStart) {
+    if (autoStart && stage.mode !== 'rhythm') {
       initializeGame(stage);
     }
   }, [autoStart, initializeGame, stage]);
+
+  // リズムモードの場合は専用コンポーネントを表示
+  if (stage.mode === 'rhythm') {
+    return (
+      <RhythmMode
+        stage={stage}
+        onNoteOn={handleNoteInputBridge}
+        onNoteOff={(note: number) => {
+          activeNotesRef.current.delete(note);
+        }}
+        onChordCorrect={handleChordCorrect}
+        onChordIncorrect={handleChordIncorrect}
+        onEnemyAttack={handleEnemyAttack}
+        onGameComplete={(result) => {
+          // リズムモードの完了処理
+          const finalScore = result === 'clear' ? 100 : 0;
+          onGameComplete(result, finalScore, 1, 1);
+        }}
+        displayOpts={{ lang: currentNoteNameLang, simple: currentSimpleNoteName }}
+      />
+    );
+  }
 
   // ゲーム開始前画面（オーバーレイ表示中は表示しない）
   if (!overlay && !gameState.isCompleting && (!gameState.isGameActive || !gameState.currentChordTarget)) {

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
+import { ChordProgressionData } from '@/types/rhythm';
 import { devLog } from '@/utils/logger';
 
 // ===== 型定義 =====
@@ -301,8 +302,17 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           </div>
         </div>
         
-        {/* 右側のアイコン */}
-        <div className="flex-shrink-0">
+        {/* 右側のアイコンとモード表示 */}
+        <div className="flex-shrink-0 text-center">
+          {/* モード表示 */}
+          {unlocked && (
+            <div className="text-xs text-gray-400 mb-1">
+              {stage.mode === 'rhythm' ? (
+                stage.chordProgressionData ? 'コード進行' : 'ランダム'
+              ) : stage.mode === 'progression' ? 'コード進行' : '単体'}
+            </div>
+          )}
+          {/* ステータスアイコン */}
           {!unlocked && (
             <div className="text-2xl">
               <span>🔒</span>
@@ -311,6 +321,12 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           {isCleared && (
             <div className="text-yellow-400 text-2xl">
               ⭐
+            </div>
+          )}
+          {/* リズムモードアイコン */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="text-purple-400 text-lg mt-1">
+              🎵
             </div>
           )}
         </div>

--- a/src/components/fantasy/RhythmJudgmentWindow.tsx
+++ b/src/components/fantasy/RhythmJudgmentWindow.tsx
@@ -1,0 +1,104 @@
+/**
+ * リズム判定ウィンドウコンポーネント
+ * キーボード入力を処理し、判定ウィンドウのロジックを管理
+ */
+
+import React, { useEffect, useCallback } from 'react';
+import { JudgmentWindow } from '@/types/rhythm';
+
+interface RhythmJudgmentWindowProps {
+  windows: JudgmentWindow[];
+  onNoteInput: (note: number) => void;
+  onNoteRelease: (note: number) => void;
+}
+
+// キーボードからMIDIノート番号へのマッピング
+const KEY_TO_MIDI: Record<string, number> = {
+  // 白鍵
+  'z': 60, // C4
+  'x': 62, // D4
+  'c': 64, // E4
+  'v': 65, // F4
+  'b': 67, // G4
+  'n': 69, // A4
+  'm': 71, // B4
+  ',': 72, // C5
+  '.': 74, // D5
+  '/': 76, // E5
+  
+  // 黒鍵
+  's': 61, // C#4
+  'd': 63, // D#4
+  'g': 66, // F#4
+  'h': 68, // G#4
+  'j': 70, // A#4
+  'l': 73, // C#5
+  ';': 75, // D#5
+  
+  // 追加の白鍵（上段）
+  'q': 48, // C3
+  'w': 50, // D3
+  'e': 52, // E3
+  'r': 53, // F3
+  't': 55, // G3
+  'y': 57, // A3
+  'u': 59, // B3
+  'i': 60, // C4 (duplicate)
+  'o': 62, // D4 (duplicate)
+  'p': 64, // E4 (duplicate)
+  
+  // 追加の黒鍵（上段）
+  '2': 49, // C#3
+  '3': 51, // D#3
+  '5': 54, // F#3
+  '6': 56, // G#3
+  '7': 58, // A#3
+  '9': 61, // C#4 (duplicate)
+  '0': 63, // D#4 (duplicate)
+};
+
+const RhythmJudgmentWindow: React.FC<RhythmJudgmentWindowProps> = ({
+  windows: _windows,
+  onNoteInput,
+  onNoteRelease
+}) => {
+  // キーボードイベントハンドラ
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    // 既に押されているキーは無視
+    if (e.repeat) return;
+    
+    const key = e.key.toLowerCase();
+    const midiNote = KEY_TO_MIDI[key];
+    
+    if (midiNote !== undefined) {
+      e.preventDefault();
+      onNoteInput(midiNote);
+    }
+  }, [onNoteInput]);
+
+  const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    const key = e.key.toLowerCase();
+    const midiNote = KEY_TO_MIDI[key];
+    
+    if (midiNote !== undefined) {
+      e.preventDefault();
+      onNoteRelease(midiNote);
+    }
+  }, [onNoteRelease]);
+
+  // キーボードイベントの登録
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
+
+  // このコンポーネントは見えない（ロジックのみ）
+  return null;
+};
+
+export default RhythmJudgmentWindow;

--- a/src/components/fantasy/RhythmMode.tsx
+++ b/src/components/fantasy/RhythmMode.tsx
@@ -1,0 +1,426 @@
+/**
+ * リズムモードコンポーネント
+ * 太鼓の達人のような右から左に流れるUIで、タイミングに合わせてコードを演奏
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useTimeStore } from '@/stores/timeStore';
+import { devLog } from '@/utils/logger';
+import { resolveChord } from '@/utils/chord-utils';
+import { bgmManager } from '@/utils/BGMManager';
+import type { DisplayOpts } from '@/utils/display-note';
+import { 
+  RhythmNote, 
+  JudgmentWindow, 
+  JUDGMENT_WINDOW_MS,
+  ChordProgressionData
+} from '@/types/rhythm';
+import RhythmNotes from './RhythmNotes';
+import RhythmJudgmentWindow from './RhythmJudgmentWindow';
+import { note as parseNote } from 'tonal';
+
+interface ChordDefinition {
+  id: string;
+  displayName: string;
+  notes: number[];
+  noteNames: string[];
+  quality: string;
+  root: string;
+}
+
+interface MonsterState {
+  id: string;
+  currentHp: number;
+  maxHp: number;
+  gauge: number;
+  icon: string;
+}
+
+interface RhythmModeProps {
+  stage: {
+    maxHp: number;
+    enemyCount: number;
+    enemyHp: number;
+    minDamage: number;
+    maxDamage: number;
+    monsterIcon?: string;
+    allowedChords?: string[];
+    chordProgressionData?: ChordProgressionData;
+    bpm: number;
+    timeSignature: number;
+    measureCount: number;
+    countInMeasures: number;
+    mp3Url?: string;
+  };
+  onNoteOn: (note: number) => void;
+  onNoteOff: (note: number) => void;
+  onChordCorrect: (chord: ChordDefinition, isSpecial: boolean, damageDealt: number, defeated: boolean, monsterId: string) => void;
+  onChordIncorrect: (expectedChord: ChordDefinition, inputNotes: number[]) => void;
+  onEnemyAttack: (attackingMonsterId?: string) => void;
+  onGameComplete: (result: 'clear' | 'gameover') => void;
+  displayOpts?: DisplayOpts;
+}
+
+const RhythmMode: React.FC<RhythmModeProps> = ({
+  stage,
+  onNoteOn,
+  onNoteOff,
+  onChordCorrect,
+  onChordIncorrect,
+  onEnemyAttack,
+  onGameComplete,
+  displayOpts
+}) => {
+  // 時間管理
+  const { 
+    currentMeasure, 
+    currentBeat, 
+    isCountIn, 
+    bpm, 
+    timeSignature,
+    setStart
+  } = useTimeStore();
+
+  // ゲーム状態
+  const [notes, setNotes] = useState<RhythmNote[]>([]);
+  const [judgmentWindows, setJudgmentWindows] = useState<JudgmentWindow[]>([]);
+  const [inputNotes, setInputNotes] = useState<number[]>([]);
+  const [playerHp, setPlayerHp] = useState(stage?.maxHp || 100);
+  const [monster, setMonster] = useState<MonsterState | null>(null);
+  const [isGameOver, setIsGameOver] = useState(false);
+  const [lastGeneratedMeasure, setLastGeneratedMeasure] = useState(0);
+
+  // タイマー用のref
+  const animationFrameRef = useRef<number>();
+  const startTimeRef = useRef<number>(0);
+
+  /**
+   * コード定義を取得
+   */
+  const getChordDefinition = useCallback((chordId: string): ChordDefinition | null => {
+    const resolved = resolveChord(chordId, 4, displayOpts);
+    if (!resolved) {
+      console.warn(`⚠️ 未定義のコード: ${chordId}`);
+      return null;
+    }
+
+    const midiNotes = resolved.notes.map(noteName => {
+      const noteObj = parseNote(noteName + '4');
+      return noteObj && typeof noteObj.midi === 'number' ? noteObj.midi : 60;
+    });
+
+    return {
+      id: chordId,
+      displayName: resolved.displayName,
+      notes: midiNotes,
+      noteNames: resolved.notes,
+      quality: resolved.quality,
+      root: resolved.root
+    };
+  }, [displayOpts]);
+
+  /**
+   * ゲームの初期化とBGM再生
+   */
+  useEffect(() => {
+    if (!stage) return;
+    
+    // モンスターの初期化
+    setMonster({
+      id: 'rhythm_monster',
+      currentHp: stage.enemyCount * stage.enemyHp,
+      maxHp: stage.enemyCount * stage.enemyHp,
+      gauge: 0,
+      icon: stage.monsterIcon || 'ghost'
+    });
+    
+    // 時間管理の初期化
+    setStart(stage.bpm, stage.timeSignature, stage.measureCount, stage.countInMeasures);
+    
+    // BGMの再生
+    if (stage.mp3Url) {
+      bgmManager.play(stage.mp3Url, {
+        bpm: stage.bpm,
+        measureCount: stage.measureCount,
+        countInMeasures: stage.countInMeasures
+      });
+    }
+    
+    return () => {
+      // クリーンアップ時にBGMを停止
+      bgmManager.stop();
+    };
+  }, [stage, setStart]);
+
+  /**
+   * ノーツの生成（ランダムパターン）
+   */
+  const generateRandomNote = useCallback((measure: number): RhythmNote | null => {
+    if (!stage?.allowedChords?.length) return null;
+    
+    const chordId = stage.allowedChords[Math.floor(Math.random() * stage.allowedChords.length)];
+    const noteId = `note_${measure}_${Date.now()}`;
+    
+    // 判定ラインに到達する時刻を計算
+    const msPerBeat = 60000 / bpm;
+    const msPerMeasure = msPerBeat * timeSignature;
+    const targetTime = startTimeRef.current + (measure - 1) * msPerMeasure;
+    
+    return {
+      id: noteId,
+      chord: chordId,
+      measure,
+      beat: 1,
+      position: 1, // 初期位置は画面右端
+      judged: false,
+      targetTime
+    };
+  }, [stage, bpm, timeSignature]);
+
+  /**
+   * ノーツの生成（プログレッションパターン）
+   */
+  const generateProgressionNote = useCallback((measure: number): RhythmNote | null => {
+    if (!stage?.chordProgressionData) return null;
+    
+    const progressionData = stage.chordProgressionData as ChordProgressionData;
+    const chordInfo = progressionData.chords.find(c => c.measure === measure);
+    
+    if (!chordInfo) return null;
+    
+    const noteId = `note_${measure}_${chordInfo.beat}_${Date.now()}`;
+    
+    // 判定ラインに到達する時刻を計算
+    const msPerBeat = 60000 / bpm;
+    const msPerMeasure = msPerBeat * timeSignature;
+    const beatOffset = (chordInfo.beat - 1) * msPerBeat;
+    const targetTime = startTimeRef.current + (measure - 1) * msPerMeasure + beatOffset;
+    
+    return {
+      id: noteId,
+      chord: chordInfo.chord,
+      measure,
+      beat: chordInfo.beat,
+      position: 1,
+      judged: false,
+      targetTime
+    };
+  }, [stage, bpm, timeSignature]);
+
+  /**
+   * ノーツの生成管理
+   */
+  useEffect(() => {
+    if (!stage || isCountIn || isGameOver) return;
+    
+    // 現在の小節のノーツがまだ生成されていない場合
+    if (currentMeasure > lastGeneratedMeasure) {
+      const newNote = stage.chordProgressionData 
+        ? generateProgressionNote(currentMeasure)
+        : generateRandomNote(currentMeasure);
+      
+      if (newNote) {
+        setNotes(prev => [...prev, newNote]);
+        
+        // 判定ウィンドウも生成
+        const window: JudgmentWindow = {
+          startTime: newNote.targetTime - JUDGMENT_WINDOW_MS,
+          endTime: newNote.targetTime + JUDGMENT_WINDOW_MS,
+          chord: newNote.chord,
+          noteId: newNote.id,
+          judged: false
+        };
+        setJudgmentWindows(prev => [...prev, window]);
+      }
+      
+      setLastGeneratedMeasure(currentMeasure);
+    }
+  }, [currentMeasure, isCountIn, isGameOver, stage, lastGeneratedMeasure, generateRandomNote, generateProgressionNote]);
+
+  /**
+   * ノート入力処理
+   */
+  const handleNoteInput = useCallback((note: number) => {
+    setInputNotes(prev => [...prev, note]);
+    onNoteOn(note);
+  }, [onNoteOn]);
+
+  const handleNoteRelease = useCallback((note: number) => {
+    setInputNotes(prev => prev.filter(n => n !== note));
+    onNoteOff(note);
+  }, [onNoteOff]);
+
+  /**
+   * コード判定処理
+   */
+  const checkChordInput = useCallback(() => {
+    const currentTime = performance.now();
+    
+    // 現在の判定ウィンドウを探す
+    const activeWindow = judgmentWindows.find(w => 
+      !w.judged && 
+      currentTime >= w.startTime && 
+      currentTime <= w.endTime
+    );
+    
+    if (!activeWindow || inputNotes.length === 0) return;
+    
+    const chordDef = getChordDefinition(activeWindow.chord);
+    if (!chordDef) return;
+    
+    // 入力されたノートがコードと一致するかチェック
+    const sortedInput = [...inputNotes].sort();
+    const sortedChord = [...chordDef.notes].sort();
+    
+    if (JSON.stringify(sortedInput) === JSON.stringify(sortedChord)) {
+      // 判定成功
+      devLog.debug('rhythm: 判定成功', { chord: activeWindow.chord, timing: currentTime - (activeWindow.startTime + JUDGMENT_WINDOW_MS) });
+      
+      // ウィンドウとノーツを判定済みにする
+      setJudgmentWindows(prev => prev.map(w => 
+        w.noteId === activeWindow.noteId ? { ...w, judged: true } : w
+      ));
+      setNotes(prev => prev.map(n => 
+        n.id === activeWindow.noteId ? { ...n, judged: true } : n
+      ));
+      
+      // モンスターにダメージ
+      if (monster) {
+        const damage = Math.floor(Math.random() * (stage.maxDamage - stage.minDamage + 1)) + stage.minDamage;
+        const newHp = Math.max(0, monster.currentHp - damage);
+        setMonster(prev => prev ? { ...prev, currentHp: newHp } : null);
+        
+        onChordCorrect(chordDef, false, damage, newHp === 0, monster.id);
+        
+        if (newHp === 0) {
+          // ゲームクリア
+          onGameComplete('clear');
+          setIsGameOver(true);
+        }
+      }
+      
+      // 入力をクリア
+      setInputNotes([]);
+    }
+  }, [inputNotes, judgmentWindows, getChordDefinition, monster, stage, onChordCorrect, onGameComplete]);
+
+  /**
+   * 判定チェック（毎フレーム）
+   */
+  useEffect(() => {
+    checkChordInput();
+  }, [inputNotes, checkChordInput]);
+
+  /**
+   * 判定失敗チェック
+   */
+  const checkMissedWindows = useCallback(() => {
+    const currentTime = performance.now();
+    
+    judgmentWindows.forEach(window => {
+      if (!window.judged && currentTime > window.endTime) {
+        // 判定失敗
+        devLog.debug('rhythm: 判定失敗', { chord: window.chord });
+        
+        // ウィンドウを判定済みにする
+        setJudgmentWindows(prev => prev.map(w => 
+          w.noteId === window.noteId ? { ...w, judged: true } : w
+        ));
+        
+        // プレイヤーがダメージを受ける
+        const damage = Math.floor(Math.random() * (stage.maxDamage - stage.minDamage + 1)) + stage.minDamage;
+        setPlayerHp((prev: number) => {
+          const newHp = Math.max(0, prev - damage);
+          if (newHp === 0) {
+            onGameComplete('gameover');
+            setIsGameOver(true);
+          }
+          return newHp;
+        });
+        
+        onEnemyAttack(monster?.id);
+        
+        const chordDef = getChordDefinition(window.chord);
+        if (chordDef) {
+          onChordIncorrect(chordDef, inputNotes);
+        }
+      }
+    });
+  }, [judgmentWindows, stage, monster, inputNotes, getChordDefinition, onEnemyAttack, onChordIncorrect, onGameComplete]);
+
+  /**
+   * アニメーションループ
+   */
+  useEffect(() => {
+    if (!startTimeRef.current) {
+      startTimeRef.current = performance.now();
+    }
+    
+    const animate = () => {
+      checkMissedWindows();
+      animationFrameRef.current = requestAnimationFrame(animate);
+    };
+    
+    animationFrameRef.current = requestAnimationFrame(animate);
+    
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [checkMissedWindows]);
+
+  return (
+    <div className="rhythm-mode">
+      {/* HP表示 */}
+      <div className="rhythm-hp-display">
+        <div className="player-hp">
+          <span>Player HP: {playerHp}/{stage?.maxHp || 100}</span>
+          <div className="hp-bar">
+            <div 
+              className="hp-fill"
+              style={{ width: `${(playerHp / (stage?.maxHp || 100)) * 100}%` }}
+            />
+          </div>
+        </div>
+        {monster && (
+          <div className="monster-hp">
+            <span>Monster HP: {monster.currentHp}/{monster.maxHp}</span>
+            <div className="hp-bar">
+              <div 
+                className="hp-fill enemy"
+                style={{ width: `${(monster.currentHp / monster.maxHp) * 100}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ノーツ表示 */}
+      <RhythmNotes 
+        notes={notes}
+        bpm={bpm}
+        timeSignature={timeSignature}
+        displayOpts={displayOpts}
+      />
+
+      {/* 判定ウィンドウ（見えない） */}
+      <RhythmJudgmentWindow
+        windows={judgmentWindows}
+        onNoteInput={handleNoteInput}
+        onNoteRelease={handleNoteRelease}
+      />
+
+      {/* デバッグ情報 */}
+      {process.env.NODE_ENV === 'development' && (
+        <div className="rhythm-debug">
+          <div>M{currentMeasure} B{currentBeat}</div>
+          <div>Input: {inputNotes.join(', ')}</div>
+          <div>Active Windows: {judgmentWindows.filter(w => !w.judged).length}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RhythmMode;

--- a/src/components/fantasy/RhythmNotes.css
+++ b/src/components/fantasy/RhythmNotes.css
@@ -1,0 +1,129 @@
+/* リズムノーツのスタイル */
+
+.rhythm-notes-container {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  background-color: rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+  border: 2px solid #333;
+  border-radius: 8px;
+}
+
+/* 判定ライン */
+.judgment-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background-color: #ff6b6b;
+  box-shadow: 0 0 10px #ff6b6b;
+  z-index: 10;
+}
+
+/* レーン（ガイドライン） */
+.rhythm-lane {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-50%);
+}
+
+/* ノーツ */
+.rhythm-note {
+  position: absolute;
+  width: 120px;
+  height: 60px;
+  background-color: #4ecdc4;
+  border: 2px solid #45b7b8;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.3s;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.rhythm-note.judged {
+  opacity: 0.3;
+  background-color: #95a5a6;
+  border-color: #7f8c8d;
+}
+
+.rhythm-note .chord-name {
+  font-size: 24px;
+  font-weight: bold;
+  color: white;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+/* HP表示 */
+.rhythm-hp-display {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: rgba(0, 0, 0, 0.6);
+  border-radius: 8px;
+}
+
+.player-hp,
+.monster-hp {
+  flex: 1;
+  margin: 0 10px;
+}
+
+.player-hp span,
+.monster-hp span {
+  color: white;
+  font-weight: bold;
+  display: block;
+  margin-bottom: 5px;
+}
+
+.hp-bar {
+  width: 100%;
+  height: 20px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  overflow: hidden;
+  position: relative;
+}
+
+.hp-fill {
+  height: 100%;
+  background-color: #2ecc71;
+  transition: width 0.3s ease;
+}
+
+.hp-fill.enemy {
+  background-color: #e74c3c;
+}
+
+/* デバッグ情報 */
+.rhythm-debug {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+  font-family: monospace;
+  font-size: 12px;
+  z-index: 1000;
+}
+
+.rhythm-debug div {
+  margin: 2px 0;
+}
+
+/* メインコンテナ */
+.rhythm-mode {
+  padding: 20px;
+  min-height: 100vh;
+  background-color: #1a1a1a;
+}

--- a/src/components/fantasy/RhythmNotes.tsx
+++ b/src/components/fantasy/RhythmNotes.tsx
@@ -1,0 +1,103 @@
+/**
+ * リズムノーツ表示コンポーネント
+ * 右から左に流れる横長長方形のノーツを表示
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { RhythmNote, NOTE_SPEED, JUDGMENT_LINE_POSITION } from '@/types/rhythm';
+import { toDisplayChordName, type DisplayOpts } from '@/utils/display-note';
+import './RhythmNotes.css';
+
+interface RhythmNotesProps {
+  notes: RhythmNote[];
+  bpm: number;
+  timeSignature: number;
+  displayOpts?: DisplayOpts;
+}
+
+const RhythmNotes: React.FC<RhythmNotesProps> = ({
+  notes,
+  bpm: _bpm,
+  timeSignature: _timeSignature,
+  displayOpts
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationFrameRef = useRef<number>();
+
+  useEffect(() => {
+    const animate = () => {
+      const currentTime = performance.now();
+      const container = containerRef.current;
+      if (!container) return;
+
+      const containerWidth = container.offsetWidth;
+      const judgmentLineX = containerWidth * JUDGMENT_LINE_POSITION;
+
+      // ノーツの位置を更新
+      notes.forEach(note => {
+        const noteElement = document.getElementById(`note-${note.id}`);
+        if (!noteElement || note.judged) return;
+
+        // ノーツが判定ラインに到達するまでの時間
+        const timeUntilJudgment = note.targetTime - currentTime;
+        
+        // 位置を計算（判定ラインからの距離）
+        const distanceFromJudgmentLine = (timeUntilJudgment / 1000) * (containerWidth / NOTE_SPEED);
+        const x = judgmentLineX + distanceFromJudgmentLine;
+
+        // ノーツの位置を更新
+        noteElement.style.transform = `translateX(${x}px)`;
+
+        // 画面外に出たノーツは非表示
+        if (x < -100) {
+          noteElement.style.display = 'none';
+        } else {
+          noteElement.style.display = 'block';
+        }
+      });
+
+      animationFrameRef.current = requestAnimationFrame(animate);
+    };
+
+    animationFrameRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [notes]);
+
+  return (
+    <div className="rhythm-notes-container" ref={containerRef}>
+      {/* 判定ライン */}
+      <div 
+        className="judgment-line"
+        style={{ left: `${JUDGMENT_LINE_POSITION * 100}%` }}
+      />
+      
+      {/* レーン（ガイドライン） */}
+      <div className="rhythm-lane" />
+      
+      {/* ノーツ */}
+      {notes.map(note => (
+        <div
+          key={note.id}
+          id={`note-${note.id}`}
+          className={`rhythm-note ${note.judged ? 'judged' : ''}`}
+          style={{
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)'
+          }}
+        >
+          <span className="chord-name">
+            {displayOpts ? toDisplayChordName(note.chord, displayOpts) : note.chord}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RhythmNotes;

--- a/src/types/rhythm.ts
+++ b/src/types/rhythm.ts
@@ -1,0 +1,47 @@
+/**
+ * リズムモード用の型定義
+ */
+
+// ノーツの型定義
+export interface RhythmNote {
+  id: string;
+  chord: string;
+  measure: number;
+  beat: number;
+  position: number; // 画面上のX座標
+  judged: boolean;
+  targetTime: number; // 判定ラインに到達する時刻(ms)
+}
+
+// 判定ウィンドウの型定義
+export interface JudgmentWindow {
+  startTime: number;
+  endTime: number;
+  chord: string;
+  noteId: string;
+  judged: boolean;
+}
+
+// リズムモードの状態
+export interface RhythmModeState {
+  notes: RhythmNote[];
+  judgmentWindows: JudgmentWindow[];
+  currentNoteIndex: number;
+  score: number;
+  combo: number;
+  isPlaying: boolean;
+}
+
+// コード進行データの型定義
+export interface ChordProgressionData {
+  chords: Array<{
+    measure: number;
+    beat: number;
+    chord: string;
+  }>;
+}
+
+// 判定タイミングの設定
+export const JUDGMENT_WINDOW_MS = 200; // 前後200ms
+export const NOTE_SPEED = 2; // ノーツの速度（秒/画面幅）
+export const JUDGMENT_LINE_POSITION = 0.1; // 画面左端から10%の位置

--- a/supabase/migrations/20250801000000_add_rhythm_mode_columns.sql
+++ b/supabase/migrations/20250801000000_add_rhythm_mode_columns.sql
@@ -1,0 +1,21 @@
+-- Add rhythm mode columns to fantasy_stages table
+ALTER TABLE fantasy_stages 
+ADD COLUMN IF NOT EXISTS bpm INTEGER DEFAULT 120 CHECK (bpm > 0 AND bpm <= 300),
+ADD COLUMN IF NOT EXISTS measure_count INTEGER DEFAULT 8 CHECK (measure_count > 0 AND measure_count <= 64),
+ADD COLUMN IF NOT EXISTS time_signature INTEGER DEFAULT 4 CHECK (time_signature > 0 AND time_signature <= 16),
+ADD COLUMN IF NOT EXISTS count_in_measures INTEGER DEFAULT 1 CHECK (count_in_measures >= 0 AND count_in_measures <= 4),
+ADD COLUMN IF NOT EXISTS mp3_url VARCHAR,
+ADD COLUMN IF NOT EXISTS chord_progression_data JSONB;
+
+-- Update mode check constraint to include rhythm mode
+ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
+ALTER TABLE fantasy_stages ADD CONSTRAINT fantasy_stages_mode_check 
+CHECK (mode IN ('single', 'progression', 'rhythm'));
+
+-- Add comments
+COMMENT ON COLUMN fantasy_stages.bpm IS 'BPM (Beats Per Minute)';
+COMMENT ON COLUMN fantasy_stages.measure_count IS '小節数';
+COMMENT ON COLUMN fantasy_stages.time_signature IS '拍子 (例: 4=4/4拍子, 3=3/4拍子)';
+COMMENT ON COLUMN fantasy_stages.count_in_measures IS 'カウントイン小節数 (BGMループ開始前の小節数)';
+COMMENT ON COLUMN fantasy_stages.mp3_url IS 'BGMファイルのURL';
+COMMENT ON COLUMN fantasy_stages.chord_progression_data IS 'リズムモード用のコード進行データ (JSON形式)';


### PR DESCRIPTION
Adds a new 'Rhythm Mode' to the fantasy game, introducing rhythm-based chord input gameplay alongside the existing quiz mode.

This new mode features a Taiko no Tatsujin-style UI with notes flowing from right to left, a ±200ms judgment window for chord completion, and supports both random and predefined chord progressions. It also decouples player/enemy attacks from specific chords, focusing purely on timing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b666ec94-b62f-42da-8f62-abe4aa110e96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b666ec94-b62f-42da-8f62-abe4aa110e96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>