### PR TITLE
Add rhythm game mode

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -34,7 +34,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -46,6 +46,7 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chordProgressionData?: any; // リズムモード用のコード進行データ
 }
 
 interface MonsterState {

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import FantasyStageSelect from './FantasyStageSelect';
 import FantasyGameScreen from './FantasyGameScreen';
+import RhythmGameScreen from '../rhythm/RhythmGameScreen';
 import { FantasyStage } from './FantasyGameEngine';
 import { useAuthStore } from '@/stores/authStore';
 import { useGameStore } from '@/stores/gameStore';
@@ -108,7 +109,8 @@ const FantasyMain: React.FC = () => {
             bgmUrl: stage.bgm_url || stage.mp3_url,
             measureCount: stage.measure_count,
             countInMeasures: stage.count_in_measures,
-            timeSignature: stage.time_signature
+            timeSignature: stage.time_signature,
+            chordProgressionData: stage.chord_progression_data
           };
           devLog.debug('🎮 FantasyStage形式に変換:', fantasyStage);
           setCurrentStage(fantasyStage);
@@ -381,7 +383,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression',
+        mode: nextStageData.mode as 'single' | 'progression' | 'rhythm',
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,
@@ -392,7 +394,8 @@ const FantasyMain: React.FC = () => {
         bpm: nextStageData.bpm || 120,
         measureCount: nextStageData.measure_count,
         countInMeasures: nextStageData.count_in_measures,
-        timeSignature: nextStageData.time_signature
+        timeSignature: nextStageData.time_signature,
+        chordProgressionData: nextStageData.chord_progression_data
       };
 
       setGameResult(null);
@@ -561,6 +564,23 @@ const FantasyMain: React.FC = () => {
   
   // ゲーム画面
   if (currentStage) {
+    // リズムモードの判定
+    if (currentStage.mode === 'rhythm') {
+      return (
+        <RhythmGameScreen
+          key={gameKey}
+          stage={currentStage}
+          autoStart={pendingAutoStart}
+          onGameComplete={handleGameComplete}
+          onBackToStageSelect={handleBackToStageSelect}
+          noteNameLang={settings.noteNameStyle === 'solfege' ? 'solfege' : 'en'}
+          simpleNoteName={settings.simpleDisplayMode}
+          lessonMode={isLessonMode}
+        />
+      );
+    }
+    
+    // 既存のクイズモード
     return (
       <FantasyGameScreen
         // ▼▼▼ 追加 ▼▼▼

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+        mode: stage.mode as 'single' | 'progression' | 'rhythm',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,
@@ -170,7 +170,8 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
         countInMeasures: stage.count_in_measures,
-        timeSignature: stage.time_signature
+        timeSignature: stage.time_signature,
+        chordProgressionData: stage.chord_progression_data
       }));
       
       const convertedProgress: FantasyUserProgress = {
@@ -299,6 +300,13 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           )}>
             {unlocked ? stage.description : "このステージはまだロックされています"}
           </div>
+          
+          {/* リズムモードのラベル */}
+          {stage.mode === 'rhythm' && unlocked && (
+            <div className="text-xs text-yellow-300 mt-1">
+              Rhythm / {stage.chordProgressionData ? '進行' : 'ランダム'}
+            </div>
+          )}
         </div>
         
         {/* 右側のアイコン */}

--- a/src/components/rhythm/RhythmGameEngine.tsx
+++ b/src/components/rhythm/RhythmGameEngine.tsx
@@ -1,0 +1,288 @@
+/**
+ * リズムゲームエンジン
+ * 判定ロジックとゲーム制御を担当
+ */
+
+import { useEffect, useCallback, useRef, useState } from 'react';
+import { useRhythmStore, ChordDefinition, RhythmNote } from '@/stores/rhythmStore';
+import { useTimeStore } from '@/stores/timeStore';
+import { FantasyStage } from '../fantasy/FantasyGameEngine';
+import { note as parseNote } from 'tonal';
+import { resolveChord } from '@/utils/chord-utils';
+import type { DisplayOpts } from '@/utils/display-note';
+import { devLog } from '@/utils/logger';
+
+// 判定ウィンドウ定数
+const JUDGMENT_WINDOW_MS = 200; // ±200ms
+
+// ユーティリティ関数
+const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDefinition | null => {
+  const resolved = resolveChord(chordId, 4, displayOpts);
+  if (!resolved) {
+    console.warn(`⚠️ 未定義のリズムコード: ${chordId}`);
+    return null;
+  }
+
+  // notesをMIDIノート番号に変換
+  const midiNotes = resolved.notes.map(noteName => {
+    const noteObj = parseNote(noteName + '4');
+    return noteObj && typeof noteObj.midi === 'number' ? noteObj.midi : 60;
+  });
+
+  return {
+    id: chordId,
+    displayName: resolved.displayName,
+    notes: midiNotes,
+    noteNames: resolved.notes,
+    quality: resolved.quality,
+    root: resolved.root
+  };
+};
+
+interface RhythmGameEngineProps {
+  stage: FantasyStage;
+  onChordCorrect: (chord: ChordDefinition, damageDealt: number) => void;
+  onChordIncorrect: () => void;
+  onEnemyAttack: (damage: number) => void;
+  inputNotes: number[];
+  displayOpts?: DisplayOpts;
+  onNotesUpdate?: (notes: RhythmNote[]) => void;
+}
+
+// カスタムフック
+export const useRhythmGameEngine = ({
+  stage,
+  onChordCorrect,
+  onChordIncorrect,
+  onEnemyAttack,
+  inputNotes,
+  displayOpts,
+  onNotesUpdate
+}: RhythmGameEngineProps) => {
+  const rhythmStore = useRhythmStore();
+  const timeStore = useTimeStore();
+  
+  const [enemyHp, setEnemyHp] = useState(stage.enemyHp);
+  const [enemyMaxHp] = useState(stage.enemyHp);
+  const [enemiesDefeated, setEnemiesDefeated] = useState(0);
+  
+  // 最後に生成したノーツの小節番号を記録
+  const lastGeneratedMeasure = useRef<number>(-1);
+  
+  // 判定タイマーのRef
+  const judgmentTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  
+  // コード進行データのパース
+  const chordProgressionData = useRef<Array<{
+    measure: number;
+    beat: number;
+    chord: string;
+  }>>([]);
+  
+  useEffect(() => {
+    if (stage.chordProgressionData?.chords) {
+      chordProgressionData.current = stage.chordProgressionData.chords;
+      devLog.debug('🎵 コード進行データ:', chordProgressionData.current);
+    }
+  }, [stage.chordProgressionData]);
+  
+  // ノーツ生成タイミングの計算
+  const calculateNoteTime = (measure: number, beat: number): number => {
+    const { bpm, timeSignature, startAt, readyDuration } = timeStore;
+    if (!startAt) return 0;
+    
+    const msPerBeat = 60000 / bpm;
+    const beatsFromStart = (measure - 1) * timeSignature + (beat - 1);
+    const totalMs = readyDuration + beatsFromStart * msPerBeat;
+    
+    return startAt + totalMs;
+  };
+  
+  // ランダムモードでのコード選択
+  const selectRandomChord = (): ChordDefinition | null => {
+    const { allowedChords } = stage;
+    if (!allowedChords || allowedChords.length === 0) return null;
+    
+    const randomIndex = Math.floor(Math.random() * allowedChords.length);
+    return getChordDefinition(allowedChords[randomIndex], displayOpts);
+  };
+  
+  // プログレッションモードでのコード選択
+  const selectProgressionChord = (measure: number): ChordDefinition | null => {
+    if (chordProgressionData.current.length === 0) return null;
+    
+    // 現在の小節のコードを探す
+    const chordData = chordProgressionData.current.find(c => c.measure === measure);
+    if (!chordData) return null;
+    
+    return getChordDefinition(chordData.chord, displayOpts);
+  };
+  
+  // ノーツの生成
+  const generateNotes = useCallback(() => {
+    const { currentMeasure, isCountIn, measureCount } = timeStore;
+    
+    // カウントイン中から次の小節のノーツを準備
+    const measureToGenerate = isCountIn 
+      ? 1 // カウントイン中は1小節目のノーツを準備
+      : currentMeasure + 1; // 通常は次の小節を準備
+    
+    // ループ処理
+    const actualMeasure = measureToGenerate > measureCount ? 1 : measureToGenerate;
+    
+    // 既に生成済みの小節はスキップ
+    if (lastGeneratedMeasure.current === actualMeasure && !isCountIn) {
+      return;
+    }
+    
+    lastGeneratedMeasure.current = actualMeasure;
+    
+    // コード選択
+    const chord = stage.chordProgressionData
+      ? selectProgressionChord(actualMeasure)
+      : selectRandomChord();
+    
+    if (!chord) return;
+    
+    // ノーツのタイミング計算
+    const hitTime = calculateNoteTime(actualMeasure, 1); // 各小節の1拍目
+    
+    const newNote: RhythmNote = {
+      id: `note_${Date.now()}_${actualMeasure}`,
+      chord,
+      hitTime,
+      measureNumber: actualMeasure,
+      beatNumber: 1
+    };
+    
+    rhythmStore.addNote(newNote);
+    devLog.debug('🎵 ノーツ生成:', newNote);
+    
+    // 判定タイマーの設定（ウィンドウ終了時に自動的にmiss判定）
+    const timerId = setTimeout(() => {
+      if (!rhythmStore.isJudged(newNote.id)) {
+        handleMissJudgment(newNote);
+      }
+    }, hitTime + JUDGMENT_WINDOW_MS - performance.now());
+    
+    judgmentTimers.current.set(newNote.id, timerId);
+  }, [timeStore, stage, displayOpts, rhythmStore]);
+  
+  // miss判定の処理
+  const handleMissJudgment = useCallback((note: RhythmNote) => {
+    rhythmStore.markAsJudged(note.id);
+    rhythmStore.removeNote(note.id);
+    
+    // 敵の攻撃
+    const damage = Math.floor(Math.random() * (stage.maxDamage - stage.minDamage + 1)) + stage.minDamage;
+    onEnemyAttack(damage);
+    onChordIncorrect();
+    
+    // タイマーのクリーンアップ
+    const timerId = judgmentTimers.current.get(note.id);
+    if (timerId) {
+      clearTimeout(timerId);
+      judgmentTimers.current.delete(note.id);
+    }
+  }, [rhythmStore, stage, onEnemyAttack, onChordIncorrect]);
+  
+  // 入力判定
+  const checkChordMatch = useCallback(() => {
+    const now = performance.now();
+    
+    // 判定ウィンドウ内のノーツを探す
+    const pendingNotes = rhythmStore.pendingNotes;
+    
+    for (const note of pendingNotes) {
+      // 既に判定済みならスキップ
+      if (rhythmStore.isJudged(note.id)) continue;
+      
+      // 判定ウィンドウ内かチェック
+      if (now >= note.hitTime - JUDGMENT_WINDOW_MS && 
+          now <= note.hitTime + JUDGMENT_WINDOW_MS) {
+        
+        // 入力ノートとコードが一致するか確認
+        const inputSet = new Set(inputNotes);
+        const targetSet = new Set(note.chord.notes);
+        
+        if (inputSet.size === targetSet.size &&
+            [...inputSet].every(n => targetSet.has(n))) {
+          // 成功判定
+          rhythmStore.markAsJudged(note.id);
+          rhythmStore.removeNote(note.id);
+          
+          // ダメージ計算
+          const damage = Math.floor(Math.random() * (stage.maxDamage - stage.minDamage + 1)) + stage.minDamage;
+          
+          // 敵HPを減らす
+          const newHp = Math.max(0, enemyHp - damage);
+          setEnemyHp(newHp);
+          
+          if (newHp === 0) {
+            // 敵を倒した
+            setEnemiesDefeated(prev => prev + 1);
+            setEnemyHp(enemyMaxHp); // 次の敵のHP
+          }
+          
+          onChordCorrect(note.chord, damage);
+          
+          // タイマーのクリーンアップ
+          const timerId = judgmentTimers.current.get(note.id);
+          if (timerId) {
+            clearTimeout(timerId);
+            judgmentTimers.current.delete(note.id);
+          }
+          
+          break; // 一度に判定するのは1つのノーツのみ
+        }
+      }
+    }
+  }, [inputNotes, rhythmStore, stage, enemyHp, enemyMaxHp, onChordCorrect]);
+  
+  // 入力が変化したら判定を実行
+  useEffect(() => {
+    if (inputNotes.length > 0) {
+      checkChordMatch();
+    }
+  }, [inputNotes, checkChordMatch]);
+  
+  // 拍の変化を監視してノーツを生成
+  useEffect(() => {
+    const { currentBeat, isCountIn } = timeStore;
+    
+    // 各小節の最初の拍でノーツを生成
+    if (currentBeat === 1 || (isCountIn && currentBeat === timeStore.timeSignature)) {
+      generateNotes();
+    }
+  }, [timeStore.currentBeat, timeStore.currentMeasure, timeStore.isCountIn, generateNotes]);
+  
+  // ノーツの更新をコールバックに通知
+  useEffect(() => {
+    if (onNotesUpdate) {
+      onNotesUpdate(rhythmStore.pendingNotes);
+    }
+  }, [rhythmStore.pendingNotes, onNotesUpdate]);
+  
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      // すべての判定タイマーをクリア
+      judgmentTimers.current.forEach(timerId => clearTimeout(timerId));
+      judgmentTimers.current.clear();
+      
+      // ストアをリセット
+      rhythmStore.reset();
+    };
+  }, []);
+  
+  return {
+    enemyHp,
+    enemyMaxHp,
+    enemiesDefeated,
+    totalEnemies: stage.enemyCount,
+    pendingNotes: rhythmStore.pendingNotes,
+    currentChord: rhythmStore.currentChord
+  };
+};
+
+export type { RhythmGameEngineProps };

--- a/src/components/rhythm/RhythmGameScreen.tsx
+++ b/src/components/rhythm/RhythmGameScreen.tsx
@@ -1,0 +1,375 @@
+/**
+ * リズムゲームメイン画面
+ * リズムモードのゲーム画面の実装
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { cn } from '@/utils/cn';
+import { devLog } from '@/utils/logger';
+import { MIDIController } from '@/utils/MidiController';
+import { useGameStore } from '@/stores/gameStore';
+import { useTimeStore } from '@/stores/timeStore';
+import { useRhythmStore, RhythmNote } from '@/stores/rhythmStore';
+import { bgmManager } from '@/utils/BGMManager';
+import { useRhythmGameEngine } from './RhythmGameEngine';
+import RhythmNotesRenderer from './RhythmNotesRenderer';
+import { FantasyStage } from '../fantasy/FantasyGameEngine';
+import { ChordDefinition } from '@/stores/rhythmStore';
+import type { DisplayOpts } from '@/utils/display-note';
+import FantasySoundManager from '@/utils/FantasySoundManager';
+
+interface RhythmGameScreenProps {
+  stage: FantasyStage;
+  autoStart?: boolean;
+  onGameComplete: (result: 'clear' | 'gameover', score: number, correctAnswers: number, totalQuestions: number) => void;
+  onBackToStageSelect: () => void;
+  noteNameLang?: DisplayOpts['lang'];
+  simpleNoteName?: boolean;
+  lessonMode?: boolean;
+}
+
+const RhythmGameScreen: React.FC<RhythmGameScreenProps> = ({
+  stage,
+  autoStart = false,
+  onGameComplete,
+  onBackToStageSelect,
+  noteNameLang = 'en',
+  simpleNoteName = false
+}) => {
+  // ゲーム状態
+  const [playerHp, setPlayerHp] = useState(stage.maxHp);
+  const [playerSp, setPlayerSp] = useState(0);
+  const [score, setScore] = useState(0);
+  const [correctAnswers, setCorrectAnswers] = useState(0);
+  const [isGameOver, setIsGameOver] = useState(false);
+  const [gameResult, setGameResult] = useState<'clear' | 'gameover' | null>(null);
+  
+  // エフェクト状態
+  const [damageShake, setDamageShake] = useState(false);
+  const [attackEffect, setAttackEffect] = useState<{ type: 'success' | 'failure'; monsterId: string } | null>(null);
+  
+  // MIDI関連
+  const [isMidiConnected, setIsMidiConnected] = useState(false);
+  const midiControllerRef = useRef<MIDIController | null>(null);
+  const [inputNotes, setInputNotes] = useState<number[]>([]);
+  const activeNotesRef = useRef<Set<number>>(new Set());
+  
+  // ストアとtimeStore
+  const { settings } = useGameStore();
+  const timeStore = useTimeStore();
+  const rhythmStore = useRhythmStore();
+  const { currentBeat, currentMeasure, tick, startAt, readyDuration, isCountIn } = timeStore;
+  
+  // ノーツレンダラー用の状態
+  const [pendingNotes, setPendingNotes] = useState<RhythmNote[]>([]);
+  
+  // エンジンのコールバック
+  const handleChordCorrect = useCallback((chord: ChordDefinition, damageDealt: number) => {
+    devLog.debug('🎯 コード正解:', { chord: chord.displayName, damage: damageDealt });
+    
+    // スコアとSP更新
+    setScore(prev => prev + 100);
+    setCorrectAnswers(prev => prev + 1);
+    setPlayerSp(prev => Math.min(5, prev + 1));
+    
+    // 効果音（ランダムに魔法を選択）
+    const magicTypes = ['fire', 'ice', 'thunder'] as const;
+    const randomMagic = magicTypes[Math.floor(Math.random() * magicTypes.length)];
+    FantasySoundManager.playMagic(randomMagic);
+    
+    // エフェクト
+    setAttackEffect({ type: 'success', monsterId: 'rhythm' });
+    setTimeout(() => setAttackEffect(null), 1000);
+  }, []);
+  
+  const handleChordIncorrect = useCallback(() => {
+    devLog.debug('❌ コード不正解');
+    // 失敗時は無音またはエネミーアタック音を使用
+    FantasySoundManager.playEnemyAttack();
+  }, []);
+  
+  const handleEnemyAttack = useCallback((damage: number) => {
+    devLog.debug('👹 敵の攻撃:', { damage });
+    
+    const newHp = Math.max(0, playerHp - damage);
+    setPlayerHp(newHp);
+    
+    // ダメージエフェクト
+    setDamageShake(true);
+    setTimeout(() => setDamageShake(false), 500);
+    
+    // 効果音
+    FantasySoundManager.playEnemyAttack();
+    
+    if (newHp === 0) {
+      setIsGameOver(true);
+      setGameResult('gameover');
+    }
+  }, [playerHp]);
+  
+  // ノーツ更新のコールバック
+  const handleNotesUpdate = useCallback((notes: RhythmNote[]) => {
+    setPendingNotes(notes);
+  }, []);
+  
+  // 表示オプション
+  const displayOpts: DisplayOpts = {
+    lang: noteNameLang,
+    simple: simpleNoteName
+  };
+  
+  // リズムゲームエンジンの使用
+  const {
+    enemyHp,
+    enemyMaxHp,
+    enemiesDefeated,
+    totalEnemies
+  } = useRhythmGameEngine({
+    stage,
+    onChordCorrect: handleChordCorrect,
+    onChordIncorrect: handleChordIncorrect,
+    onEnemyAttack: handleEnemyAttack,
+    inputNotes,
+    displayOpts,
+    onNotesUpdate: handleNotesUpdate
+  });
+  
+  // 時間管理のtick
+  useEffect(() => {
+    const id = setInterval(() => tick(), 100);
+    return () => clearInterval(id);
+  }, [tick]);
+  
+  // Ready状態の判定
+  const isReady = startAt !== null && performance.now() - startAt < readyDuration;
+  
+  // ゲーム開始時の初期化
+  useEffect(() => {
+    if (autoStart && !startAt) {
+      timeStore.setStart(
+        stage.bpm || 120,
+        stage.timeSignature || 4,
+        stage.measureCount || 8,
+        stage.countInMeasures || 1
+      );
+    }
+  }, [autoStart, startAt, stage, timeStore]);
+  
+  // BGM管理
+  useEffect(() => {
+    if (!isReady && startAt) {
+      bgmManager.play(
+        stage.bgmUrl || '/demo-1.mp3',
+        stage.bpm || 120,
+        stage.timeSignature || 4,
+        stage.measureCount || 8,
+        stage.countInMeasures || 1,
+        settings.bgmVolume ?? 0.7
+      );
+    } else {
+      bgmManager.stop();
+    }
+    return () => bgmManager.stop();
+  }, [isReady, stage, settings.bgmVolume, startAt]);
+  
+  // MIDIController初期化
+  useEffect(() => {
+    if (!midiControllerRef.current) {
+      const controller = new MIDIController({
+        onNoteOn: (note: number) => {
+          devLog.debug('🎹 MIDI Note On:', { note });
+          activeNotesRef.current.add(note);
+          setInputNotes(Array.from(activeNotesRef.current));
+        },
+        onNoteOff: (note: number) => {
+          devLog.debug('🎹 MIDI Note Off:', { note });
+          activeNotesRef.current.delete(note);
+          setInputNotes(Array.from(activeNotesRef.current));
+        },
+        playMidiSound: true
+      });
+      
+      controller.setConnectionChangeCallback((connected: boolean) => {
+        setIsMidiConnected(connected);
+      });
+      
+      midiControllerRef.current = controller;
+      controller.initialize();
+    }
+    
+    return () => {
+      if (midiControllerRef.current) {
+        midiControllerRef.current.destroy();
+        midiControllerRef.current = null;
+      }
+    };
+  }, []);
+  
+  // 全敵撃破でクリア
+  useEffect(() => {
+    if (enemiesDefeated >= totalEnemies && !isGameOver) {
+      setIsGameOver(true);
+      setGameResult('clear');
+    }
+  }, [enemiesDefeated, totalEnemies, isGameOver]);
+  
+  // ゲーム終了処理
+  useEffect(() => {
+    if (isGameOver && gameResult) {
+      onGameComplete(gameResult, score, correctAnswers, 0);
+    }
+  }, [isGameOver, gameResult, score, correctAnswers, onGameComplete]);
+  
+  // SPアタック
+  const handleSpAttack = useCallback(() => {
+    if (playerSp < 5) return;
+    
+    setPlayerSp(0);
+    // SPアタックは特別な魔法音を再生
+    FantasySoundManager.playMagic('thunder');
+    
+    // 現在のノーツをすべて成功扱いにする
+    const currentNotes = rhythmStore.pendingNotes;
+    currentNotes.forEach(note => {
+      if (!rhythmStore.isJudged(note.id)) {
+        rhythmStore.markAsJudged(note.id);
+                 handleChordCorrect(note.chord, stage.maxDamage);
+      }
+    });
+      }, [playerSp, rhythmStore, handleChordCorrect, stage.maxDamage]);
+  
+  return (
+    <div className={cn(
+      "min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900",
+      "flex flex-col relative overflow-hidden fantasy-game-screen",
+      damageShake && "animate-shake"
+    )}>
+      {/* ヘッダー部分 */}
+      <div className="relative z-10 p-4 flex justify-between items-center">
+        <button
+          onClick={onBackToStageSelect}
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+        >
+          戻る
+        </button>
+        
+        <div className="text-white text-center">
+          <h2 className="text-2xl font-bold">{stage.name}</h2>
+          <div className="text-sm">
+            {isCountIn ? (
+              <span>M / - B {currentBeat}</span>
+            ) : (
+              <span>M {currentMeasure} - B {currentBeat}</span>
+            )}
+          </div>
+        </div>
+        
+        <div className="text-white text-right">
+          <div>Score: {score}</div>
+          <div>撃破: {enemiesDefeated} / {totalEnemies}</div>
+        </div>
+      </div>
+      
+      {/* ノーツ表示エリア */}
+      <div className="flex-1 relative">
+        <RhythmNotesRenderer
+          width={window.innerWidth}
+          height={200}
+          notes={pendingNotes}
+          className="absolute top-0 left-0 w-full"
+        />
+        
+        {/* Ready表示 */}
+        {isReady && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="text-6xl font-bold text-white animate-pulse">
+              READY...
+            </div>
+          </div>
+        )}
+      </div>
+      
+      {/* 下部UI */}
+      <div className="relative z-10 p-4">
+        {/* プレイヤーHP */}
+        <div className="mb-4">
+          <div className="flex items-center gap-2">
+            <span className="text-white">HP:</span>
+            <div className="flex-1 bg-gray-700 rounded-full h-6 relative overflow-hidden">
+              <div 
+                className="absolute inset-y-0 left-0 bg-gradient-to-r from-green-400 to-green-600 transition-all duration-300"
+                style={{ width: `${(playerHp / stage.maxHp) * 100}%` }}
+              />
+              <div className="absolute inset-0 flex items-center justify-center text-white text-sm font-medium">
+                {playerHp} / {stage.maxHp}
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        {/* SPゲージ */}
+        <div className="mb-4">
+          <div className="flex items-center gap-2">
+            <span className="text-white">SP:</span>
+            <div className="flex gap-1">
+              {[...Array(5)].map((_, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "w-8 h-8 rounded-full border-2",
+                    i < playerSp
+                      ? "bg-yellow-400 border-yellow-600"
+                      : "bg-gray-700 border-gray-600"
+                  )}
+                />
+              ))}
+            </div>
+            {playerSp >= 5 && (
+              <button
+                onClick={handleSpAttack}
+                className="ml-4 px-4 py-2 bg-yellow-500 hover:bg-yellow-400 text-black font-bold rounded-lg animate-pulse"
+              >
+                SPアタック！
+              </button>
+            )}
+          </div>
+        </div>
+        
+        {/* 敵HP */}
+        <div className="mb-4">
+          <div className="flex items-center gap-2">
+            <span className="text-white">敵HP:</span>
+            <div className="flex-1 bg-gray-700 rounded-full h-6 relative overflow-hidden">
+              <div 
+                className="absolute inset-y-0 left-0 bg-gradient-to-r from-red-400 to-red-600 transition-all duration-300"
+                style={{ width: `${(enemyHp / enemyMaxHp) * 100}%` }}
+              />
+              <div className="absolute inset-0 flex items-center justify-center text-white text-sm font-medium">
+                {enemyHp} / {enemyMaxHp}
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        {/* MIDI接続状態 */}
+        <div className="text-center text-white text-sm">
+          {isMidiConnected ? '🎹 MIDI接続中' : '🎹 MIDI未接続'}
+        </div>
+      </div>
+      
+      {/* 攻撃エフェクト */}
+      {attackEffect && (
+        <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
+          <div className={cn(
+            "text-6xl font-bold animate-bounce",
+            attackEffect.type === 'success' ? "text-yellow-400" : "text-red-500"
+          )}>
+            {attackEffect.type === 'success' ? 'HIT!' : 'MISS!'}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RhythmGameScreen;

--- a/src/components/rhythm/RhythmNotesRenderer.tsx
+++ b/src/components/rhythm/RhythmNotesRenderer.tsx
@@ -1,0 +1,208 @@
+/**
+ * リズムモード専用ノーツレンダラー
+ * 太鼓の達人風の右から左に流れるノーツ表示
+ */
+
+import React, { useEffect, useRef, useCallback } from 'react';
+import * as PIXI from 'pixi.js';
+import { RhythmNote } from '@/stores/rhythmStore';
+import { devLog } from '@/utils/logger';
+
+interface RhythmNotesRendererProps {
+  width: number;
+  height: number;
+  notes: RhythmNote[];
+  onReady?: () => void;
+  className?: string;
+}
+
+// 定数
+const HIT_LINE_X = 200; // ヒットラインのX座標（左から200px）
+const NOTE_SPEED = 0.4; // ノーツの速度（px/ms）
+const NOTE_RADIUS = 40; // ノーツの半径
+const NOTE_HEIGHT = 100; // ノーツの表示Y座標
+
+const RhythmNotesRenderer: React.FC<RhythmNotesRendererProps> = ({
+  width,
+  height,
+  notes,
+  onReady,
+  className
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const appRef = useRef<PIXI.Application | null>(null);
+  const notesContainerRef = useRef<PIXI.Container | null>(null);
+  const noteSpriteMapRef = useRef<Map<string, PIXI.Container>>(new Map());
+
+  // PIXIアプリケーションの初期化
+  const initPixi = useCallback(async () => {
+    if (!containerRef.current || appRef.current) return;
+
+    try {
+      // PIXIアプリケーション作成
+      const app = new PIXI.Application({
+        width,
+        height,
+        backgroundColor: 0x1a1a2e, // ダークな背景
+        antialias: true,
+        resolution: window.devicePixelRatio || 1,
+        autoDensity: true
+      });
+
+      containerRef.current.appendChild(app.view as HTMLCanvasElement);
+      appRef.current = app;
+
+      // ノーツコンテナ
+      const notesContainer = new PIXI.Container();
+      app.stage.addChild(notesContainer);
+      notesContainerRef.current = notesContainer;
+
+      // ヒットライン描画
+      const hitLine = new PIXI.Graphics();
+      hitLine.lineStyle(4, 0xFFFFFF, 0.8);
+      hitLine.moveTo(HIT_LINE_X, 0);
+      hitLine.lineTo(HIT_LINE_X, height);
+      app.stage.addChild(hitLine);
+
+      // 判定エリアの視覚化（デバッグ用）
+      const judgmentArea = new PIXI.Graphics();
+      judgmentArea.beginFill(0x00FF00, 0.1);
+      judgmentArea.drawRect(HIT_LINE_X - 50, 0, 100, height);
+      judgmentArea.endFill();
+      app.stage.addChild(judgmentArea);
+
+      devLog.debug('✅ リズムノーツレンダラー初期化完了');
+      onReady?.();
+    } catch (error) {
+      console.error('❌ リズムノーツレンダラー初期化エラー:', error);
+    }
+  }, [width, height, onReady]);
+
+  // ノーツの作成
+  const createNoteSprite = useCallback((note: RhythmNote): PIXI.Container => {
+    const container = new PIXI.Container();
+
+    // ノーツの背景円
+    const circle = new PIXI.Graphics();
+    circle.beginFill(0xFF6B6B);
+    circle.drawCircle(0, 0, NOTE_RADIUS);
+    circle.endFill();
+    container.addChild(circle);
+
+    // コード名テキスト
+    const text = new PIXI.Text(note.chord.displayName, {
+      fontFamily: 'Arial',
+      fontSize: 24,
+      fontWeight: 'bold',
+      fill: 0xFFFFFF,
+      align: 'center'
+    });
+    text.anchor.set(0.5, 0.5);
+    container.addChild(text);
+
+    // 初期位置（画面右外）
+    container.x = width + NOTE_RADIUS;
+    container.y = NOTE_HEIGHT;
+
+    return container;
+  }, [width]);
+
+  // ノーツの更新
+  const updateNotes = useCallback(() => {
+    if (!notesContainerRef.current || !appRef.current) return;
+
+    const now = performance.now();
+
+    // 新しいノーツの追加
+    notes.forEach(note => {
+      if (!noteSpriteMapRef.current.has(note.id)) {
+        const sprite = createNoteSprite(note);
+        notesContainerRef.current!.addChild(sprite);
+        noteSpriteMapRef.current.set(note.id, sprite);
+      }
+    });
+
+    // 削除されたノーツの除去
+    const currentNoteIds = new Set(notes.map(n => n.id));
+    noteSpriteMapRef.current.forEach((sprite, id) => {
+      if (!currentNoteIds.has(id)) {
+        notesContainerRef.current!.removeChild(sprite);
+        sprite.destroy();
+        noteSpriteMapRef.current.delete(id);
+      }
+    });
+
+    // ノーツの位置更新
+    notes.forEach(note => {
+      const sprite = noteSpriteMapRef.current.get(note.id);
+      if (!sprite) return;
+
+      // ノーツが理想時刻にヒットラインに到達するように位置を計算
+      const timeUntilHit = note.hitTime - now;
+      const x = HIT_LINE_X + timeUntilHit * NOTE_SPEED;
+
+      sprite.x = x;
+
+      // 判定ウィンドウ内では色を変える
+      if (Math.abs(timeUntilHit) <= 200) {
+        const circle = sprite.children[0] as PIXI.Graphics;
+        circle.clear();
+        circle.beginFill(0xFFD93D); // 黄色
+        circle.drawCircle(0, 0, NOTE_RADIUS);
+        circle.endFill();
+      }
+
+      // 画面外に出たノーツは非表示
+      sprite.visible = x > -NOTE_RADIUS && x < width + NOTE_RADIUS;
+    });
+  }, [notes, width, createNoteSprite]);
+
+  // アニメーションループ
+  useEffect(() => {
+    if (!appRef.current) return;
+
+    const ticker = appRef.current.ticker;
+    ticker.add(updateNotes);
+
+    return () => {
+      ticker.remove(updateNotes);
+    };
+  }, [updateNotes]);
+
+  // 初期化
+  useEffect(() => {
+    initPixi();
+
+    return () => {
+      if (appRef.current) {
+        // すべてのノーツスプライトを破棄
+        noteSpriteMapRef.current.forEach(sprite => {
+          sprite.destroy();
+        });
+        noteSpriteMapRef.current.clear();
+
+        // PIXIアプリケーションの破棄
+        appRef.current.destroy(true, { children: true, texture: true, baseTexture: true });
+        appRef.current = null;
+        notesContainerRef.current = null;
+      }
+    };
+  }, [initPixi]);
+
+  // サイズ変更対応
+  useEffect(() => {
+    if (appRef.current) {
+      appRef.current.renderer.resize(width, height);
+    }
+  }, [width, height]);
+
+  return (
+    <div 
+      ref={containerRef} 
+      className={className}
+      style={{ width, height }}
+    />
+  );
+};
+
+export default RhythmNotesRenderer;

--- a/src/stores/rhythmStore.ts
+++ b/src/stores/rhythmStore.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand'
+
+// ChordDefinitionの型定義（FantasyGameEngineから移植）
+export interface ChordDefinition {
+  id: string;
+  displayName: string;
+  notes: number[];
+  noteNames: string[];
+  quality: string;
+  root: string;
+}
+
+export interface RhythmNote {
+  id: string;
+  chord: ChordDefinition;
+  hitTime: number; // 理想中心時刻 (ms)
+  measureNumber: number; // 小節番号
+  beatNumber: number; // 拍番号
+}
+
+interface RhythmState {
+  // 現在の出題コード
+  currentChord: ChordDefinition | null;
+  // 判定ウィンドウ（理想時刻の前後200ms）
+  windowStart: number;
+  windowEnd: number;
+  // ノーツキュー（画面に表示されるノーツ）
+  pendingNotes: RhythmNote[];
+  // 判定済みノーツID（重複判定防止）
+  judgedNoteIds: Set<string>;
+  // コード進行モードの場合の進行インデックス
+  progressionIndex: number;
+  
+  // Actions
+  setChord: (chord: ChordDefinition, centerTime: number) => void;
+  addNote: (note: RhythmNote) => void;
+  removeNote: (noteId: string) => void;
+  clearNotes: () => void;
+  judge: (now: number, playedChord: ChordDefinition) => 'hit' | 'miss' | null;
+  markAsJudged: (noteId: string) => void;
+  isJudged: (noteId: string) => boolean;
+  setProgressionIndex: (index: number) => void;
+  reset: () => void;
+}
+
+export const useRhythmStore = create<RhythmState>((set, get) => ({
+  currentChord: null,
+  windowStart: 0,
+  windowEnd: 0,
+  pendingNotes: [],
+  judgedNoteIds: new Set(),
+  progressionIndex: 0,
+  
+  setChord: (chord, centerTime) => {
+    set({
+      currentChord: chord,
+      windowStart: centerTime - 200,
+      windowEnd: centerTime + 200
+    });
+  },
+  
+  addNote: (note) => {
+    set(state => ({
+      pendingNotes: [...state.pendingNotes, note]
+    }));
+  },
+  
+  removeNote: (noteId) => {
+    set(state => ({
+      pendingNotes: state.pendingNotes.filter(n => n.id !== noteId)
+    }));
+  },
+  
+  clearNotes: () => {
+    set({ 
+      pendingNotes: [],
+      judgedNoteIds: new Set()
+    });
+  },
+  
+  judge: (now, playedChord) => {
+    const state = get();
+    
+    // 判定ウィンドウ内のノーツを探す
+    const noteInWindow = state.pendingNotes.find(note => 
+      now >= note.hitTime - 200 &&
+      now <= note.hitTime + 200 &&
+      !state.judgedNoteIds.has(note.id)
+    );
+    
+    if (!noteInWindow) return null;
+    
+    // コードが一致するか確認
+    const isMatch = playedChord.id === noteInWindow.chord.id;
+    
+    // 判定済みとしてマーク
+    get().markAsJudged(noteInWindow.id);
+    
+    return isMatch ? 'hit' : 'miss';
+  },
+  
+  markAsJudged: (noteId) => {
+    set(state => ({
+      judgedNoteIds: new Set([...state.judgedNoteIds, noteId])
+    }));
+  },
+  
+  isJudged: (noteId) => {
+    return get().judgedNoteIds.has(noteId);
+  },
+  
+  setProgressionIndex: (index) => {
+    set({ progressionIndex: index });
+  },
+  
+  reset: () => {
+    set({
+      currentChord: null,
+      windowStart: 0,
+      windowEnd: 0,
+      pendingNotes: [],
+      judgedNoteIds: new Set(),
+      progressionIndex: 0
+    });
+  }
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@
 
 // ===== 基本的なゲーム状態 =====
 
-export type GameMode = 'practice' | 'performance';
+export type GameMode = 'practice' | 'performance' | 'rhythm';
 export type InstrumentMode = 'piano' | 'guitar';
 export type InputMode = 'midi' | 'audio' | 'both';
 
@@ -635,7 +635,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;
@@ -648,6 +648,7 @@ export interface FantasyStage {
   measure_count?: number;
   time_signature?: number;
   count_in_measures?: number;
+  chord_progression_data?: any; // リズムモード用のコード進行データ
 }
 
 export interface LessonContext {


### PR DESCRIPTION
Add a new "Rhythm" game mode to introduce real-time, note-based gameplay, completely separate from the existing "Quiz" mode.

This PR introduces a completely new game engine and renderer for the Rhythm mode, as direct reuse of the existing Quiz mode's UI and game logic proved problematic due to fundamental differences in real-time mechanics, hit detection precision, and enemy management. A dedicated `rhythmStore` and `RhythmGameEngine` ensure precise time synchronization with BGM and accurate ±200ms judgment, while `RhythmNotesRenderer` handles the unique 'Taiko no Tatsujin'-style note display.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4b09ac5-660f-46fd-82dc-28a2351da2da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4b09ac5-660f-46fd-82dc-28a2351da2da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>