### PR TITLE
Implement rhythm mode with timing and judgment mechanics

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -888,9 +888,21 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
                       >
                         <div
-                          className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
+                          className={cn(
+                            "h-full transition-all duration-100",
+                            gameState.isRhythmMode && monster.gauge >= 90
+                              ? "bg-gradient-to-r from-yellow-500 to-yellow-600" // 判定ウィンドウ内
+                              : "bg-gradient-to-r from-purple-500 to-purple-700" // 通常
+                          )}
                           style={{ width: `${monster.gauge}%` }}
                         />
+                        {/* リズムモード: 判定ウィンドウの視覚的表示 */}
+                        {gameState.isRhythmMode && (
+                          <div
+                            className="absolute h-full bg-white bg-opacity-20 right-0"
+                            style={{ width: '10%' }} // 90-100%の範囲
+                          />
+                        )}
                       </div>
                       
                       {/* HPゲージ */}

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -299,6 +299,21 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモード情報 */}
+          {unlocked && stage.bgmUrl && stage.bpm && (
+            <div className="mt-2 flex items-center gap-2 text-xs">
+              <span className="px-2 py-1 bg-purple-600 bg-opacity-50 rounded text-purple-200">
+                リズムタイプ
+              </span>
+              <span className="px-2 py-1 bg-blue-600 bg-opacity-50 rounded text-blue-200">
+                {stage.chordProgressionData ? "コード進行" : "ランダム"}
+              </span>
+              <span className="text-gray-400">
+                BPM: {stage.bpm}
+              </span>
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -16,6 +16,12 @@ const ToastContainer: React.FC = () => {
 
 const ToastItem: React.FC<{ toast: Toast; onRemove: (id: string) => void }> = ({ toast, onRemove }) => {
   const [isExiting, setIsExiting] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  // マウント時にアニメーションを開始
+  useEffect(() => {
+    setTimeout(() => setIsVisible(true), 10);
+  }, []);
 
   const handleRemove = useCallback(() => {
     setIsExiting(true);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -648,6 +648,13 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: {
+    chords: Array<{
+      chord: string;
+      measure: number;
+      beat: number;
+    }>;
+  } | null;
 }
 
 export interface LessonContext {

--- a/supabase/migrations/20250101000000_add_rhythm_mode.sql
+++ b/supabase/migrations/20250101000000_add_rhythm_mode.sql
@@ -1,0 +1,12 @@
+-- Add chord_progression_data column for rhythm mode
+ALTER TABLE fantasy_stages
+ADD COLUMN IF NOT EXISTS chord_progression_data JSONB DEFAULT NULL;
+
+-- Update column comment
+COMMENT ON COLUMN fantasy_stages.chord_progression_data IS 'リズムモード用のコード進行データ (JSON形式)';
+
+-- Existing mode values remain the same ('single', 'progression')
+-- These will be used in combination with the game logic to determine behavior:
+-- - Quiz mode: Uses mode field normally
+-- - Rhythm mode (random): mode='single' and chord_progression_data IS NULL
+-- - Rhythm mode (progression): mode='progression' and chord_progression_data IS NOT NULL


### PR DESCRIPTION
Add Rhythm Mode to Fantasy game, introducing timed chord input with judgment windows and distinct random/progression patterns.

This PR implements a new game mode where players input chords in sync with music. It includes a ±200ms judgment window, question display 3 beats before judgment, and handles two patterns: a random mode with fixed 1-beat judgment/2-beat question timing per measure, and a progression mode using predefined `chord_progression_data`. UI updates include visual judgment windows on the gauge and chord names below monsters.

---
<a href="https://cursor.com/background-agent?bcId=bc-802081a9-2a16-47ef-bbe5-ebfe9e9e6d35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-802081a9-2a16-47ef-bbe5-ebfe9e9e6d35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>