### PR TITLE
Implement new rhythm mode for fantasy

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import FantasyStageSelect from './FantasyStageSelect';
 import FantasyGameScreen from './FantasyGameScreen';
+import { RhythmGameScreen } from './RhythmGameScreen';
 import { FantasyStage } from './FantasyGameEngine';
 import { useAuthStore } from '@/stores/authStore';
 import { useGameStore } from '@/stores/gameStore';
@@ -561,6 +562,26 @@ const FantasyMain: React.FC = () => {
   
   // ゲーム画面
   if (currentStage) {
+    // リズムモードの場合
+    if (currentStage.mode === 'rhythm') {
+      const rhythmStage = {
+        ...currentStage,
+        mode: 'rhythm' as const,
+        chordProgressionData: currentStage.chordProgression || null,
+      };
+      
+      return (
+        <RhythmGameScreen
+          stage={rhythmStage}
+          onBackToMenu={handleBackToStageSelect}
+          onGameEnd={(result, score) => {
+            handleGameComplete(result, score, score > 0 ? 1 : 0, 1); // スコアがあれば正解扱い
+          }}
+        />
+      );
+    }
+    
+    // クイズモード（既存のコード）
     return (
       <FantasyGameScreen
         // ▼▼▼ 追加 ▼▼▼

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -299,6 +299,13 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモードの場合、タイプを表示 */}
+          {unlocked && stage.mode === 'rhythm' && (
+            <div className="text-xs text-yellow-300 mt-1">
+              リズムタイプ: {stage.chordProgression ? 'コード進行' : 'ランダム'}
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/components/fantasy/RhythmGameEngine.tsx
+++ b/src/components/fantasy/RhythmGameEngine.tsx
@@ -1,0 +1,409 @@
+/**
+ * リズムゲームエンジン
+ * リズムに合わせてコードを演奏するゲームモードのロジック
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { devLog } from '@/utils/logger';
+import { resolveChord } from '@/utils/chord-utils';
+import { toDisplayChordName } from '@/utils/display-note';
+import { useTimeStore } from '@/stores/timeStore';
+
+// ===== 型定義 =====
+
+interface ChordDefinition {
+  id: string;
+  displayName: string;
+  notes: number[];
+  noteNames: string[];
+  quality: string;
+  root: string;
+}
+
+interface RhythmStage {
+  id: string;
+  stageNumber: string;
+  name: string;
+  description: string;
+  maxHp: number;
+  enemyCount: number;
+  enemyHp: number;
+  minDamage: number;
+  maxDamage: number;
+  mode: 'rhythm';
+  allowedChords: string[];
+  chordProgressionData?: string[] | null;
+  showSheetMusic: boolean;
+  showGuide: boolean;
+  monsterIcon: string;
+  bgmUrl?: string;
+  bpm: number;
+  measureCount?: number;
+  countInMeasures?: number;
+  timeSignature?: number;
+}
+
+interface ChordNote {
+  id: string;
+  chord: ChordDefinition;
+  targetTime: number; // ヒットすべき時刻（ms）
+  position: number; // 現在のX座標（0-1000）
+  hit: boolean;
+  missed: boolean;
+}
+
+interface RhythmGameState {
+  currentStage: RhythmStage | null;
+  playerHp: number;
+  score: number;
+  combo: number;
+  maxCombo: number;
+  totalNotes: number;
+  perfectCount: number;
+  greatCount: number;
+  goodCount: number;
+  missCount: number;
+  isGameActive: boolean;
+  isGameOver: boolean;
+  gameResult: 'clear' | 'gameover' | null;
+  chordNotes: ChordNote[];
+  currentBeat: number;
+  measureNumber: number;
+  isCountIn: boolean;
+}
+
+type TimingJudgment = 'perfect' | 'great' | 'good' | 'miss';
+
+interface RhythmGameEngineProps {
+  stage: RhythmStage | null;
+  onGameStateChange: (state: RhythmGameState) => void;
+  playingChordIds: string[];
+  onGameEnd: (result: 'clear' | 'gameover', score: number) => void;
+}
+
+// ===== 定数 =====
+const JUDGMENT_WINDOW = {
+  perfect: 50,  // ±50ms
+  great: 100,   // ±100ms
+  good: 200,    // ±200ms
+};
+
+const LANE_LENGTH = 1000; // レーンの長さ（論理座標）
+const NOTE_SPEED_FACTOR = 0.5; // ノートの速度調整係数
+
+// ===== リズムゲームエンジン本体 =====
+export const RhythmGameEngine: React.FC<RhythmGameEngineProps> = ({
+  stage,
+  onGameStateChange,
+  playingChordIds,
+  onGameEnd,
+}) => {
+  const [gameState, setGameState] = useState<RhythmGameState>({
+    currentStage: null,
+    playerHp: 100,
+    score: 0,
+    combo: 0,
+    maxCombo: 0,
+    totalNotes: 0,
+    perfectCount: 0,
+    greatCount: 0,
+    goodCount: 0,
+    missCount: 0,
+    isGameActive: false,
+    isGameOver: false,
+    gameResult: null,
+    chordNotes: [],
+    currentBeat: 0,
+    measureNumber: 0,
+    isCountIn: true,
+  });
+
+  const startTimeRef = useRef<number>(0);
+  const animationFrameRef = useRef<number>(0);
+  const lastNoteSpawnTimeRef = useRef<number>(0);
+  const beatIntervalRef = useRef<number>(0);
+
+  // タイミング判定
+  const judgeTimingWindow = useCallback((deltaTime: number): TimingJudgment => {
+    const absDelta = Math.abs(deltaTime);
+    if (absDelta <= JUDGMENT_WINDOW.perfect) return 'perfect';
+    if (absDelta <= JUDGMENT_WINDOW.great) return 'great';
+    if (absDelta <= JUDGMENT_WINDOW.good) return 'good';
+    return 'miss';
+  }, []);
+
+  // スコア計算
+  const calculateScore = useCallback((judgment: TimingJudgment, combo: number): number => {
+    const baseScore = {
+      perfect: 1000,
+      great: 700,
+      good: 400,
+      miss: 0,
+    }[judgment];
+
+    const comboBonus = Math.min(combo * 10, 500);
+    return baseScore + comboBonus;
+  }, []);
+
+  // ダメージ計算
+  const calculateDamage = useCallback((judgment: TimingJudgment, stage: RhythmStage): number => {
+    if (!stage) return 0;
+    
+    const damageMultiplier = {
+      perfect: 1.5,
+      great: 1.2,
+      good: 1.0,
+      miss: 0,
+    }[judgment];
+
+    const baseDamage = stage.minDamage + Math.random() * (stage.maxDamage - stage.minDamage);
+    return Math.floor(baseDamage * damageMultiplier);
+  }, []);
+
+  // コードノートの生成
+  const generateChordNote = useCallback((stage: RhythmStage, targetTime: number): ChordNote => {
+    const chordId = stage.allowedChords[Math.floor(Math.random() * stage.allowedChords.length)];
+    const resolved = resolveChord(chordId);
+    
+    if (!resolved) {
+      throw new Error(`Invalid chord ID: ${chordId}`);
+    }
+
+    const chord: ChordDefinition = {
+      id: chordId,
+      displayName: toDisplayChordName(chordId, { lang: 'ja', isSimple: true }),
+      notes: resolved.notes,
+      noteNames: resolved.noteNames,
+      quality: resolved.quality,
+      root: resolved.root,
+    };
+
+    return {
+      id: `${Date.now()}-${Math.random()}`,
+      chord,
+      targetTime,
+      position: LANE_LENGTH, // 右端から開始
+      hit: false,
+      missed: false,
+    };
+  }, []);
+
+  // ゲーム開始
+  const startGame = useCallback(() => {
+    if (!stage) return;
+
+    const bpm = stage.bpm || 120;
+    const beatInterval = 60000 / bpm; // 1拍の長さ（ms）
+    beatIntervalRef.current = beatInterval;
+
+    const countInMeasures = stage.countInMeasures || 2;
+    const countInTime = countInMeasures * 4 * beatInterval; // 4/4拍子想定
+
+    startTimeRef.current = Date.now() + countInTime;
+    
+    setGameState({
+      currentStage: stage,
+      playerHp: stage.maxHp,
+      score: 0,
+      combo: 0,
+      maxCombo: 0,
+      totalNotes: 0,
+      perfectCount: 0,
+      greatCount: 0,
+      goodCount: 0,
+      missCount: 0,
+      isGameActive: true,
+      isGameOver: false,
+      gameResult: null,
+      chordNotes: [],
+      currentBeat: 0,
+      measureNumber: 0,
+      isCountIn: true,
+    });
+
+    devLog('Rhythm game started', { stage: stage.name, bpm, countInTime });
+  }, [stage]);
+
+  // ゲームループ
+  const gameLoop = useCallback(() => {
+    if (!gameState.isGameActive || !gameState.currentStage) return;
+
+    const currentTime = Date.now();
+    const gameTime = currentTime - startTimeRef.current;
+
+    // カウントイン終了チェック
+    if (gameState.isCountIn && gameTime >= 0) {
+      setGameState(prev => ({ ...prev, isCountIn: false }));
+    }
+
+    // ノートの生成（毎小節の1拍目）
+    if (!gameState.isCountIn && gameTime >= 0) {
+      const beatInterval = beatIntervalRef.current;
+      const measureInterval = beatInterval * 4; // 4/4拍子
+      const nextNoteTime = Math.floor(gameTime / measureInterval) * measureInterval + measureInterval;
+
+      if (nextNoteTime - lastNoteSpawnTimeRef.current >= measureInterval - 100) {
+        const targetTime = startTimeRef.current + nextNoteTime;
+        const newNote = generateChordNote(gameState.currentStage, targetTime);
+        
+        setGameState(prev => ({
+          ...prev,
+          chordNotes: [...prev.chordNotes, newNote],
+          totalNotes: prev.totalNotes + 1,
+        }));
+
+        lastNoteSpawnTimeRef.current = nextNoteTime;
+      }
+    }
+
+    // ノートの移動と判定
+    setGameState(prev => {
+      const updatedNotes = prev.chordNotes.map(note => {
+        if (note.hit || note.missed) return note;
+
+        // ノートの位置更新
+        const timeToTarget = note.targetTime - currentTime;
+        const position = (timeToTarget / (beatIntervalRef.current * 4)) * LANE_LENGTH * NOTE_SPEED_FACTOR;
+
+        // ミス判定（判定ラインを超えた）
+        if (position < -JUDGMENT_WINDOW.good) {
+          return { ...note, position: 0, missed: true };
+        }
+
+        return { ...note, position: Math.max(0, position) };
+      });
+
+      // ミスした場合の処理
+      const newMisses = updatedNotes.filter(n => n.missed && !prev.chordNotes.find(pn => pn.id === n.id)?.missed);
+      if (newMisses.length > 0) {
+        const damage = prev.currentStage?.enemyHp || 10;
+        const newHp = Math.max(0, prev.playerHp - damage * newMisses.length);
+        
+        return {
+          ...prev,
+          chordNotes: updatedNotes.filter(n => !n.missed || currentTime - n.targetTime < 1000),
+          playerHp: newHp,
+          combo: 0,
+          missCount: prev.missCount + newMisses.length,
+          isGameOver: newHp <= 0,
+          gameResult: newHp <= 0 ? 'gameover' : null,
+        };
+      }
+
+      return { ...prev, chordNotes: updatedNotes };
+    });
+
+    animationFrameRef.current = requestAnimationFrame(gameLoop);
+  }, [gameState, generateChordNote]);
+
+  // コード入力処理
+  const handleChordInput = useCallback(() => {
+    if (!gameState.isGameActive || gameState.isCountIn) return;
+    if (playingChordIds.length === 0) return;
+
+    const currentTime = Date.now();
+    const playingChordId = playingChordIds[0]; // 単一コードのみ対応
+
+    // 判定可能なノートを探す
+    const targetNote = gameState.chordNotes.find(note => {
+      if (note.hit || note.missed) return false;
+      const deltaTime = currentTime - note.targetTime;
+      return Math.abs(deltaTime) <= JUDGMENT_WINDOW.good;
+    });
+
+    if (!targetNote) {
+      devLog('No notes in judgment window');
+      return;
+    }
+
+    // コード判定
+    const isCorrect = targetNote.chord.id === playingChordId;
+    if (!isCorrect) {
+      devLog('Wrong chord', { expected: targetNote.chord.id, played: playingChordId });
+      return;
+    }
+
+    // タイミング判定
+    const deltaTime = currentTime - targetNote.targetTime;
+    const judgment = judgeTimingWindow(deltaTime);
+
+    // スコアとダメージの計算
+    const score = calculateScore(judgment, gameState.combo);
+    const damage = calculateDamage(judgment, gameState.currentStage!);
+
+    // 状態更新
+    setGameState(prev => {
+      const newCombo = judgment !== 'miss' ? prev.combo + 1 : 0;
+      const enemyHp = prev.currentStage!.enemyHp * prev.totalNotes;
+      const totalDamageDealt = (prev.perfectCount + prev.greatCount + prev.goodCount + 1) * prev.currentStage!.enemyHp;
+
+      const updatedState = {
+        ...prev,
+        chordNotes: prev.chordNotes.map(n => 
+          n.id === targetNote.id ? { ...n, hit: true } : n
+        ),
+        score: prev.score + score,
+        combo: newCombo,
+        maxCombo: Math.max(prev.maxCombo, newCombo),
+        perfectCount: prev.perfectCount + (judgment === 'perfect' ? 1 : 0),
+        greatCount: prev.greatCount + (judgment === 'great' ? 1 : 0),
+        goodCount: prev.goodCount + (judgment === 'good' ? 1 : 0),
+      };
+
+      // クリア判定
+      if (totalDamageDealt >= enemyHp) {
+        return {
+          ...updatedState,
+          isGameActive: false,
+          gameResult: 'clear',
+        };
+      }
+
+      return updatedState;
+    });
+
+    devLog('Chord hit', { judgment, score, damage, combo: gameState.combo });
+  }, [gameState, playingChordIds, judgeTimingWindow, calculateScore, calculateDamage]);
+
+  // ゲーム終了処理
+  useEffect(() => {
+    if (gameState.gameResult && !gameState.isGameActive) {
+      cancelAnimationFrame(animationFrameRef.current);
+      onGameEnd(gameState.gameResult, gameState.score);
+    }
+  }, [gameState.gameResult, gameState.isGameActive, gameState.score, onGameEnd]);
+
+  // プレイ中のコードが変わったら判定
+  useEffect(() => {
+    handleChordInput();
+  }, [playingChordIds, handleChordInput]);
+
+  // ゲームループの開始/停止
+  useEffect(() => {
+    if (gameState.isGameActive) {
+      animationFrameRef.current = requestAnimationFrame(gameLoop);
+    } else {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    return () => {
+      cancelAnimationFrame(animationFrameRef.current);
+    };
+  }, [gameState.isGameActive, gameLoop]);
+
+  // ステージが設定されたらゲーム開始
+  useEffect(() => {
+    if (stage) {
+      startGame();
+    }
+  }, [stage, startGame]);
+
+  // 状態変更を親コンポーネントに通知
+  useEffect(() => {
+    onGameStateChange(gameState);
+  }, [gameState, onGameStateChange]);
+
+  return null; // このコンポーネントは表示要素を持たない
+};
+
+export type { RhythmStage, RhythmGameState, ChordNote, TimingJudgment };

--- a/src/components/fantasy/RhythmGameScreen.tsx
+++ b/src/components/fantasy/RhythmGameScreen.tsx
@@ -1,0 +1,316 @@
+/**
+ * リズムゲーム画面
+ * コードが右から左に流れるリズムゲームの表示を担当
+ */
+
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { cn } from '@/utils/cn';
+import { usePianoStore } from '@/stores/pianoStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { Button } from '@/components/ui/button';
+import { Piano } from '@/components/Piano';
+import { RhythmGameEngine, type RhythmGameState, type RhythmStage, type ChordNote } from './RhythmGameEngine';
+import { devLog } from '@/utils/logger';
+
+interface RhythmGameScreenProps {
+  stage: RhythmStage;
+  onBackToMenu: () => void;
+  onGameEnd: (result: 'clear' | 'gameover', score: number) => void;
+}
+
+export const RhythmGameScreen: React.FC<RhythmGameScreenProps> = ({
+  stage,
+  onBackToMenu,
+  onGameEnd,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationFrameRef = useRef<number>(0);
+  const [gameState, setGameState] = useState<RhythmGameState | null>(null);
+  const [isGameStarted, setIsGameStarted] = useState(false);
+  
+  const { playingChordIds } = usePianoStore();
+  const { settings } = useSettingsStore();
+
+  // Canvas描画
+  const draw = useCallback((ctx: CanvasRenderingContext2D, state: RhythmGameState) => {
+    const canvas = ctx.canvas;
+    const width = canvas.width;
+    const height = canvas.height;
+
+    // 背景のクリア
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, 0, width, height);
+
+    // レーンの描画
+    const laneY = height / 2;
+    const laneHeight = 100;
+    
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.1)';
+    ctx.fillRect(0, laneY - laneHeight / 2, width, laneHeight);
+
+    // 判定ラインの描画
+    const judgmentLineX = 100;
+    ctx.strokeStyle = '#ff6b6b';
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.moveTo(judgmentLineX, laneY - laneHeight);
+    ctx.lineTo(judgmentLineX, laneY + laneHeight);
+    ctx.stroke();
+
+    // 判定ウィンドウの可視化（デバッグ用）
+    if (settings.isDevelopment) {
+      ctx.fillStyle = 'rgba(255, 107, 107, 0.1)';
+      ctx.fillRect(judgmentLineX - 20, laneY - laneHeight / 2, 40, laneHeight);
+    }
+
+    // カウントイン表示
+    if (state.isCountIn) {
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '48px bold sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('READY...', width / 2, height / 2);
+      return;
+    }
+
+    // コードノートの描画
+    state.chordNotes.forEach(note => {
+      if (note.hit || note.missed) return;
+
+      const noteX = judgmentLineX + (note.position / 1000) * (width - judgmentLineX - 100);
+      const noteWidth = 80;
+      const noteHeight = 60;
+      const noteY = laneY - noteHeight / 2;
+
+      // ノートの背景
+      ctx.fillStyle = '#4ecdc4';
+      ctx.fillRect(noteX - noteWidth / 2, noteY, noteWidth, noteHeight);
+
+      // ノートの枠線
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(noteX - noteWidth / 2, noteY, noteWidth, noteHeight);
+
+      // コード名
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '20px bold sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(note.chord.displayName, noteX, laneY);
+    });
+
+    // ゲーム情報の表示
+    // スコア
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '24px bold sans-serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(`SCORE: ${state.score}`, 20, 20);
+
+    // コンボ
+    if (state.combo > 0) {
+      ctx.fillStyle = '#ffd93d';
+      ctx.font = '32px bold sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(`${state.combo} COMBO`, width / 2, height - 100);
+    }
+
+    // HP表示
+    const hpBarWidth = 300;
+    const hpBarHeight = 20;
+    const hpBarX = width - hpBarWidth - 20;
+    const hpBarY = 20;
+    const hpPercentage = state.playerHp / (stage.maxHp || 100);
+
+    // HPバーの背景
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+    ctx.fillRect(hpBarX, hpBarY, hpBarWidth, hpBarHeight);
+
+    // HPバー
+    ctx.fillStyle = hpPercentage > 0.3 ? '#4ecdc4' : '#ff6b6b';
+    ctx.fillRect(hpBarX, hpBarY, hpBarWidth * hpPercentage, hpBarHeight);
+
+    // HPバーの枠線
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(hpBarX, hpBarY, hpBarWidth, hpBarHeight);
+
+    // HP数値
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '16px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillText(`HP: ${state.playerHp}/${stage.maxHp}`, hpBarX - 10, hpBarY);
+
+    // 判定結果の表示（最新のヒット時のみ）
+    const recentHit = state.chordNotes.find(n => n.hit);
+    if (recentHit) {
+      const timeSinceHit = Date.now() - recentHit.targetTime;
+      if (timeSinceHit < 1000) {
+        const alpha = 1 - timeSinceHit / 1000;
+        ctx.fillStyle = `rgba(255, 215, 0, ${alpha})`;
+        ctx.font = '36px bold sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        
+        const judgment = state.perfectCount > 0 ? 'PERFECT!' : 
+                        state.greatCount > 0 ? 'GREAT!' : 
+                        state.goodCount > 0 ? 'GOOD!' : '';
+        
+        if (judgment) {
+          ctx.fillText(judgment, width / 2, height / 2 - 100);
+        }
+      }
+    }
+  }, [stage, settings]);
+
+  // アニメーションループ
+  const animate = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    
+    if (ctx && gameState && gameState.isGameActive) {
+      draw(ctx, gameState);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(animate);
+  }, [gameState, draw]);
+
+  // Canvas のリサイズ処理
+  useEffect(() => {
+    const handleResize = () => {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        canvas.width = canvas.offsetWidth;
+        canvas.height = canvas.offsetHeight;
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // アニメーションの開始/停止
+  useEffect(() => {
+    if (isGameStarted && gameState) {
+      animationFrameRef.current = requestAnimationFrame(animate);
+    } else {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    return () => {
+      cancelAnimationFrame(animationFrameRef.current);
+    };
+  }, [isGameStarted, gameState, animate]);
+
+  // ゲーム開始
+  const handleStartGame = () => {
+    setIsGameStarted(true);
+  };
+
+  // ゲーム終了処理
+  const handleGameEnd = useCallback((result: 'clear' | 'gameover', score: number) => {
+    setIsGameStarted(false);
+    onGameEnd(result, score);
+  }, [onGameEnd]);
+
+  return (
+    <div className="flex flex-col h-screen bg-gray-900">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between p-4 bg-gray-800">
+        <Button
+          variant="ghost"
+          onClick={onBackToMenu}
+          className="text-white hover:bg-gray-700"
+        >
+          ← メニューに戻る
+        </Button>
+        <h2 className="text-2xl font-bold text-white">
+          {stage.name} - リズムモード
+        </h2>
+        <div className="w-32" /> {/* スペーサー */}
+      </div>
+
+      {/* ゲーム画面 */}
+      <div className="flex-1 relative">
+        <canvas
+          ref={canvasRef}
+          className="w-full h-full"
+          style={{ imageRendering: 'pixelated' }}
+        />
+
+        {/* ゲーム開始前のオーバーレイ */}
+        {!isGameStarted && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="text-center">
+              <h3 className="text-3xl font-bold text-white mb-4">
+                {stage.name}
+              </h3>
+              <p className="text-lg text-gray-300 mb-8">
+                リズムタイプ: {stage.chordProgressionData ? 'コード進行' : 'ランダム'}
+              </p>
+              <Button
+                size="lg"
+                onClick={handleStartGame}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 text-xl"
+              >
+                ゲームスタート
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* ゲームオーバー/クリア画面 */}
+        {gameState && gameState.gameResult && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-75">
+            <div className="text-center p-8 bg-gray-800 rounded-lg">
+              <h3 className="text-4xl font-bold mb-4">
+                {gameState.gameResult === 'clear' ? (
+                  <span className="text-yellow-400">STAGE CLEAR!</span>
+                ) : (
+                  <span className="text-red-400">GAME OVER</span>
+                )}
+              </h3>
+              
+              <div className="text-white text-xl space-y-2 mb-6">
+                <p>スコア: {gameState.score}</p>
+                <p>最大コンボ: {gameState.maxCombo}</p>
+                <div className="mt-4 space-y-1">
+                  <p>Perfect: {gameState.perfectCount}</p>
+                  <p>Great: {gameState.greatCount}</p>
+                  <p>Good: {gameState.goodCount}</p>
+                  <p>Miss: {gameState.missCount}</p>
+                </div>
+              </div>
+
+              <Button
+                size="lg"
+                onClick={() => handleGameEnd(gameState.gameResult!, gameState.score)}
+                className="bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                結果を確認
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ピアノ */}
+      <div className="h-64 bg-gray-800 border-t border-gray-700">
+        <Piano />
+      </div>
+
+      {/* ゲームエンジン（非表示） */}
+      {isGameStarted && (
+        <RhythmGameEngine
+          stage={stage}
+          onGameStateChange={setGameState}
+          playingChordIds={playingChordIds}
+          onGameEnd={handleGameEnd}
+        />
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Implement a new 'Rhythm Mode' in Fantasy Mode to allow users to play chords to a rhythm.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e92f17b-d933-4a07-81e4-21bf97692379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e92f17b-d933-4a07-81e4-21bf97692379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>