### PR TITLE
Expand fantasy mode progression patterns

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -1266,4 +1266,3 @@ export const useFantasyGameEngine = ({
 
 // エクスポート
 export type { ChordDefinition, FantasyStage, MonsterState, FantasyGameState };
-export { useFantasyGameEngine };

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -385,7 +385,12 @@ export const useFantasyGameEngine = ({
   const imageTexturesRef = useRef<Map<string, PIXI.Texture>>(new Map());
   
   // タイムストアから時間情報を取得
-  const { currentBeat, currentMeasure, isCountIn, bpm, timeSignature } = useTimeStore();
+  const timeStore = useTimeStore();
+  const currentBeat = timeStore?.currentBeat || 1;
+  const currentMeasure = timeStore?.currentMeasure || 1;
+  const isCountIn = timeStore?.isCountIn || false;
+  const bpm = timeStore?.bpm || 120;
+  const timeSignature = timeStore?.timeSignature || 4;
   
   const [gameState, setGameState] = useState<FantasyGameState>({
     currentStage: null,
@@ -1260,9 +1265,12 @@ export const useFantasyGameEngine = ({
     selectRandomChord,
     getProgressionChord,
     startGame,
-    calculateAttackGauge // 攻撃ゲージ計算関数を追加
+    calculateAttackGauge, // 攻撃ゲージ計算関数を追加
+    getCurrentEnemy,
+    ENEMY_LIST
   };
 };
 
 // エクスポート
 export type { ChordDefinition, FantasyStage, MonsterState, FantasyGameState };
+export { getCurrentEnemy, ENEMY_LIST };

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -754,6 +754,35 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         */}
         
+        {/* プログレッションモード用の攻撃ゲージ */}
+        {stage.mode === 'progression' && (
+          <div className="mb-2 px-4">
+            <div className="text-xs text-gray-400 mb-1">攻撃ゲージ</div>
+            <div className="w-full h-6 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative">
+              <div
+                className={`h-full transition-all duration-100 ${
+                  gameState.attackGaugePercent >= 90 && gameState.attackGaugePercent <= 100
+                    ? 'bg-gradient-to-r from-yellow-500 to-orange-500 animate-pulse' // 90-100%の時は黄色系でアニメーション
+                    : 'bg-gradient-to-r from-blue-500 to-cyan-500' // 通常時は青系
+                }`}
+                style={{ width: `${gameState.attackGaugePercent}%` }}
+              />
+              {/* 90%と100%のマーカー */}
+              <div className="absolute top-0 left-[90%] w-0.5 h-full bg-white opacity-50" />
+              <div className="absolute top-0 left-[95%] w-0.5 h-full bg-yellow-300 opacity-75" />
+              {/* パーセンテージ表示 */}
+              <div className="absolute inset-0 flex items-center justify-center text-xs font-bold">
+                {Math.round(gameState.attackGaugePercent)}%
+              </div>
+            </div>
+            {gameState.isInJudgementWindow && (
+              <div className="text-xs text-yellow-300 mt-1 animate-pulse">
+                判定受付中！
+              </div>
+            )}
+          </div>
+        )}
+        
         {/* ===== モンスター＋エフェクト描画エリア ===== */}
         <div className="mb-2 text-center relative w-full">
           <div

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -331,7 +331,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     imageTexturesRef, // 追加: プリロードされたテクスチャへの参照
     ENEMY_LIST
   } = useFantasyGameEngine({
-    stage: null, // ★★★ change
+    stage: stage, // 実際のstageを渡す
     onGameStateChange: handleGameStateChange,
     onChordCorrect: handleChordCorrect,
     onChordIncorrect: handleChordIncorrect,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Extend fantasy mode progression pattern with dynamic attack gauge, precise question/judgment timings, and a game start bug fix.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This enhancement introduces rhythm-based gameplay to the progression mode by dynamically calculating the attack gauge (95% at the 1st beat of each measure), setting specific timings for question presentation (2nd beat) and judgment acceptance (1st beat, only 90-100% gauge), and managing post-judgment question resets. It also resolves a bug that caused the game to prematurely return to the start screen upon enemy attacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-2db6608b-a6f4-4b3c-9457-61527981e721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2db6608b-a6f4-4b3c-9457-61527981e721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>