### PR TITLE
Add rhythm mode to fantasy game

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,8 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chord_progression_data?: string; // リズムモード用のコード進行データ (JSON形式)
+  mp3_url?: string; // BGM用MP3ファイルのURL
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import FantasyStageSelect from './FantasyStageSelect';
 import FantasyGameScreen from './FantasyGameScreen';
+import RhythmGameScreen from './RhythmGameScreen';
 import { FantasyStage } from './FantasyGameEngine';
 import { useAuthStore } from '@/stores/authStore';
 import { useGameStore } from '@/stores/gameStore';
@@ -561,6 +562,23 @@ const FantasyMain: React.FC = () => {
   
   // ゲーム画面
   if (currentStage) {
+    // リズムモードの場合
+    if (currentStage.mode === 'rhythm') {
+      return (
+        <RhythmGameScreen
+          key={gameKey}
+          stage={currentStage}
+          autoStart={pendingAutoStart}
+          onGameComplete={handleGameComplete}
+          onBackToStageSelect={handleBackToStageSelect}
+          noteNameLang={settings.noteNameStyle === 'solfege' ? 'solfege' : 'en'}
+          simpleNoteName={settings.simpleDisplayMode}
+          lessonMode={isLessonMode}
+        />
+      );
+    }
+    
+    // クイズモード（既存）
     return (
       <FantasyGameScreen
         // ▼▼▼ 追加 ▼▼▼

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -292,6 +292,18 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
             {unlocked ? stage.name : "???"}
           </div>
           
+          {/* モード表示 */}
+          {unlocked && (
+            <div className="text-xs text-yellow-300 mb-1">
+              {stage.mode === 'rhythm' ? 'リズム' : 'クイズ'}
+              {stage.mode === 'rhythm' && (
+                <span className="ml-2">
+                  / {stage.chord_progression_data ? 'コード進行' : 'ランダム'}
+                </span>
+              )}
+            </div>
+          )}
+          
           {/* 説明文 */}
           <div className={cn(
             "text-sm leading-relaxed",

--- a/src/components/fantasy/RhythmGameEngine.tsx
+++ b/src/components/fantasy/RhythmGameEngine.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useTimeStore } from '@/stores/timeStore';
+import { useRhythmStore } from '@/stores/rhythmStore';
+import { useEnemyStore } from '@/stores/enemyStore';
+import { FantasyStage, MonsterState } from './FantasyGameEngine';
+import { devLog } from '@/utils/logger';
+
+type GamePhase = 'ready' | 'playing' | 'clear' | 'gameover';
+
+interface RhythmGameState {
+  phase: GamePhase;
+  playerHp: number;
+  totalDamageDealt: number;
+  successCount: number;
+  monsters: MonsterState[];
+  currentMonsterIndex: number;
+}
+
+interface UseRhythmGameEngineProps {
+  stage: FantasyStage;
+  onGameComplete: (result: 'clear' | 'gameover', score: number, successCount: number) => void;
+}
+
+export const useRhythmGameEngine = ({ stage, onGameComplete }: UseRhythmGameEngineProps) => {
+  const gameStateRef = useRef<RhythmGameState>({
+    phase: 'ready',
+    playerHp: stage.maxHp,
+    totalDamageDealt: 0,
+    successCount: 0,
+    monsters: [],
+    currentMonsterIndex: 0
+  });
+  
+  const { 
+    setStage, 
+    generateInitialNotes, 
+    generateNotesForMeasure,
+    judgeInput, 
+    cleanupOldNotes,
+    reset: resetRhythm,
+    notes,
+    lastGeneratedMeasure
+  } = useRhythmStore();
+  
+  const { 
+    currentMeasure, 
+    isCountIn, 
+    getCurrentTime,
+    startAt,
+    readyDuration,
+    measureCount
+  } = useTimeStore();
+  
+  const { setEnrage } = useEnemyStore();
+  
+  // 初期化
+  useEffect(() => {
+    devLog.debug('🎮 RhythmGameEngine: Initializing');
+    
+    // ステージ設定
+    setStage(stage);
+    
+    // モンスター初期化（敵は1体固定）
+    const monsters: MonsterState[] = [{
+      id: 'rhythm-monster-1',
+      index: 0,
+      position: 'A',
+      currentHp: stage.enemyHp,
+      maxHp: stage.enemyHp,
+      gauge: 0,
+      chordTarget: {
+        id: '',
+        displayName: '',
+        notes: [],
+        noteNames: [],
+        quality: '',
+        root: ''
+      },
+      correctNotes: [],
+      icon: stage.monsterIcon || 'fa-dragon',
+      name: 'リズムモンスター'
+    }];
+    
+    gameStateRef.current = {
+      ...gameStateRef.current,
+      monsters,
+      phase: 'ready'
+    };
+    
+    // 初期ノーツ生成
+    generateInitialNotes();
+    
+    return () => {
+      resetRhythm();
+    };
+  }, [stage, setStage, generateInitialNotes, resetRhythm]);
+  
+  // ゲームフェーズ管理
+  useEffect(() => {
+    if (!startAt) return;
+    
+    const elapsed = performance.now() - startAt;
+    const currentState = gameStateRef.current;
+    
+    if (elapsed < readyDuration && currentState.phase === 'ready') {
+      // Ready フェーズ
+    } else if (currentState.phase === 'ready') {
+      // Ready → Playing
+      gameStateRef.current.phase = 'playing';
+      devLog.debug('🎮 RhythmGameEngine: Phase changed to playing');
+    }
+  }, [startAt, readyDuration, currentMeasure]);
+  
+  // ランダムパターンの動的ノーツ生成
+  useEffect(() => {
+    if (!stage.chord_progression_data && currentMeasure > 0) {
+      // 現在の小節に対応するノーツがあるかチェック
+      const hasNoteForCurrentMeasure = notes.some(note => note.measure === currentMeasure);
+      
+      if (!hasNoteForCurrentMeasure) {
+        generateNotesForMeasure(currentMeasure);
+        devLog.debug(`🎵 Generated notes for measure ${currentMeasure}`);
+      }
+      
+      // 先読み生成（次の2小節分）
+      for (let i = 1; i <= 2; i++) {
+        const nextMeasure = ((currentMeasure + i - 1) % (measureCount || 8)) + 1;
+        const hasNoteForNextMeasure = notes.some(note => note.measure === nextMeasure);
+        if (!hasNoteForNextMeasure) {
+          generateNotesForMeasure(nextMeasure);
+        }
+      }
+    }
+  }, [currentMeasure, generateNotesForMeasure, stage.chord_progression_data, measureCount, notes]);
+  
+  // 古いノーツのクリーンアップ
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentTime = getCurrentTime();
+      cleanupOldNotes(currentTime);
+    }, 1000); // 1秒ごとにクリーンアップ
+    
+    return () => clearInterval(interval);
+  }, [getCurrentTime, cleanupOldNotes]);
+  
+  // コード入力処理
+  const handleChordInput = useCallback((inputChord: string) => {
+    const currentTime = getCurrentTime();
+    const result = judgeInput(inputChord, currentTime);
+    const currentState = gameStateRef.current;
+    
+    if (result === 'perfect') {
+      // 攻撃成功
+      const damage = Math.floor(Math.random() * (stage.maxDamage - stage.minDamage + 1)) + stage.minDamage;
+      const currentMonster = currentState.monsters[currentState.currentMonsterIndex];
+      
+      if (currentMonster) {
+        currentMonster.currentHp = Math.max(0, currentMonster.currentHp - damage);
+        gameStateRef.current.totalDamageDealt += damage;
+        gameStateRef.current.successCount += 1;
+        
+        // エフェクト用に怒りフラグを立てる
+        setEnrage(currentMonster.id, true);
+        setTimeout(() => setEnrage(currentMonster.id, false), 300);
+        
+        devLog.debug('🎯 Attack success!', { damage, remainingHp: currentMonster.currentHp });
+        
+        // モンスター撃破チェック
+        if (currentMonster.currentHp <= 0) {
+          
+          // 次のモンスターへ（リズムモードでは常に新しいモンスターを生成）
+          const nextIndex = currentState.currentMonsterIndex + 1;
+          if (nextIndex < stage.enemyCount) {
+            const newMonster: MonsterState = {
+              id: `rhythm-monster-${nextIndex + 1}`,
+              index: nextIndex,
+              position: 'A',
+              currentHp: stage.enemyHp,
+              maxHp: stage.enemyHp,
+              gauge: 0,
+              chordTarget: {
+                id: '',
+                displayName: '',
+                notes: [],
+                noteNames: [],
+                quality: '',
+                root: ''
+              },
+              correctNotes: [],
+              icon: stage.monsterIcon || 'fa-dragon',
+              name: 'リズムモンスター'
+            };
+            currentState.monsters.push(newMonster);
+            gameStateRef.current.currentMonsterIndex = nextIndex;
+          } else {
+            // 全モンスター撃破 → クリア
+            gameStateRef.current.phase = 'clear';
+            onGameComplete('clear', gameStateRef.current.totalDamageDealt, gameStateRef.current.successCount);
+          }
+        }
+      }
+    } else if (result === 'miss') {
+      // 攻撃失敗（敵の攻撃として扱う）
+      handleEnemyAttack();
+    }
+  }, [getCurrentTime, judgeInput, stage, setEnrage, onGameComplete]);
+  
+  // 敵の攻撃処理（判定失敗時）
+  const handleEnemyAttack = useCallback(() => {
+    gameStateRef.current.playerHp = Math.max(0, gameStateRef.current.playerHp - 1);
+    devLog.debug('💔 Player damaged!', { remainingHp: gameStateRef.current.playerHp });
+    
+    if (gameStateRef.current.playerHp <= 0) {
+      gameStateRef.current.phase = 'gameover';
+      onGameComplete('gameover', gameStateRef.current.totalDamageDealt, gameStateRef.current.successCount);
+    }
+  }, [onGameComplete]);
+  
+  // 判定ウィンドウを過ぎたノーツの自動miss判定
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (gameStateRef.current.phase !== 'playing') return;
+      
+      const currentTime = getCurrentTime();
+      const oldNotesCount = notes.filter(note => 
+        !note.judged && 
+        note.time + 0.2 < currentTime // 判定ウィンドウ外
+      ).length;
+      
+      // miss判定されたノーツ分だけ敵の攻撃
+      for (let i = 0; i < oldNotesCount; i++) {
+        handleEnemyAttack();
+      }
+    }, 100);
+    
+    return () => clearInterval(interval);
+  }, [notes, getCurrentTime, handleEnemyAttack]);
+  
+  return {
+    gameState: gameStateRef.current,
+    handleChordInput,
+    notes,
+    isPlaying: gameStateRef.current.phase === 'playing',
+    isCountIn
+  };
+};

--- a/src/components/fantasy/RhythmGameScreen.tsx
+++ b/src/components/fantasy/RhythmGameScreen.tsx
@@ -1,0 +1,391 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { cn } from '@/utils/cn';
+import { devLog } from '@/utils/logger';
+import { MIDIController } from '@/utils/MidiController';
+import { useGameStore } from '@/stores/gameStore';
+import { useTimeStore } from '@/stores/timeStore';
+import { bgmManager } from '@/utils/BGMManager';
+import { useRhythmGameEngine } from './RhythmGameEngine';
+import { FantasyStage, ChordDefinition } from './FantasyGameEngine';
+import { PIXINotesRenderer, PIXINotesRendererInstance } from '../game/PIXINotesRenderer';
+import { FantasyPIXIRenderer, FantasyPIXIInstance } from './FantasyPIXIRenderer';
+import FantasySettingsModal from './FantasySettingsModal';
+import RhythmPIXIRenderer from './RhythmPIXIRenderer';
+import type { DisplayOpts } from '@/utils/display-note';
+import { toDisplayName } from '@/utils/display-note';
+import { resolveChord } from '@/utils/chord-utils';
+
+interface RhythmGameScreenProps {
+  stage: FantasyStage;
+  autoStart?: boolean;
+  onGameComplete: (result: 'clear' | 'gameover', score: number, correctAnswers: number, totalQuestions: number) => void;
+  onBackToStageSelect: () => void;
+  noteNameLang?: DisplayOpts['lang'];
+  simpleNoteName?: boolean;
+  lessonMode?: boolean;
+}
+
+const RhythmGameScreen: React.FC<RhythmGameScreenProps> = ({
+  stage,
+  autoStart = false,
+  onGameComplete,
+  onBackToStageSelect,
+  noteNameLang = 'en',
+  simpleNoteName = false,
+  lessonMode = false
+}) => {
+  // エフェクト状態
+  const [damageShake, setDamageShake] = useState(false);
+  const [heartFlash, setHeartFlash] = useState(false);
+  const [overlay, setOverlay] = useState<null | { text: string }>(null);
+  
+  // 設定モーダル状態
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  
+  // 設定状態
+  const [currentNoteNameLang, setCurrentNoteNameLang] = useState<DisplayOpts['lang']>(noteNameLang);
+  const [currentSimpleNoteName, setCurrentSimpleNoteName] = useState(simpleNoteName);
+  
+  // 魔法名表示状態
+  const [magicName, setMagicName] = useState<{ monsterId: string; name: string; isSpecial: boolean } | null>(null);
+  
+  // 時間管理
+  const { currentBeat, currentMeasure, tick, startAt, readyDuration, isCountIn, setStart } = useTimeStore();
+  const { settings, updateSettings } = useGameStore();
+  
+  // MIDI Controller
+  const midiControllerRef = useRef<MIDIController | null>(null);
+  const [isMidiConnected, setIsMidiConnected] = useState(false);
+  
+  // モンスターエリアの幅管理
+  const [monsterAreaWidth, setMonsterAreaWidth] = useState<number>(window.innerWidth);
+  const monsterAreaRef = useRef<HTMLDivElement>(null);
+  
+  // 自動開始フラグ
+  const [hasAutoStarted, setHasAutoStarted] = useState(false);
+  
+  // リズムゲームエンジン
+  const { gameState, handleChordInput, notes, isPlaying, isCountIn: engineCountIn } = useRhythmGameEngine({
+    stage,
+    onGameComplete: (result, score, successCount) => {
+      onGameComplete(result, score, successCount, stage.enemyCount);
+    }
+  });
+  
+  /* 毎 100 ms で時間ストア tick */
+  useEffect(() => {
+    const id = setInterval(() => tick(), 100);
+    return () => clearInterval(id);
+  }, [tick]);
+  
+  /* Ready → Start 判定 */
+  const isReady = startAt !== null && performance.now() - startAt < readyDuration;
+  
+  // モンスターエリアのサイズ監視
+  useEffect(() => {
+    const update = () => {
+      if (monsterAreaRef.current) {
+        setMonsterAreaWidth(monsterAreaRef.current.clientWidth);
+      }
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if (monsterAreaRef.current) {
+      ro.observe(monsterAreaRef.current);
+    }
+    window.addEventListener('resize', update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+  
+  // Ready 終了時に BGM 再生
+  useEffect(() => {
+    if (!isReady && startAt) {
+      bgmManager.play(
+        stage.mp3_url || stage.bgmUrl || '/demo-1.mp3',
+        stage.bpm || 120,
+        stage.timeSignature || 4,
+        stage.measureCount ?? 8,
+        stage.countInMeasures ?? 0,
+        settings.bgmVolume ?? 0.7
+      );
+    } else {
+      bgmManager.stop();
+    }
+    return () => bgmManager.stop();
+  }, [isReady, stage, settings.bgmVolume, startAt]);
+  
+  // ゲーム開始処理
+  const startGame = useCallback(() => {
+    devLog.debug('🎮 Starting rhythm game');
+    setStart(
+      stage.bpm || 120,
+      stage.timeSignature || 4,
+      stage.measureCount ?? 8,
+      stage.countInMeasures ?? 0
+    );
+  }, [stage, setStart]);
+  
+  // 自動開始
+  useEffect(() => {
+    if (autoStart && !hasAutoStarted && !startAt) {
+      setHasAutoStarted(true);
+      // 少し遅延させて開始
+      setTimeout(() => {
+        startGame();
+      }, 100);
+    }
+  }, [autoStart, hasAutoStarted, startAt, startGame]);
+  
+  // ノート入力のハンドリング用ref
+  const handleNoteInputRef = useRef<(note: number, source?: 'mouse' | 'midi') => void>();
+  
+  // ノート入力処理
+  const handleNoteInput = useCallback((note: number, source?: 'mouse' | 'midi') => {
+    if (!isPlaying) return;
+    
+    // 単音を即座にコードとして判定
+    const chord = resolveChord(note.toString());
+    if (chord) {
+      handleChordInput(chord.id);
+    }
+  }, [isPlaying, handleChordInput]);
+  
+  // refを更新
+  useEffect(() => {
+    handleNoteInputRef.current = handleNoteInput;
+  }, [handleNoteInput]);
+  
+  // MIDIControllerの初期化
+  useEffect(() => {
+    if (!midiControllerRef.current) {
+      const controller = new MIDIController({
+        onNoteOn: (note: number, velocity?: number) => {
+          devLog.debug('🎹 MIDI Note On:', { note, velocity });
+          if (handleNoteInputRef.current) {
+            handleNoteInputRef.current(note, 'midi');
+          }
+        },
+        onNoteOff: (note: number) => {
+          devLog.debug('🎹 MIDI Note Off:', { note });
+        },
+        playMidiSound: true
+      });
+      
+      controller.setConnectionChangeCallback((connected: boolean) => {
+        setIsMidiConnected(connected);
+        devLog.debug('🎹 MIDI接続状態変更:', { connected });
+      });
+      
+      midiControllerRef.current = controller;
+      
+      controller.initialize().then(() => {
+        devLog.debug('✅ リズムモードMIDIController初期化完了');
+      }).catch(error => {
+        devLog.debug('❌ MIDI初期化エラー:', error);
+      });
+    }
+    
+    return () => {
+      if (midiControllerRef.current) {
+        midiControllerRef.current.destroy();
+        midiControllerRef.current = null;
+      }
+    };
+  }, []);
+  
+  // MIDIデバイス接続
+  useEffect(() => {
+    // MIDIデバイス接続は自動的に行われるため、特別な処理は不要
+    // MIDIControllerが初期化時に自動的に接続を管理する
+  }, []);
+  
+  // 設定の更新
+  const handleSettingsUpdate = useCallback((updatedSettings: Partial<typeof settings>) => {
+    updateSettings(updatedSettings);
+    if (updatedSettings.bgmVolume !== undefined) {
+      bgmManager.setVolume(updatedSettings.bgmVolume);
+    }
+  }, [updateSettings]);
+  
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-purple-50 to-pink-50 p-4">
+      {/* オーバーレイ */}
+      {overlay && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+          <div className="text-8xl font-bold text-white animate-fade-out">
+            {overlay.text}
+          </div>
+        </div>
+      )}
+      
+      {/* メインコンテナ */}
+      <div className={cn(
+        "max-w-6xl mx-auto",
+        damageShake && "animate-shake"
+      )}>
+        {/* ヘッダー部分 */}
+        <div className="bg-white rounded-t-2xl shadow-lg p-4 flex justify-between items-center">
+          <button
+            onClick={onBackToStageSelect}
+            className="flex items-center space-x-2 text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            <i className="fas fa-arrow-left"></i>
+            <span>ステージ選択に戻る</span>
+          </button>
+          
+          <div className="text-center">
+            <h2 className="text-2xl font-bold text-gray-800">{stage.name}</h2>
+            <p className="text-gray-600">リズムモード</p>
+          </div>
+          
+          <button
+            onClick={() => setIsSettingsModalOpen(true)}
+            className="p-2 text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            <i className="fas fa-cog text-xl"></i>
+          </button>
+        </div>
+        
+        {/* ゲーム情報バー */}
+        <div className="bg-gradient-to-r from-purple-100 to-pink-100 p-4 flex justify-between items-center">
+          <div className="flex items-center space-x-6">
+            {/* プレイヤーHP */}
+            <div className="flex items-center space-x-2">
+              <i className={cn("fas fa-heart text-2xl", heartFlash ? "text-red-500 animate-pulse" : "text-pink-500")}></i>
+              <span className="text-xl font-bold">{gameState.playerHp}/{stage.maxHp}</span>
+            </div>
+            
+            {/* 撃破数 */}
+            <div className="flex items-center space-x-2">
+              <i className="fas fa-skull text-gray-600"></i>
+              <span className="font-semibold">{gameState.currentMonsterIndex}/{stage.enemyCount}</span>
+            </div>
+            
+            {/* 時間表示 */}
+            <div className="flex items-center space-x-2">
+              <i className="fas fa-music text-blue-500"></i>
+              <span className="font-mono">
+                {isCountIn ? `M / - B ${currentBeat}` : `M ${currentMeasure} - B ${currentBeat}`}
+              </span>
+            </div>
+          </div>
+          
+          {/* MIDI接続状態 */}
+          <div className="flex items-center space-x-2">
+            {isMidiConnected && (
+              <div className="flex items-center space-x-2 text-green-600">
+                <i className="fas fa-plug"></i>
+                <span className="text-sm">MIDI接続中</span>
+              </div>
+            )}
+          </div>
+        </div>
+        
+        {/* メインゲームエリア */}
+        <div className="bg-white rounded-b-2xl shadow-lg p-6">
+          {/* モンスターエリア（クイズモードと同じ） */}
+          <div ref={monsterAreaRef} className="relative h-[200px] mb-6 bg-black bg-opacity-20 rounded-lg overflow-hidden">
+            {gameState.monsters.length > 0 && gameState.monsters[gameState.currentMonsterIndex] && (
+              <FantasyPIXIRenderer
+                width={Math.max(monsterAreaWidth, 1)}
+                height={200}
+                monsterIcon={gameState.monsters[gameState.currentMonsterIndex].icon}
+                enemyGauge={0} // リズムモードではゲージは使わない
+                onMonsterDefeated={() => {}}
+                onShowMagicName={(name: string, isSpecial: boolean, monsterId: string) => {
+                  setMagicName({ monsterId, name, isSpecial });
+                  setTimeout(() => setMagicName(null), 2000);
+                }}
+                className="w-full h-full"
+                activeMonsters={gameState.monsters}
+              />
+            )}
+          </div>
+          
+          {/* 魔法名表示 */}
+          {magicName && (
+            <div className="text-center mb-4">
+              <span className={cn(
+                "text-2xl font-bold",
+                magicName.isSpecial ? "text-yellow-500 animate-pulse" : "text-purple-600"
+              )}>
+                {magicName.name}
+              </span>
+            </div>
+          )}
+          
+          {/* リズムノーツ表示エリア */}
+          <div className="relative h-[150px] mb-6 bg-gray-50 rounded-lg overflow-hidden">
+            <RhythmPIXIRenderer
+              notes={notes}
+              currentTime={useTimeStore.getState().getCurrentTime()}
+              width={monsterAreaWidth}
+              height={150}
+              displayOpts={{ lang: currentNoteNameLang, simpleNoteName: currentSimpleNoteName }}
+            />
+          </div>
+          
+          {/* 鍵盤表示（クイズモードと同じ） */}
+          {stage.showGuide && (
+            <div className="mb-6">
+              <PIXINotesRenderer
+                activeNotes={[]} // リズムモードでは常に空
+                width={monsterAreaWidth}
+                height={200}
+                currentTime={0}
+                className="w-full"
+              />
+            </div>
+          )}
+          
+          {/* Ready/Start表示 */}
+          {isReady && (
+            <div className="text-center">
+              <h1 className="text-6xl font-bold text-purple-600 animate-pulse">READY...</h1>
+            </div>
+          )}
+          
+          {/* ゲーム開始ボタン（開始前のみ） */}
+          {!startAt && !autoStart && (
+            <div className="text-center">
+              <button
+                onClick={startGame}
+                className="bg-purple-600 text-white px-8 py-4 rounded-lg text-xl font-bold hover:bg-purple-700 transition-colors"
+              >
+                ゲーム開始
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      
+      {/* 設定モーダル */}
+      <FantasySettingsModal
+        isOpen={isSettingsModalOpen}
+        onClose={() => setIsSettingsModalOpen(false)}
+        onSettingsChange={(fantasySettings) => {
+          // FantasySettings型からGameSettings型への変換
+          handleSettingsUpdate({
+            bgmVolume: fantasySettings.bgmVolume,
+            soundEffectVolume: fantasySettings.soundEffectVolume,
+            rootSoundVolume: fantasySettings.rootSoundVolume,
+            playRootSound: fantasySettings.playRootSound
+          });
+        }}
+        isMidiConnected={isMidiConnected}
+        volume={0.8} // デフォルト音量
+        soundEffectVolume={settings.soundEffectVolume}
+        bgmVolume={settings.bgmVolume}
+        noteNameLang={currentNoteNameLang}
+        simpleNoteName={currentSimpleNoteName}
+        playRootSound={settings.playRootSound}
+        rootSoundVolume={settings.rootSoundVolume}
+      />
+    </div>
+  );
+};
+
+export default RhythmGameScreen;

--- a/src/components/fantasy/RhythmPIXIRenderer.tsx
+++ b/src/components/fantasy/RhythmPIXIRenderer.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useRef } from 'react';
+import * as PIXI from 'pixi.js';
+import { RhythmNote } from '@/stores/rhythmStore';
+import { DisplayOpts, toDisplayChordName } from '@/utils/display-note';
+import { devLog } from '@/utils/logger';
+
+interface RhythmPIXIRendererProps {
+  notes: RhythmNote[];
+  currentTime: number;
+  width: number;
+  height: number;
+  displayOpts: {
+    lang: DisplayOpts['lang'];
+    simpleNoteName?: boolean;
+  };
+}
+
+const RhythmPIXIRenderer: React.FC<RhythmPIXIRendererProps> = ({
+  notes,
+  currentTime,
+  width,
+  height,
+  displayOpts
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const appRef = useRef<PIXI.Application | null>(null);
+  const notesContainerRef = useRef<PIXI.Container | null>(null);
+  const noteSpritesRef = useRef<Map<string, PIXI.Container>>(new Map());
+  
+  // 定数
+  const JUDGE_LINE_X = 150; // 判定ラインのX座標
+  const NOTE_SPEED = 300; // ピクセル/秒
+  const NOTE_WIDTH = 100;
+  const NOTE_HEIGHT = 60;
+  const JUDGMENT_WINDOW_VISUAL = 0.2; // 判定ウィンドウの視覚表示（±200ms）
+  
+  // PIXI初期化
+  useEffect(() => {
+    if (!containerRef.current) return;
+    
+    // 既存のcanvasをクリア
+    while (containerRef.current.firstChild) {
+      containerRef.current.removeChild(containerRef.current.firstChild);
+    }
+    
+    // PIXIアプリケーション作成
+    const app = new PIXI.Application({
+      width,
+      height,
+      backgroundColor: 0xf0f0f0,
+      antialias: true,
+      resolution: window.devicePixelRatio || 1,
+      autoDensity: true
+    });
+    
+    containerRef.current.appendChild(app.view as HTMLCanvasElement);
+    appRef.current = app;
+    
+    // ノーツコンテナ
+    const notesContainer = new PIXI.Container();
+    app.stage.addChild(notesContainer);
+    notesContainerRef.current = notesContainer;
+    
+    // 判定ライン描画
+    const judgeLine = new PIXI.Graphics();
+    judgeLine.lineStyle(4, 0xff0000);
+    judgeLine.moveTo(JUDGE_LINE_X, 0);
+    judgeLine.lineTo(JUDGE_LINE_X, height);
+    app.stage.addChild(judgeLine);
+    
+    // 判定ウィンドウ表示（デバッグ用）
+    const windowGraphics = new PIXI.Graphics();
+    windowGraphics.beginFill(0x00ff00, 0.1);
+    windowGraphics.drawRect(
+      JUDGE_LINE_X - JUDGMENT_WINDOW_VISUAL * NOTE_SPEED,
+      0,
+      JUDGMENT_WINDOW_VISUAL * NOTE_SPEED * 2,
+      height
+    );
+    windowGraphics.endFill();
+    app.stage.addChild(windowGraphics);
+    
+    // レーン線
+    const laneGraphics = new PIXI.Graphics();
+    laneGraphics.lineStyle(1, 0xcccccc);
+    laneGraphics.moveTo(0, height / 2);
+    laneGraphics.lineTo(width, height / 2);
+    app.stage.addChild(laneGraphics);
+    
+    devLog.debug('🎨 RhythmPIXIRenderer initialized');
+    
+    return () => {
+      app.destroy(true, { children: true, texture: true, baseTexture: true });
+      appRef.current = null;
+      notesContainerRef.current = null;
+      noteSpritesRef.current.clear();
+    };
+  }, [width, height]);
+  
+  // ノーツ更新
+  useEffect(() => {
+    if (!appRef.current || !notesContainerRef.current) return;
+    
+    const app = appRef.current;
+    const notesContainer = notesContainerRef.current;
+    const noteSprites = noteSpritesRef.current;
+    
+    // 現在のノーツIDセット
+    const currentNoteIds = new Set(notes.map(note => note.id));
+    
+    // 削除されたノーツを除去
+    for (const [id, sprite] of noteSprites.entries()) {
+      if (!currentNoteIds.has(id)) {
+        notesContainer.removeChild(sprite);
+        sprite.destroy();
+        noteSprites.delete(id);
+      }
+    }
+    
+    // ノーツを更新・作成
+    notes.forEach(note => {
+      let noteContainer = noteSprites.get(note.id);
+      
+      if (!noteContainer) {
+        // 新規ノーツ作成
+        noteContainer = new PIXI.Container();
+        
+        // ノート背景
+        const bg = new PIXI.Graphics();
+        const color = note.judgmentResult === 'perfect' ? 0x00ff00 : 
+                     note.judgmentResult === 'miss' ? 0xff0000 : 
+                     0x3b82f6;
+        bg.beginFill(color, note.judged ? 0.5 : 1);
+        bg.drawRoundedRect(0, 0, NOTE_WIDTH, NOTE_HEIGHT, 10);
+        bg.endFill();
+        noteContainer.addChild(bg);
+        
+        // コード名テキスト
+        const text = new PIXI.Text(
+          toDisplayChordName(note.chord, { 
+            lang: displayOpts.lang, 
+            simple: displayOpts.simpleNoteName || false 
+          }),
+          {
+            fontFamily: 'Arial',
+            fontSize: 24,
+            fontWeight: 'bold',
+            fill: 0xffffff,
+            align: 'center'
+          }
+        );
+        text.anchor.set(0.5);
+        text.x = NOTE_WIDTH / 2;
+        text.y = NOTE_HEIGHT / 2;
+        noteContainer.addChild(text);
+        
+        // 判定結果テキスト
+        if (note.judged && note.judgmentResult) {
+          const resultText = new PIXI.Text(
+            note.judgmentResult.toUpperCase(),
+            {
+              fontFamily: 'Arial',
+              fontSize: 16,
+              fontWeight: 'bold',
+              fill: note.judgmentResult === 'perfect' ? 0x00ff00 : 0xff0000,
+              stroke: 0xffffff,
+              strokeThickness: 2
+            }
+          );
+          resultText.anchor.set(0.5);
+          resultText.x = NOTE_WIDTH / 2;
+          resultText.y = -10;
+          noteContainer.addChild(resultText);
+        }
+        
+        notesContainer.addChild(noteContainer);
+        noteSprites.set(note.id, noteContainer);
+      }
+      
+      // 位置更新
+      const timeDiff = note.time - currentTime;
+      const x = JUDGE_LINE_X + timeDiff * NOTE_SPEED;
+      noteContainer.x = x - NOTE_WIDTH / 2;
+      noteContainer.y = (height - NOTE_HEIGHT) / 2;
+      
+      // 画面外のノーツは非表示
+      noteContainer.visible = x > -NOTE_WIDTH && x < width + NOTE_WIDTH;
+      
+      // 判定済みノーツは透明度を下げる
+      if (note.judged) {
+        noteContainer.alpha = 0.5;
+      }
+    });
+    
+    // レンダリング
+    app.render();
+  }, [notes, currentTime, displayOpts]);
+  
+  return (
+    <div 
+      ref={containerRef} 
+      style={{ width, height }}
+      className="rhythm-pixi-renderer"
+    />
+  );
+};
+
+export default RhythmPIXIRenderer;

--- a/src/stores/rhythmStore.ts
+++ b/src/stores/rhythmStore.ts
@@ -1,0 +1,175 @@
+import { create } from 'zustand';
+import { FantasyStage } from '@/components/fantasy/FantasyGameEngine';
+import { useTimeStore } from './timeStore';
+
+export interface RhythmNote {
+  id: string;
+  chord: string;
+  measure: number;
+  beat: number;
+  time: number; // 絶対時間（秒）
+  judged: boolean;
+  judgmentResult: 'perfect' | 'miss' | null;
+}
+
+interface RhythmState {
+  // ノーツ管理
+  notes: RhythmNote[];
+  nextNoteId: number;
+  
+  // 判定ウィンドウ（±200ms）
+  judgmentWindow: number;
+  
+  // 現在のステージ情報
+  currentStage: FantasyStage | null;
+  
+  // プログレッションパターンのインデックス
+  progressionIndex: number;
+  
+  // 最後に生成したノーツの小節番号（ランダムパターン用）
+  lastGeneratedMeasure: number;
+  
+  // アクション
+  setStage: (stage: FantasyStage) => void;
+  generateInitialNotes: () => void;
+  generateNotesForMeasure: (measure: number) => void;
+  judgeInput: (inputChord: string, currentTime: number) => 'perfect' | 'miss' | null;
+  cleanupOldNotes: (currentTime: number) => void;
+  reset: () => void;
+}
+
+export const useRhythmStore = create<RhythmState>((set, get) => ({
+  notes: [],
+  nextNoteId: 0,
+  judgmentWindow: 0.2, // ±200ms
+  currentStage: null,
+  progressionIndex: 0,
+  lastGeneratedMeasure: 0,
+  
+  setStage: (stage) => {
+    set({ currentStage: stage, progressionIndex: 0, lastGeneratedMeasure: 0 });
+  },
+  
+  generateInitialNotes: () => {
+    const { currentStage } = get();
+    if (!currentStage) return;
+    
+    const timeStore = useTimeStore.getState();
+    const notes: RhythmNote[] = [];
+    let noteId = 0;
+    
+    if (currentStage.chord_progression_data) {
+      // プログレッションパターン: JSONから全ノーツを生成
+      try {
+        const data = JSON.parse(currentStage.chord_progression_data);
+        if (data.chords && Array.isArray(data.chords)) {
+          data.chords.forEach((item: { chord: string; measure: number; beat: number }) => {
+            const time = timeStore.getMeasureBeatTime(item.measure, item.beat);
+            notes.push({
+              id: `note-${noteId++}`,
+              chord: item.chord,
+              measure: item.measure,
+              beat: item.beat,
+              time,
+              judged: false,
+              judgmentResult: null
+            });
+          });
+        }
+      } catch (e) {
+        console.error('Failed to parse chord progression data:', e);
+      }
+    } else {
+      // ランダムパターン: 最初の数小節分を生成
+      const initialMeasures = Math.min(8, currentStage.measureCount ?? 8);
+      for (let measure = 1; measure <= initialMeasures; measure++) {
+        get().generateNotesForMeasure(measure);
+      }
+    }
+    
+    set({ notes, nextNoteId: noteId });
+  },
+  
+  generateNotesForMeasure: (measure) => {
+    const { currentStage, nextNoteId } = get();
+    if (!currentStage || currentStage.chord_progression_data) return;
+    
+    const timeStore = useTimeStore.getState();
+    const allowedChords = currentStage.allowedChords || ['C', 'G', 'Am', 'F'];
+    const randomChord = allowedChords[Math.floor(Math.random() * allowedChords.length)];
+    
+    // 1小節の1拍目に配置
+    const time = timeStore.getMeasureBeatTime(measure, 1);
+    const newNote: RhythmNote = {
+      id: `note-${nextNoteId}`,
+      chord: randomChord,
+      measure,
+      beat: 1,
+      time,
+      judged: false,
+      judgmentResult: null
+    };
+    
+    set(state => ({
+      notes: [...state.notes, newNote],
+      nextNoteId: nextNoteId + 1,
+      lastGeneratedMeasure: measure
+    }));
+  },
+  
+  judgeInput: (inputChord, currentTime) => {
+    const { notes, judgmentWindow } = get();
+    
+    // 判定対象のノーツを探す（未判定かつ判定ウィンドウ内）
+    const targetNote = notes.find(note => 
+      !note.judged && 
+      Math.abs(note.time - currentTime) <= judgmentWindow
+    );
+    
+    if (!targetNote) {
+      return null;
+    }
+    
+    const isCorrect = targetNote.chord === inputChord;
+    const result = isCorrect ? 'perfect' : 'miss';
+    
+    // ノーツを判定済みにする
+    set(state => ({
+      notes: state.notes.map(note => 
+        note.id === targetNote.id 
+          ? { ...note, judged: true, judgmentResult: result }
+          : note
+      )
+    }));
+    
+    return result;
+  },
+  
+  cleanupOldNotes: (currentTime) => {
+    // 判定ウィンドウを過ぎた未判定ノーツを自動的にmiss判定
+    // 画面外に出た古いノーツを削除（メモリ管理）
+    const { judgmentWindow } = get();
+    const cleanupThreshold = 10; // 10秒前のノーツは削除
+    
+    set(state => ({
+      notes: state.notes
+        .map(note => {
+          // 未判定で判定ウィンドウを過ぎたらmiss
+          if (!note.judged && note.time + judgmentWindow < currentTime) {
+            return { ...note, judged: true, judgmentResult: 'miss' as const };
+          }
+          return note;
+        })
+        .filter(note => note.time > currentTime - cleanupThreshold)
+    }));
+  },
+  
+  reset: () => {
+    set({
+      notes: [],
+      nextNoteId: 0,
+      progressionIndex: 0,
+      lastGeneratedMeasure: 0
+    });
+  }
+}));

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -27,6 +27,10 @@ interface TimeState {
     now?: number
   ) => void
   tick: () => void
+  /* 現在の絶対時間位置（秒）を取得 */
+  getCurrentTime: () => number
+  /* 指定した小節・拍の絶対時間（秒）を取得 */
+  getMeasureBeatTime: (measure: number, beat: number) => number
 }
 
 export const useTimeStore = create<TimeState>((set, get) => ({
@@ -91,5 +95,23 @@ export const useTimeStore = create<TimeState>((set, get) => ({
         isCountIn: false
       })
     }
+  },
+  getCurrentTime: () => {
+    const s = get()
+    if (s.startAt === null) return 0
+    const elapsed = performance.now() - s.startAt - s.readyDuration
+    return Math.max(0, elapsed / 1000) // 秒単位で返す
+  },
+  getMeasureBeatTime: (measure: number, beat: number) => {
+    const s = get()
+    const msecPerBeat = 60000 / s.bpm
+    const msecPerMeasure = msecPerBeat * s.timeSignature
+    
+    // カウントイン考慮: measure 1 = カウントイン後の最初の小節
+    const totalMeasures = s.countInMeasures + measure - 1
+    const totalBeats = totalMeasures * s.timeSignature + (beat - 1)
+    const totalMsec = totalBeats * msecPerBeat
+    
+    return totalMsec / 1000 // 秒単位で返す
   }
 }))


### PR DESCRIPTION
Add Rhythm Mode to Fantasy Mode with a new game engine and UI, distinct from the existing Quiz Mode.

This PR introduces a new rhythm-based gameplay experience where players input chords in time with music, featuring a "Taiko no Tatsujin" style note flow. The existing Quiz Mode remains untouched, and stage selection now allows choosing between modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b0ddb01-6a8c-402b-804c-2fe8087c7dc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b0ddb01-6a8c-402b-804c-2fe8087c7dc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>