### PR TITLE
Implement beat-synced player gauge in progression mode

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -660,7 +660,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   }, [autoStart, initializeGame, stage]);
 
   // ゲーム開始前画面（オーバーレイ表示中は表示しない）
-  if (!overlay && !gameState.isCompleting && (!gameState.isGameActive || !gameState.currentChordTarget)) {
+  if (!overlay && !gameState.isCompleting && !gameState.isGameActive) {
     devLog.debug('🎮 ゲーム開始前画面表示:', { 
       isGameActive: gameState.isGameActive,
       hasCurrentChord: !!gameState.currentChordTarget,
@@ -935,6 +935,23 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                   pointer-events-none bg-black/40 rounded px-2 py-1">
         {renderSpGauge(gameState.playerSp)}
       </div>
+      
+      {/* Attack Gauge */}
+      {gameState.currentStage?.mode === 'progression' && (
+        <div className="absolute left-4 right-4 bottom-14 z-50">
+          <div className="h-6 bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className={cn(
+                "h-full transition-all duration-100",
+                gameState.playerGauge >= 90
+                  ? "bg-gradient-to-r from-lime-400 to-lime-600"
+                  : "bg-gradient-to-r from-purple-500 to-purple-700"
+              )}
+              style={{ width: `${gameState.playerGauge}%` }}
+            />
+          </div>
+        </div>
+      )}
       
       {/* ===== ピアノ鍵盤エリア ===== */}
       <div 

--- a/src/utils/fantasy/position.ts
+++ b/src/utils/fantasy/position.ts
@@ -1,0 +1,25 @@
+/**
+ * ファンタジーゲームのポジション計算ユーティリティ
+ */
+
+/**
+ * プレイヤーゲージの計算
+ * @param now 現在時刻
+ * @param beat2 問題開始（Beat2）時刻
+ * @param beat1 次のBeat1時刻
+ * @returns 0-100のゲージ値
+ */
+export function calcPlayerGauge(
+  now: number,
+  beat2: number,
+  beat1: number
+): number {
+  const firstSpan = beat1 - beat2; // 0%→95%
+  const secondSpan = 400; // 95%→100% (±200ms)
+  
+  const p = now < beat1
+    ? (now - beat2) / firstSpan * 95
+    : 95 + Math.min((now - beat1) / secondSpan * 5, 5);
+    
+  return Math.max(0, Math.min(100, p));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -218,4 +218,10 @@ export default {
   	}
   },
   plugins: [require("tailwindcss-animate")],
+  safelist: [
+    'from-purple-500',
+    'to-purple-700',
+    'from-lime-400',
+    'to-lime-600'
+  ]
 } 


### PR DESCRIPTION
Implement a beat-synced player attack gauge for progression mode, including new input timing rules and a related UI bug fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-f518582e-324c-45d8-ba3c-6ef0141a6ed2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f518582e-324c-45d8-ba3c-6ef0141a6ed2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>