### PR TITLE
Expand fantasy mode progression patterns

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -609,18 +609,30 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 敵のゲージ表示（黄色系）
   const renderEnemyGauge = useCallback(() => {
+    const gauge = gameState.enemyGauge;
+    const isInJudgmentRange = stage?.mode === 'progression' && gauge >= 90 && gauge <= 100;
+    
     return (
       <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
         <div 
-          className="h-full bg-gradient-to-r from-yellow-500 to-orange-400 rounded-full transition-all duration-200 ease-out"
+          className={cn(
+            "h-full rounded-full transition-all duration-200 ease-out",
+            isInJudgmentRange 
+              ? "bg-gradient-to-r from-red-500 to-pink-500" // 判定タイミングは赤系
+              : "bg-gradient-to-r from-yellow-500 to-orange-400" // 通常は黄色系
+          )}
           style={{ 
             width: `${Math.min(gameState.enemyGauge, 100)}%`,
-            boxShadow: gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
+            boxShadow: isInJudgmentRange 
+              ? '0 0 15px rgba(239, 68, 68, 0.8)' // 赤く光る
+              : gameState.enemyGauge > 80 
+                ? '0 0 10px rgba(245, 158, 11, 0.6)' 
+                : 'none'
           }}
         />
       </div>
     );
-  }, [gameState.enemyGauge]);
+  }, [gameState.enemyGauge, stage?.mode]);
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
@@ -660,7 +672,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   }, [autoStart, initializeGame, stage]);
 
   // ゲーム開始前画面（オーバーレイ表示中は表示しない）
-  if (!overlay && !gameState.isCompleting && (!gameState.isGameActive || !gameState.currentChordTarget)) {
+  if (!overlay && !gameState.isCompleting && !gameState.isGameActive) {
     devLog.debug('🎮 ゲーム開始前画面表示:', { 
       isGameActive: gameState.isGameActive,
       hasCurrentChord: !!gameState.currentChordTarget,
@@ -832,7 +844,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       <div className={`text-yellow-300 font-bold text-center mb-1 truncate w-full ${
                         monsterCount > 5 ? 'text-sm' : monsterCount > 3 ? 'text-base' : 'text-xl'
                       }`}>
-                        {monster.chordTarget.displayName}
+                        {monster.chordTarget?.displayName || (stage.mode === 'progression' ? '？' : '')}
                       </div>
                       
                       {/* ★★★ ここにヒント表示を追加 ★★★ */}


### PR DESCRIPTION
Implement dynamic attack gauge and problem timing for Fantasy Mode progression, with a restricted judgment window.

This PR also fixes an issue where the pre-game screen would incorrectly display during progression mode when no chord target was present, ensuring the game screen remains active throughout gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-26a18a2e-14a6-40a3-9891-0123d430a369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-26a18a2e-14a6-40a3-9891-0123d430a369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>