### PR TITLE
feat: add rhythm mode stage metadata

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -46,6 +46,9 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  gameType?: 'quiz' | 'rhythm';
+  rhythmPattern?: 'random' | 'progression';
+  chordProgressionData?: Array<{ chord: string; measure: number; beat: number }>;
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -170,7 +170,10 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
         countInMeasures: stage.count_in_measures,
-        timeSignature: stage.time_signature
+        timeSignature: stage.time_signature,
+        gameType: stage.game_type as 'quiz' | 'rhythm',
+        rhythmPattern: stage.rhythm_pattern as 'random' | 'progression' | undefined,
+        chordProgressionData: Array.isArray(stage.chord_progression_data) ? stage.chord_progression_data : undefined
       }));
       
       const convertedProgress: FantasyUserProgress = {
@@ -299,6 +302,13 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          {unlocked && (
+            <div className="text-xs mt-1 text-gray-400">
+              {stage.gameType === 'rhythm'
+                ? `リズム（${stage.rhythmPattern === 'progression' ? 'コード進行' : 'ランダム'}）`
+                : 'クイズ'}
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -648,6 +648,9 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  game_type?: 'quiz' | 'rhythm';
+  rhythm_pattern?: 'random' | 'progression';
+  chord_progression_data?: Array<{ chord: string; measure: number; beat: number }>;
 }
 
 export interface LessonContext {


### PR DESCRIPTION
## Summary
- extend stage types with rhythm mode fields for game engine and shared types
- show rhythm type and pattern on fantasy stage cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 430 errors, 400 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688da14a4c30832884ce7116cc93ba69