### PR TITLE
ファンタジーモードのプログレッションパターンを拡張

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -439,7 +439,7 @@ export const useFantasyGameEngine = ({
   const [enemyGaugeTimer, setEnemyGaugeTimer] = useState<NodeJS.Timeout | null>(null);
   
   // ゲーム初期化
-  const initializeGame = useCallback((stage: FantasyStage) => {
+  const initializeGame = useCallback(async (stage: FantasyStage) => {
     devLog.debug('🎮 ゲーム初期化開始:', {
       stage: JSON.stringify(stage, null, 2)
     });

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -642,56 +642,46 @@ export const useFantasyGameEngine = ({
     const elapsed = now - startAt - readyDuration;
     const msPerBeat = 60000 / bpm;
     const currentBeatTime = Math.floor(elapsed / msPerBeat) * msPerBeat; // 現在の拍の開始時刻
-    const nextBeatTime = currentBeatTime + msPerBeat; // 次の拍の開始時刻
-    const beatInMeasure = currentBeat; // currentBeatは既に1-4の範囲なのでそのまま使用
-
+    
     setGameState(prevState => {
       if (!prevState.isGameActive || !prevState.currentStage) return prevState;
 
-      // 判定ウィンドウの管理（1拍目の±200ms）
-      if (beatInMeasure === 1) {
+      // 1拍目の処理
+      if (currentBeat === 1) {
         const beatOffset = elapsed - currentBeatTime;
         const isInWindow = beatOffset >= -200 && beatOffset <= 200;
         
-        // 判定ウィンドウの状態が変わった場合
-        if (isInWindow !== prevState.isInJudgmentWindow) {
-          devLog.debug('判定ウィンドウ状態変更:', { 
-            isInWindow, 
+        // 判定ウィンドウに入った瞬間
+        if (isInWindow && !prevState.isInJudgmentWindow) {
+          devLog.debug('⏰ 判定ウィンドウ開始', { 
             beatOffset,
             gauge: prevState.activeMonsters[0]?.gauge,
             currentChord: prevState.activeMonsters[0]?.chordTarget?.displayName
           });
-        }
-
-        // 判定ウィンドウを抜けた瞬間の処理
-        if (!isInWindow && prevState.isInJudgmentWindow && prevState.activeMonsters.length > 0) {
-          // ゲーム開始直後（questionShowTimeがnull）の場合はタイムオーバー処理をスキップ
-          if (prevState.questionShowTime === null) {
-            devLog.debug('🎮 ゲーム開始直後のため、タイムオーバー処理をスキップ');
-            return {
-              ...prevState,
-              isInJudgmentWindow: false
-            };
-          }
           
-          // タイムオーバー処理（問題がNULLでない場合）
-          const hasActiveQuestion = prevState.activeMonsters.some(m => m.chordTarget !== null);
-          if (hasActiveQuestion) {
-            devLog.debug('⏰ タイムオーバー！判定ウィンドウ終了', {
-              elapsed,
-              beatOffset,
-              currentBeatTime,
-              hasActiveQuestion,
-              currentChord: prevState.activeMonsters[0]?.chordTarget?.displayName
-            });
-            
-            // モンスターのコードをNULLに設定
+          return {
+            ...prevState,
+            isInJudgmentWindow: true
+          };
+        }
+        
+        // 判定ウィンドウを抜けた瞬間（1拍目+200ms後）
+        if (!isInWindow && prevState.isInJudgmentWindow) {
+          devLog.debug('⏰ 判定ウィンドウ終了', {
+            beatOffset,
+            currentChord: prevState.activeMonsters[0]?.chordTarget?.displayName
+          });
+          
+          // タイムオーバー処理
+          if (prevState.activeMonsters.some(m => m.chordTarget !== null)) {
+            // 判定が終わったらコードをNULLに
             const updatedMonsters = prevState.activeMonsters.map(m => ({
               ...m,
-              chordTarget: null as any, // 一時的にNULLに
-              correctNotes: []
+              chordTarget: null as any,
+              correctNotes: [],
+              gauge: 0 // ゲージもリセット
             }));
-
+            
             return {
               ...prevState,
               activeMonsters: updatedMonsters,
@@ -699,66 +689,47 @@ export const useFantasyGameEngine = ({
               questionShowTime: null
             };
           }
-        }
-
-        return {
-          ...prevState,
-          isInJudgmentWindow: isInWindow
-        };
-      }
-
-      // 問題出題タイミング（2拍目または判定後3拍目）
-      const hasNullChord = prevState.activeMonsters.some(m => !m.chordTarget);
-      const hasActiveChord = prevState.activeMonsters.some(m => m.chordTarget !== null);
-      
-      // コードが既に設定されている場合は出題しない
-      if (hasActiveChord) {
-        return prevState;
-      }
-      
-      const shouldShowNewQuestion = 
-        (beatInMeasure === 2 && hasNullChord) || // 2拍目でコードがNULLの場合
-        (beatInMeasure === 4 && hasNullChord); // 4拍目でもチェック（3拍待機後）
-
-      devLog.debug('🎵 問題出題チェック:', {
-        beatInMeasure,
-        questionShowTime: prevState.questionShowTime,
-        hasNullChord,
-        shouldShowNewQuestion,
-        activeMonsters: prevState.activeMonsters.length,
-        currentChord: prevState.activeMonsters[0]?.chordTarget?.displayName
-      });
-
-      if (shouldShowNewQuestion && prevState.activeMonsters.length > 0) {
-        // 新しい問題を出題
-        const progression = prevState.currentStage.chordProgression || [];
-        if (progression.length === 0) return prevState;
-
-        const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-        const nextChord = getProgressionChord(progression, nextIndex, displayOpts);
-
-        if (nextChord) {
-          const updatedMonsters = prevState.activeMonsters.map(m => ({
-            ...m,
-            chordTarget: nextChord,
-            correctNotes: []
-          }));
-
-          devLog.debug('📝 新しい問題を出題:', {
-            chord: nextChord.id,
-            index: nextIndex,
-            beat: beatInMeasure,
-            measure: currentMeasure
-          });
-
+          
           return {
             ...prevState,
-            activeMonsters: updatedMonsters,
-            currentChordTarget: nextChord, // 互換性のため
-            currentQuestionIndex: nextIndex,
-            questionShowTime: now,
-            nextQuestionBeat: 2 // 次も2拍目に出題
+            isInJudgmentWindow: false
           };
+        }
+      }
+      
+      // 2拍目：新しい問題を出題
+      if (currentBeat === 2) {
+        const hasNullChord = prevState.activeMonsters.some(m => !m.chordTarget);
+        
+        if (hasNullChord) {
+          const progression = prevState.currentStage.chordProgression || [];
+          if (progression.length === 0) return prevState;
+
+          const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
+          const nextChord = getProgressionChord(progression, nextIndex, displayOpts);
+
+          if (nextChord) {
+            const updatedMonsters = prevState.activeMonsters.map(m => ({
+              ...m,
+              chordTarget: nextChord,
+              correctNotes: []
+            }));
+
+            devLog.debug('📝 新しい問題を出題（2拍目）:', {
+              chord: nextChord.displayName,
+              index: nextIndex,
+              beat: currentBeat,
+              measure: currentMeasure
+            });
+
+            return {
+              ...prevState,
+              activeMonsters: updatedMonsters,
+              currentChordTarget: nextChord,
+              currentQuestionIndex: nextIndex,
+              questionShowTime: now
+            };
+          }
         }
       }
 

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -1090,6 +1090,11 @@ export const useFantasyGameEngine = ({
 
       // 1. 今回の入力でどのモンスターが影響を受けるか判定し、新しい状態を作る
       const monstersAfterInput = prevState.activeMonsters.map(monster => {
+        // chordTargetがnullの場合はスキップ
+        if (!monster.chordTarget) {
+          return monster;
+        }
+        
         const targetNotes = [...new Set(monster.chordTarget.notes.map(n => n % 12))];
         
         // 既に完成しているモンスターや、入力音と関係ないモンスターはスキップ
@@ -1158,7 +1163,7 @@ export const useFantasyGameEngine = ({
               // シングルモードの場合は即座に新しい問題
               const nextChord = selectRandomChord(
                 stateAfterAttack.currentStage!.allowedChords,
-                monster.chordTarget.id,
+                monster.chordTarget?.id,
                 displayOpts
               );
               return { ...monster, chordTarget: nextChord!, correctNotes: [], gauge: 0 };
@@ -1178,7 +1183,7 @@ export const useFantasyGameEngine = ({
 
         if (monstersToAddCount > 0) {
                       const availablePositions = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].filter(pos => !remainingMonsters.some(m => m.position === pos));
-          const lastUsedChordId = completedMonsters.length > 0 ? completedMonsters[0].chordTarget.id : undefined;
+          const lastUsedChordId = completedMonsters.length > 0 ? completedMonsters[0].chordTarget?.id : undefined;
 
           for (let i = 0; i < monstersToAddCount; i++) {
             const monsterIndex = newMonsterQueue.shift()!;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -841,14 +841,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       <div className={`text-yellow-300 font-bold text-center mb-1 truncate w-full ${
                         monsterCount > 5 ? 'text-sm' : monsterCount > 3 ? 'text-base' : 'text-xl'
                       }`}>
-                        {monster.chordTarget.displayName}
+                        {monster.chordTarget ? monster.chordTarget.displayName : '？'}
                       </div>
                       
                       {/* ★★★ ここにヒント表示を追加 ★★★ */}
                       <div className={`mt-1 font-medium h-6 text-center ${
                         monsterCount > 5 ? 'text-xs' : 'text-sm'
                       }`}>
-                        {monster.chordTarget.noteNames.map((noteName, index) => {
+                        {monster.chordTarget ? monster.chordTarget.noteNames.map((noteName, index) => {
                           // 表示オプションを定義
                           const displayOpts: DisplayOpts = { lang: currentNoteNameLang, simple: currentSimpleNoteName };
                           // 表示用の音名に変換
@@ -873,7 +873,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                               {isCorrect && '✓'}
                             </span>
                           );
-                        })}
+                        }) : null}
                       </div>
                       
                       {/* 魔法名表示 */}

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -609,13 +609,22 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // 敵のゲージ表示（黄色系）
   const renderEnemyGauge = useCallback(() => {
+    const isJudgmentZone = gameState.enemyGauge >= 90;
+    
     return (
       <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
         <div 
-          className="h-full bg-gradient-to-r from-yellow-500 to-orange-400 rounded-full transition-all duration-200 ease-out"
+          className={cn(
+            "h-full rounded-full transition-all duration-200 ease-out",
+            // 判定受付ゾーン（90-100%）の色分け
+            isJudgmentZone 
+              ? "bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse" 
+              : "bg-gradient-to-r from-yellow-500 to-orange-400"
+          )}
           style={{ 
             width: `${Math.min(gameState.enemyGauge, 100)}%`,
-            boxShadow: gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
+            boxShadow: isJudgmentZone ? '0 0 15px rgba(168, 85, 247, 0.8)' : 
+                       gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
           }}
         />
       </div>
@@ -660,7 +669,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   }, [autoStart, initializeGame, stage]);
 
   // ゲーム開始前画面（オーバーレイ表示中は表示しない）
-  if (!overlay && !gameState.isCompleting && (!gameState.isGameActive || !gameState.currentChordTarget)) {
+  if (!overlay && !gameState.isCompleting && !gameState.isGameActive) {
     devLog.debug('🎮 ゲーム開始前画面表示:', { 
       isGameActive: gameState.isGameActive,
       hasCurrentChord: !!gameState.currentChordTarget,

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -613,9 +613,19 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     return (
       <div className="relative w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
-        {/* 判定ウィンドウマーカー（90%と100%の位置） */}
-        <div className="absolute left-[90%] top-0 bottom-0 w-0.5 bg-white opacity-50 z-10" />
-        <div className="absolute left-[95%] top-0 bottom-0 w-0.5 bg-yellow-300 opacity-75 z-10" />
+        {/* 判定ウィンドウ領域の背景（90-100%） */}
+        <div className="absolute left-[90%] right-0 top-0 bottom-0 bg-purple-900 opacity-30" />
+        
+        {/* 判定ウィンドウマーカー */}
+        <div className="absolute left-[90%] top-0 bottom-0 w-1 bg-purple-400 opacity-80 z-10">
+          <span className="absolute -top-5 -left-2 text-xs text-purple-300">90%</span>
+        </div>
+        <div className="absolute left-[95%] top-0 bottom-0 w-1 bg-yellow-300 z-10">
+          <span className="absolute -top-5 -left-2 text-xs text-yellow-300">95%</span>
+        </div>
+        <div className="absolute right-0 top-0 bottom-0 w-1 bg-red-400 opacity-80 z-10">
+          <span className="absolute -top-5 -right-2 text-xs text-red-300">100%</span>
+        </div>
         
         {/* ゲージ本体 */}
         <div 
@@ -632,9 +642,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                        gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
           }}
         />
-        
-        {/* 判定ウィンドウ領域の背景（90-100%） */}
-        <div className="absolute left-[90%] right-0 top-0 bottom-0 bg-white opacity-10" />
       </div>
     );
   }, [gameState.enemyGauge]);

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -331,7 +331,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     imageTexturesRef, // 追加: プリロードされたテクスチャへの参照
     ENEMY_LIST
   } = useFantasyGameEngine({
-    stage: null, // ★★★ change
+    stage: stage, // stageプロパティを正しく渡す
     onGameStateChange: handleGameStateChange,
     onChordCorrect: handleChordCorrect,
     onChordIncorrect: handleChordIncorrect,

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -612,10 +612,15 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     const isJudgmentZone = gameState.enemyGauge >= 90;
     
     return (
-      <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
+      <div className="relative w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
+        {/* 判定ウィンドウマーカー（90%と100%の位置） */}
+        <div className="absolute left-[90%] top-0 bottom-0 w-0.5 bg-white opacity-50 z-10" />
+        <div className="absolute left-[95%] top-0 bottom-0 w-0.5 bg-yellow-300 opacity-75 z-10" />
+        
+        {/* ゲージ本体 */}
         <div 
           className={cn(
-            "h-full rounded-full transition-all duration-200 ease-out",
+            "h-full rounded-full transition-all duration-200 ease-out relative",
             // 判定受付ゾーン（90-100%）の色分け
             isJudgmentZone 
               ? "bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse" 
@@ -627,6 +632,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                        gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
           }}
         />
+        
+        {/* 判定ウィンドウ領域の背景（90-100%） */}
+        <div className="absolute left-[90%] right-0 top-0 bottom-0 bg-white opacity-10" />
       </div>
     );
   }, [gameState.enemyGauge]);

--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -154,19 +154,19 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
     
     for (let i = 0; i < 10; i++) {
       const isJudgmentBlock = i >= 9; // 90%以上（9番目と10番目のブロック）
-      const isFilled = i < filledBlocks;
+      const isFilled = i < filledBlocks || (i === Math.floor(enemyGauge / 10) && enemyGauge % 10 > 0);
       
       blocks.push(
         <div
           key={i}
           className={cn(
-            "flex-1 border border-gray-600 transition-all duration-100",
+            "flex-1 border transition-all duration-100",
             sizeConfig.gauge,
             // 判定受付ゾーン（90-100%）の色分け
-            isFilled && isJudgmentBlock ? "bg-yellow-500 animate-pulse" :
-            isFilled ? "bg-red-500" :
-            isJudgmentBlock ? "bg-gray-600" : // 判定ゾーン未到達時は少し明るく
-            "bg-gray-700"
+            isFilled && isJudgmentBlock ? "bg-yellow-500 animate-pulse border-yellow-400" :
+            isFilled ? "bg-red-500 border-red-600" :
+            isJudgmentBlock ? "bg-gray-600 border-gray-500" : // 判定ゾーン未到達時
+            "bg-gray-700 border-gray-600"
           )}
         />
       );

--- a/src/components/fantasy/FantasyMonster.tsx
+++ b/src/components/fantasy/FantasyMonster.tsx
@@ -153,13 +153,20 @@ const FantasyMonster: React.FC<FantasyMonsterProps> = ({
     const blocks = [];
     
     for (let i = 0; i < 10; i++) {
+      const isJudgmentBlock = i >= 9; // 90%以上（9番目と10番目のブロック）
+      const isFilled = i < filledBlocks;
+      
       blocks.push(
         <div
           key={i}
           className={cn(
             "flex-1 border border-gray-600 transition-all duration-100",
             sizeConfig.gauge,
-            i < filledBlocks ? "bg-red-500" : "bg-gray-700"
+            // 判定受付ゾーン（90-100%）の色分け
+            isFilled && isJudgmentBlock ? "bg-yellow-500 animate-pulse" :
+            isFilled ? "bg-red-500" :
+            isJudgmentBlock ? "bg-gray-600" : // 判定ゾーン未到達時は少し明るく
+            "bg-gray-700"
           )}
         />
       );

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -827,8 +827,10 @@ export class FantasyPIXIInstance {
     sprite.x = visualState.x + gameState.staggerOffset.x;
     sprite.y = visualState.y + gameState.staggerOffset.y;
     
-    sprite.scale.x = visualState.scale;
-    sprite.scale.y = visualState.scale;
+    if (sprite.scale) {
+      sprite.scale.x = visualState.scale;
+      sprite.scale.y = visualState.scale;
+    }
     
     sprite.rotation = visualState.rotation;
     sprite.tint = gameState.isHit ? gameState.hitColor : visualState.tint;


### PR DESCRIPTION
Enhance Fantasy Mode progression pattern with dynamic attack gauge timing, precise question presentation, and judgment windows.

This PR implements a rhythm-game-like experience for Fantasy Mode's progression pattern, synchronizing attack gauge filling, question appearance (2nd beat), and judgment windows (1st beat ±200ms) with musical beats. It also fixes a bug where the game start screen appeared when chords were temporarily `NULL`.

---
<a href="https://cursor.com/background-agent?bcId=bc-97ad4a3e-a30a-4fe9-af65-a1b456d0c6e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97ad4a3e-a30a-4fe9-af65-a1b456d0c6e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>