### PR TITLE
ビート同期による攻撃ゲージと判定ウィンドウの改修

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -692,7 +692,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           {process.env.NODE_ENV === 'development' && (
             <div className="mt-4 bg-black bg-opacity-50 text-white text-xs p-3 rounded">
               <div>ゲーム状態: {gameState.isGameActive ? 'アクティブ' : '非アクティブ'}</div>
-              <div>現在のコード: {gameState.currentChordTarget?.displayName || 'なし'}</div>
+              <div>現在のコード: {gameState.currentChordTarget?.displayName || ''}</div>
               <div>許可コード数: {stage.allowedChords?.length || 0}</div>
               <div>敵ゲージ秒数: {stage.enemyGaugeSeconds}</div>
               <div>オーバーレイ: {overlay ? '表示中' : 'なし'}</div>
@@ -832,7 +832,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       <div className={`text-yellow-300 font-bold text-center mb-1 truncate w-full ${
                         monsterCount > 5 ? 'text-sm' : monsterCount > 3 ? 'text-base' : 'text-xl'
                       }`}>
-                        {monster.chordTarget.displayName}
+                        {monster.chordTarget ? monster.chordTarget.displayName : ''}
                       </div>
                       
                       {/* ★★★ ここにヒント表示を追加 ★★★ */}
@@ -888,7 +888,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
                       >
                         <div
-                          className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
+                          className={cn(
+                            "h-full transition-all duration-100",
+                            monster.gauge >= 90 && monster.gauge <= 100
+                              ? "bg-red-500"
+                              : "bg-gradient-to-r from-purple-500 to-purple-700"
+                          )}
                           style={{ width: `${monster.gauge}%` }}
                         />
                       </div>
@@ -1018,7 +1023,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           <div>ゲージ: {gameState.enemyGauge.toFixed(1)}%</div>
           <div>スコア: {gameState.score}</div>
           <div>正解数: {gameState.correctAnswers}</div>
-          <div>現在のコード: {gameState.currentChordTarget?.displayName || 'なし'}</div>
+          <div>現在のコード: {gameState.currentChordTarget?.displayName || ''}</div>
           <div>SP: {gameState.playerSp}</div>
           
           {/* ゲージ強制満タンテストボタン */}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement beat-synchronized enemy attack gauges and judgment windows to transform the game into a rhythm-game experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This refactor changes the game's core timing mechanics from time-based to beat-based. Enemy gauges now fill per measure based on BPM, input judgment is restricted to a precise window around the first beat, and chord presentation is synchronized to the second beat, making timing crucial for gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-c386e4d4-4166-4cb3-8e9f-40cdec04e6a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c386e4d4-4166-4cb3-8e9f-40cdec04e6a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>