### PR TITLE
Expand fantasy mode progression and fix attack bug

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -283,26 +283,24 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   const handleEnemyAttack = useCallback(async (attackingMonsterId?: string) => {
     console.log('🔥 handleEnemyAttack called with monsterId:', attackingMonsterId);
-    devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
     
-    // 敵の攻撃音を再生
     try {
+      // エフェクト表示
+      setDamageShake(true);
+      setHeartFlash(true);
+      setTimeout(() => {
+        setDamageShake(false);
+        setHeartFlash(false);
+      }, 500);
+      
+      // FantasySoundManagerで効果音再生
       const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-      FantasySoundManager.playEnemyAttack();
+      FantasySoundManager.playSound('damage');
+      devLog.debug('🔊 ダメージ効果音再生');
     } catch (error) {
-      console.error('Failed to play enemy attack sound:', error);
+      console.error('敵の攻撃処理中のエラー:', error);
+      // エラーが発生してもゲームは続行する
     }
-    
-    // confetti削除 - 何もしない
-    
-    // ダメージ時の画面振動
-    setDamageShake(true);
-    setTimeout(() => setDamageShake(false), 500);
-    
-    // ハートフラッシュ効果
-    setHeartFlash(true);
-    setTimeout(() => setHeartFlash(false), 150);
-    
   }, []);
   
   const handleGameCompleteCallback = useCallback((result: 'clear' | 'gameover', finalState: FantasyGameState) => {
@@ -888,9 +886,22 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
                       >
                         <div
-                          className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
+                          className={cn(
+                            "h-full transition-all duration-100",
+                            // プログレッションモードで90%以上の場合は色を変更
+                            stage.mode === 'progression' && monster.gauge >= 90
+                              ? "bg-gradient-to-r from-yellow-400 to-orange-500 animate-pulse"
+                              : "bg-gradient-to-r from-purple-500 to-purple-700"
+                          )}
                           style={{ width: `${monster.gauge}%` }}
                         />
+                        {/* 90%と100%のマーカーを追加（プログレッションモードのみ） */}
+                        {stage.mode === 'progression' && (
+                          <>
+                            <div className="absolute top-0 bottom-0 w-px bg-yellow-300/50" style={{ left: '90%' }} />
+                            <div className="absolute top-0 bottom-0 w-px bg-red-500/50" style={{ left: '100%' }} />
+                          </>
+                        )}
                       </div>
                       
                       {/* HPゲージ */}

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -341,11 +341,25 @@ const FantasyMain: React.FC = () => {
   
   // ステージ選択に戻る
   const handleBackToStageSelect = useCallback(() => {
-    setCurrentStage(null);
-    setGameResult(null);
-    setShowResult(false);
-    setPendingAutoStart(false); // pendingAutoStart もリセット
-  }, []);
+    try {
+      // レッスンモードの場合は特別な処理が必要
+      if (isLessonMode && lessonContext) {
+        devLog.debug('🎮 レッスンモードからの終了');
+        // レッスン詳細ページに戻る
+        window.location.hash = `#lesson-detail?id=${lessonContext.lessonId}`;
+        return;
+      }
+      
+      setCurrentStage(null);
+      setGameResult(null);
+      setShowResult(false);
+      setPendingAutoStart(false); // pendingAutoStart もリセット
+    } catch (error) {
+      console.error('ステージ選択に戻る際のエラー:', error);
+      // エラーが発生した場合は安全にダッシュボードに戻る
+      window.location.hash = '#dashboard';
+    }
+  }, [isLessonMode, lessonContext]);
   
   // ★ 追加: 次のステージに待機画面で遷移
   const gotoNextStageWaiting = useCallback(async () => {


### PR DESCRIPTION
Implement new Fantasy Mode progression logic and fix enemy attack redirection bug.

This PR extends the Fantasy Mode progression pattern by introducing dynamic attack gauge speed (95% at 1st beat), precise question presentation on the 2nd beat, and a strict judgment window around the 1st beat (only when the gauge is 90-100%). It also includes visual feedback for the attack gauge and resolves a critical bug where enemy attacks would incorrectly redirect the player to the start screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-75e0eb49-dd53-4cbe-a950-a762a83cb363">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75e0eb49-dd53-4cbe-a950-a762a83cb363">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>