### PR TITLE
Extend fantasy mode progression timings

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -35,7 +35,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';  // rhythmを追加
   allowedChords: string[];
   chordProgression?: string[];
   showSheetMusic: boolean;
@@ -48,8 +48,8 @@ interface FantasyStage {
   countInMeasures?: number;
   timeSignature?: number;
   // リズムモード用のフィールドを追加
-  gameType?: 'quiz' | 'rhythm';
-  rhythmPattern?: 'random' | 'progression';
+  gameType?: 'quiz' | 'rhythm';  // 廃止予定（互換性のため残す）
+  rhythmPattern?: 'random' | 'progression';  // 廃止予定（互換性のため残す）
   mp3Url?: string;
   chordProgressionData?: any[];
   rhythmData?: string;
@@ -100,7 +100,6 @@ interface FantasyGameState {
   isCompleting: boolean;
   // リズムモード用の状態を追加
   isRhythmMode: boolean;
-  rhythmPattern?: 'random' | 'progression';
   currentMeasure: number;
   currentBeat: number;
   hasCompletedChordInMeasure: boolean; // 現在の小節でコードを完成させたか
@@ -428,7 +427,6 @@ export const useFantasyGameEngine = ({
     isCompleting: false,
     // リズムモード用の状態
     isRhythmMode: false,
-    rhythmPattern: 'random', // デフォルトはランダム
     currentMeasure: 1,
     currentBeat: 1,
     hasCompletedChordInMeasure: false,
@@ -447,8 +445,7 @@ export const useFantasyGameEngine = ({
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
     const simultaneousCount = stage.simultaneousMonsterCount || 1;
-    const isRhythmMode = stage.gameType === 'rhythm';
-    const rhythmPattern = stage.rhythmPattern;
+    const isRhythmMode = stage.mode === 'rhythm';
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -511,8 +508,8 @@ export const useFantasyGameEngine = ({
 
     // リズムモードのプログレッションパターンでは最初から全モンスターを配置しない
     // 出題タイミングで配置する
-    if (isRhythmMode && rhythmPattern === 'progression') {
-      // プログレッションパターンでは初期配置しない
+    if (isRhythmMode) {
+      // リズムモードのプログレッションパターンでは初期配置しない
       // 出題タイミングで配置する
     } else {
       // 既に同時出現数が 1 の場合に後続モンスターが "フェードアウト待ち" の間に
@@ -572,7 +569,6 @@ export const useFantasyGameEngine = ({
       isCompleting: false,
       // リズムモード用の状態
       isRhythmMode,
-      rhythmPattern,
       currentMeasure: 1,
       currentBeat: 1,
       hasCompletedChordInMeasure: false,
@@ -601,7 +597,7 @@ export const useFantasyGameEngine = ({
       simultaneousCount,
       activeMonsters: activeMonsters.length,
       isRhythmMode,
-      rhythmPattern
+      rhythmPattern: 'random' // リズムモードの場合はパターンを固定
     });
   }, [onGameStateChange, displayOpts]);
   
@@ -775,11 +771,14 @@ export const useFantasyGameEngine = ({
     
     // ゲームがアクティブな場合のみ新しいタイマーを開始
     if (gameState.isGameActive && gameState.currentStage) {
-      devLog.debug('⏰ 敵ゲージタイマー開始');
-      const timer = setInterval(() => {
-        updateEnemyGauge();
-      }, 100); // 100ms間隔で更新
-      setEnemyGaugeTimer(timer);
+      // リズムモードではゲージタイマーは不要
+      if (gameState.currentStage.mode !== 'rhythm') {
+        devLog.debug('⏰ 敵ゲージタイマー開始');
+        const timer = setInterval(() => {
+          updateEnemyGauge();
+        }, 100); // 100ms間隔で更新
+        setEnemyGaugeTimer(timer);
+      }
     }
     
     // クリーンアップ
@@ -792,7 +791,7 @@ export const useFantasyGameEngine = ({
   
   // リズムモード - プログレッションパターンの問題出現処理
   const handleRhythmProgression = useCallback(() => {
-    if (!gameState.isRhythmMode || gameState.rhythmPattern !== 'progression') return;
+    if (gameState.currentStage?.mode !== 'rhythm') return;
     if (!gameState.currentStage || !gameState.isGameActive) return;
     
     const timeState = useTimeStore.getState();
@@ -935,7 +934,7 @@ export const useFantasyGameEngine = ({
 
   // リズムモードのタイミング監視
   useEffect(() => {
-    if (gameState.isRhythmMode && gameState.rhythmPattern === 'progression' && gameState.isGameActive) {
+    if (gameState.currentStage?.mode === 'rhythm' && gameState.isGameActive) {
       // 高頻度でタイミングをチェック
       const timer = setInterval(() => {
         handleRhythmProgression();
@@ -950,7 +949,7 @@ export const useFantasyGameEngine = ({
         }
       };
     }
-  }, [gameState.isRhythmMode, gameState.rhythmPattern, gameState.isGameActive, handleRhythmProgression]);
+  }, [gameState.currentStage?.mode, gameState.isGameActive, handleRhythmProgression]);
 
   // 敵ゲージの更新（マルチモンスター対応）
   const updateEnemyGauge = useCallback(() => {
@@ -961,8 +960,8 @@ export const useFantasyGameEngine = ({
       return;
     }
     
-    // リズムモードのプログレッションパターンでは敵ゲージを使用しない
-    if (gameState.isRhythmMode && gameState.rhythmPattern === 'progression') {
+    // リズムモードでは敵ゲージを使用しない
+    if (gameState.currentStage?.mode === 'rhythm') {
       return;
     }
     
@@ -1031,8 +1030,8 @@ export const useFantasyGameEngine = ({
         return prevState;
       }
 
-      // リズムモードのプログレッションパターンでの追加チェック
-      if (prevState.isRhythmMode && prevState.rhythmPattern === 'progression') {
+      // リズムモードでの追加チェック
+      if (prevState.currentStage?.mode === 'rhythm') {
         // NULL期間中は入力を受け付けない
         if (prevState.isInNullPeriod) {
           devLog.debug('🚫 NULL期間中のため入力無効');
@@ -1089,8 +1088,8 @@ export const useFantasyGameEngine = ({
       if (completedMonsters.length > 0) {
         devLog.debug(`🎯 ${completedMonsters.length}体のコードが完成しました！`, { ids: completedMonsters.map(m => m.id) });
 
-        // リズムモードのプログレッションパターンの場合
-        if (prevState.isRhythmMode && prevState.rhythmPattern === 'progression') {
+        // リズムモードの場合
+        if (prevState.currentStage?.mode === 'rhythm') {
           // 全てのモンスターが完成したかチェック
           const allCompleted = monstersAfterInput.every(m => {
             if (!m.chordTarget) return true; // NULLコードはスキップ
@@ -1141,7 +1140,7 @@ export const useFantasyGameEngine = ({
           }
         }
 
-        // 通常のファンタジーモード（シングルパターン）の処理
+        // 通常のファンタジーモード（シングル/プログレッションパターン）の処理
         // ★ 攻撃処理後の状態を計算する
         let stateAfterAttack = { ...prevState, activeMonsters: monstersAfterInput };
         

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -11,6 +11,7 @@ import { useEnemyStore } from '@/stores/enemyStore';
 import { useTimeStore } from '@/stores/timeStore';
 import { MONSTERS, getStageMonsterIds } from '@/data/monsters';
 import * as PIXI from 'pixi.js';
+import { getRhythmTimingState, isWithinJudgmentWindow, getJudgmentCutoffBeat } from '@/utils/rhythm-timing';
 
 // ===== 型定義 =====
 
@@ -46,6 +47,12 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  // リズムモード用のフィールドを追加
+  gameType?: 'quiz' | 'rhythm';
+  rhythmPattern?: 'random' | 'progression';
+  mp3Url?: string;
+  chordProgressionData?: any[];
+  rhythmData?: string;
 }
 
 interface MonsterState {
@@ -91,6 +98,14 @@ interface FantasyGameState {
   simultaneousMonsterCount: number; // 同時表示数
   // ゲーム完了処理中フラグ
   isCompleting: boolean;
+  // リズムモード用の状態を追加
+  isRhythmMode: boolean;
+  rhythmPattern?: 'random' | 'progression';
+  currentMeasure: number;
+  currentBeat: number;
+  hasCompletedChordInMeasure: boolean; // 現在の小節でコードを完成させたか
+  isInNullPeriod: boolean; // NULL期間中か
+  nextQuestionScheduled: boolean; // 次の問題が予約されているか
 }
 
 interface FantasyGameEngineProps {
@@ -378,6 +393,10 @@ export const useFantasyGameEngine = ({
   // プリロードしたテクスチャを保持
   const imageTexturesRef = useRef<Map<string, PIXI.Texture>>(new Map());
   
+  // リズムモード用のタイマー
+  const rhythmTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const nextQuestionTimerRef = useRef<NodeJS.Timeout | null>(null);
+  
   const [gameState, setGameState] = useState<FantasyGameState>({
     currentStage: null,
     currentQuestionIndex: 0,
@@ -406,7 +425,15 @@ export const useFantasyGameEngine = ({
     monsterQueue: [],
     simultaneousMonsterCount: 1,
     // ゲーム完了処理中フラグ
-    isCompleting: false
+    isCompleting: false,
+    // リズムモード用の状態
+    isRhythmMode: false,
+    rhythmPattern: 'random', // デフォルトはランダム
+    currentMeasure: 1,
+    currentBeat: 1,
+    hasCompletedChordInMeasure: false,
+    isInNullPeriod: false,
+    nextQuestionScheduled: false
   });
   
   const [enemyGaugeTimer, setEnemyGaugeTimer] = useState<NodeJS.Timeout | null>(null);
@@ -420,6 +447,8 @@ export const useFantasyGameEngine = ({
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
     const simultaneousCount = stage.simultaneousMonsterCount || 1;
+    const isRhythmMode = stage.gameType === 'rhythm';
+    const rhythmPattern = stage.rhythmPattern;
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -480,24 +509,31 @@ export const useFantasyGameEngine = ({
     // ▼▼▼ 修正点2: コードの重複を避けるロジックを追加 ▼▼▼
     let lastChordId: string | undefined = undefined; // 直前のコードIDを記録する変数を追加
 
-    // 既に同時出現数が 1 の場合に後続モンスターが "フェードアウト待ち" の間に
-    // 追加生成されないよう、queue だけ作って最初の 1 体だけ生成する。
-    for (let i = 0; i < initialMonsterCount; i++) {
-      const monsterIndex = monsterQueue.shift()!;
-      // simultaneousMonsterCount === 1 のとき、0 番目のみ即生成。
-      if (i === 0 || simultaneousCount > 1) {
-        const monster = createMonsterFromQueue(
-          monsterIndex,
-          positions[i],
-          enemyHp,
-          stage.allowedChords,
-          lastChordId,
-          displayOpts,
-          monsterIds        // ✅ 今回作った配列
-        );
-        activeMonsters.push(monster);
-        usedChordIds.push(monster.chordTarget.id);
-        lastChordId = monster.chordTarget.id;
+    // リズムモードのプログレッションパターンでは最初から全モンスターを配置しない
+    // 出題タイミングで配置する
+    if (isRhythmMode && rhythmPattern === 'progression') {
+      // プログレッションパターンでは初期配置しない
+      // 出題タイミングで配置する
+    } else {
+      // 既に同時出現数が 1 の場合に後続モンスターが "フェードアウト待ち" の間に
+      // 追加生成されないよう、queue だけ作って最初の 1 体だけ生成する。
+      for (let i = 0; i < initialMonsterCount; i++) {
+        const monsterIndex = monsterQueue.shift()!;
+        // simultaneousMonsterCount === 1 のとき、0 番目のみ即生成。
+        if (i === 0 || simultaneousCount > 1) {
+          const monster = createMonsterFromQueue(
+            monsterIndex,
+            positions[i],
+            enemyHp,
+            stage.allowedChords,
+            lastChordId,
+            displayOpts,
+            monsterIds        // ✅ 今回作った配列
+          );
+          activeMonsters.push(monster);
+          usedChordIds.push(monster.chordTarget.id);
+          lastChordId = monster.chordTarget.id;
+        }
       }
     }
 
@@ -533,7 +569,15 @@ export const useFantasyGameEngine = ({
       monsterQueue,
       simultaneousMonsterCount: simultaneousCount,
       // ゲーム完了処理中フラグ
-      isCompleting: false
+      isCompleting: false,
+      // リズムモード用の状態
+      isRhythmMode,
+      rhythmPattern,
+      currentMeasure: 1,
+      currentBeat: 1,
+      hasCompletedChordInMeasure: false,
+      isInNullPeriod: false,
+      nextQuestionScheduled: false
     };
 
     setGameState(newState);
@@ -555,9 +599,11 @@ export const useFantasyGameEngine = ({
       enemyHp,
       totalQuestions,
       simultaneousCount,
-      activeMonsters: activeMonsters.length
+      activeMonsters: activeMonsters.length,
+      isRhythmMode,
+      rhythmPattern
     });
-  }, [onGameStateChange]);
+  }, [onGameStateChange, displayOpts]);
   
   // 次の問題への移行（マルチモンスター対応）
   const proceedToNextQuestion = useCallback(() => {
@@ -744,12 +790,179 @@ export const useFantasyGameEngine = ({
     };
   }, [gameState.isGameActive, gameState.currentStage]); // ゲーム状態とステージの変更を監視
   
+  // リズムモード - プログレッションパターンの問題出現処理
+  const handleRhythmProgression = useCallback(() => {
+    if (!gameState.isRhythmMode || gameState.rhythmPattern !== 'progression') return;
+    if (!gameState.currentStage || !gameState.isGameActive) return;
+    
+    const timeState = useTimeStore.getState();
+    const currentBeatDecimal = timeState.getCurrentBeatDecimal();
+    const timeSignature = timeState.timeSignature;
+    const bpm = timeState.bpm;
+    
+    // 現在のリズムタイミング状態を取得
+    const timingState = getRhythmTimingState(
+      currentBeatDecimal,
+      timeSignature,
+      bpm,
+      gameState.hasCompletedChordInMeasure
+    );
+    
+    // NULL期間の管理
+    if (gameState.hasCompletedChordInMeasure && !gameState.isInNullPeriod) {
+      // コード完成後、NULL期間に入る
+      setGameState(prev => {
+        const newState = { ...prev, isInNullPeriod: true };
+        onGameStateChange(newState);
+        return newState;
+      });
+      
+      // 現在のモンスターのコードをNULLに設定
+      setGameState(prev => {
+        const updatedMonsters = prev.activeMonsters.map(monster => ({
+          ...monster,
+          chordTarget: null as any // NULL状態を表現
+        }));
+        const newState = { ...prev, activeMonsters: updatedMonsters };
+        onGameStateChange(newState);
+        return newState;
+      });
+    }
+    
+    // 判定受付終了タイミング（4.49）でのチェック
+    const cutoffBeat = getJudgmentCutoffBeat(timeSignature);
+    const normalizedBeat = ((currentBeatDecimal - 1) % timeSignature) + 1;
+    
+    if (normalizedBeat >= cutoffBeat && normalizedBeat < cutoffBeat + 0.01 && !gameState.hasCompletedChordInMeasure) {
+      // 判定時間切れ - 自動的に次へ進む
+      devLog.debug('⏰ リズムモード: 判定時間切れ、自動進行');
+      
+      // 敵の攻撃処理
+      gameState.activeMonsters.forEach(monster => {
+        if (monster.correctNotes.length > 0) {
+          // 部分的に音を入力していた場合も失敗扱い
+          onChordIncorrect(monster.chordTarget, monster.correctNotes);
+        }
+      });
+      
+      // 全モンスターのゲージを満タンにして攻撃
+      const attackingMonster = gameState.activeMonsters[0]; // 代表して最初のモンスターが攻撃
+      if (attackingMonster) {
+        handleEnemyAttack(attackingMonster.id);
+      }
+      
+      // NULL期間に入る
+      setGameState(prev => {
+        const newState = { 
+          ...prev, 
+          hasCompletedChordInMeasure: true,
+          isInNullPeriod: true 
+        };
+        onGameStateChange(newState);
+        return newState;
+      });
+    }
+    
+    // 出題タイミング（4.50）での処理
+    const questionBeat = timeSignature + 0.50;
+    if (normalizedBeat >= questionBeat && !gameState.nextQuestionScheduled) {
+      devLog.debug('🎵 リズムモード: 出題タイミング到達');
+      
+      // 次の小節の準備
+      setGameState(prev => {
+        // 次の問題を生成
+        let newMonsters: MonsterState[] = [];
+        const positions = assignPositions(prev.simultaneousMonsterCount);
+        const progression = prev.currentStage?.chordProgression || prev.currentStage?.allowedChords || [];
+        
+        // プログレッションパターンで次のコードを決定
+        for (let i = 0; i < prev.simultaneousMonsterCount && prev.monsterQueue.length > 0; i++) {
+          const monsterIndex = prev.monsterQueue.shift()!;
+          const nextChordIndex = (prev.currentQuestionIndex + i) % progression.length;
+          const nextChordId = progression[nextChordIndex];
+          const nextChord = getChordDefinition(nextChordId, displayOpts);
+          
+          if (nextChord) {
+            const monster = createMonsterFromQueue(
+              monsterIndex,
+              positions[i],
+              prev.maxEnemyHp,
+              [nextChordId], // 特定のコードのみ
+              undefined,
+              displayOpts,
+              stageMonsterIds
+            );
+            // 強制的に特定のコードを設定
+            monster.chordTarget = nextChord;
+            newMonsters.push(monster);
+          }
+        }
+        
+        const newState = {
+          ...prev,
+          activeMonsters: newMonsters,
+          currentQuestionIndex: (prev.currentQuestionIndex + prev.simultaneousMonsterCount) % progression.length,
+          hasCompletedChordInMeasure: false,
+          isInNullPeriod: false,
+          nextQuestionScheduled: true,
+          correctNotes: [],
+          currentChordTarget: newMonsters[0]?.chordTarget || null
+        };
+        
+        onGameStateChange(newState);
+        return newState;
+      });
+      
+      // 少し待ってからフラグをリセット（同じ小節で2回実行されないように）
+      setTimeout(() => {
+        setGameState(prev => ({ ...prev, nextQuestionScheduled: false }));
+      }, 100);
+    }
+    
+    // 小節の切り替わりを検出
+    if (timeState.currentMeasure !== gameState.currentMeasure) {
+      setGameState(prev => {
+        const newState = { 
+          ...prev, 
+          currentMeasure: timeState.currentMeasure,
+          currentBeat: timeState.currentBeat
+        };
+        onGameStateChange(newState);
+        return newState;
+      });
+    }
+  }, [gameState, onGameStateChange, onChordIncorrect, handleEnemyAttack, displayOpts, stageMonsterIds]);
+
+  // リズムモードのタイミング監視
+  useEffect(() => {
+    if (gameState.isRhythmMode && gameState.rhythmPattern === 'progression' && gameState.isGameActive) {
+      // 高頻度でタイミングをチェック
+      const timer = setInterval(() => {
+        handleRhythmProgression();
+      }, 10); // 10msごとにチェック
+      
+      rhythmTimerRef.current = timer;
+      
+      return () => {
+        if (rhythmTimerRef.current) {
+          clearInterval(rhythmTimerRef.current);
+          rhythmTimerRef.current = null;
+        }
+      };
+    }
+  }, [gameState.isRhythmMode, gameState.rhythmPattern, gameState.isGameActive, handleRhythmProgression]);
+
   // 敵ゲージの更新（マルチモンスター対応）
   const updateEnemyGauge = useCallback(() => {
     /* Ready 中はゲージ停止 */
     const timeState = useTimeStore.getState();
     if (timeState.startAt &&
         performance.now() - timeState.startAt < timeState.readyDuration) {
+      return;
+    }
+    
+    // リズムモードのプログレッションパターンでは敵ゲージを使用しない
+    if (gameState.isRhythmMode && gameState.rhythmPattern === 'progression') {
       return;
     }
     
@@ -818,6 +1031,25 @@ export const useFantasyGameEngine = ({
         return prevState;
       }
 
+      // リズムモードのプログレッションパターンでの追加チェック
+      if (prevState.isRhythmMode && prevState.rhythmPattern === 'progression') {
+        // NULL期間中は入力を受け付けない
+        if (prevState.isInNullPeriod) {
+          devLog.debug('🚫 NULL期間中のため入力無効');
+          return prevState;
+        }
+        
+        // 判定受付期間外は入力を受け付けない
+        const timeState = useTimeStore.getState();
+        const currentBeatDecimal = timeState.getCurrentBeatDecimal();
+        const timeSignature = timeState.timeSignature;
+        
+        if (!isWithinJudgmentWindow(currentBeatDecimal, timeSignature)) {
+          devLog.debug('🚫 判定受付期間外のため入力無効', { currentBeatDecimal });
+          return prevState;
+        }
+      }
+
       devLog.debug('🎹 ノート入力受信 (in updater):', { note, noteMod12: note % 12 });
 
       const noteMod12 = note % 12;
@@ -826,6 +1058,9 @@ export const useFantasyGameEngine = ({
 
       // 1. 今回の入力でどのモンスターが影響を受けるか判定し、新しい状態を作る
       const monstersAfterInput = prevState.activeMonsters.map(monster => {
+        // NULLコードのモンスターはスキップ
+        if (!monster.chordTarget) return monster;
+        
         const targetNotes = [...new Set(monster.chordTarget.notes.map(n => n % 12))];
         
         // 既に完成しているモンスターや、入力音と関係ないモンスターはスキップ
@@ -854,6 +1089,59 @@ export const useFantasyGameEngine = ({
       if (completedMonsters.length > 0) {
         devLog.debug(`🎯 ${completedMonsters.length}体のコードが完成しました！`, { ids: completedMonsters.map(m => m.id) });
 
+        // リズムモードのプログレッションパターンの場合
+        if (prevState.isRhythmMode && prevState.rhythmPattern === 'progression') {
+          // 全てのモンスターが完成したかチェック
+          const allCompleted = monstersAfterInput.every(m => {
+            if (!m.chordTarget) return true; // NULLコードはスキップ
+            const targetNotes = [...new Set(m.chordTarget.notes.map(n => n % 12))];
+            return m.correctNotes.length === targetNotes.length;
+          });
+          
+          if (allCompleted) {
+            // 全モンスター完成 - NULL期間に入る
+            devLog.debug('✨ リズムモード: 全モンスター完成、NULL期間へ');
+            
+            // 攻撃処理
+            let stateAfterAttack = { ...prevState, activeMonsters: monstersAfterInput };
+            const isSpecialAttack = stateAfterAttack.playerSp >= 5;
+            
+            completedMonsters.forEach(completed => {
+              const monsterToUpdate = stateAfterAttack.activeMonsters.find(m => m.id === completed.id);
+              if (!monsterToUpdate) return;
+
+              const currentStage = stateAfterAttack.currentStage!;
+              const damageDealt = (Math.floor(Math.random() * (currentStage.maxDamage - currentStage.minDamage + 1)) + currentStage.minDamage) * (isSpecialAttack ? 2 : 1);
+              const willBeDefeated = (monsterToUpdate.currentHp - damageDealt) <= 0;
+              
+              onChordCorrect(completed.chordTarget, isSpecialAttack, damageDealt, willBeDefeated, completed.id);
+              monsterToUpdate.currentHp -= damageDealt;
+            });
+            
+            // 状態を更新
+            stateAfterAttack.hasCompletedChordInMeasure = true;
+            stateAfterAttack.playerSp = isSpecialAttack ? 0 : Math.min(stateAfterAttack.playerSp + completedMonsters.length, 5);
+            stateAfterAttack.score += 1000 * completedMonsters.length;
+            stateAfterAttack.correctAnswers += completedMonsters.length;
+            
+            // 倒されたモンスターを除外
+            const defeatedCount = stateAfterAttack.activeMonsters.filter(m => m.currentHp <= 0).length;
+            stateAfterAttack.enemiesDefeated += defeatedCount;
+            stateAfterAttack.activeMonsters = stateAfterAttack.activeMonsters.filter(m => m.currentHp > 0);
+            
+            // ゲームクリア判定
+            if (stateAfterAttack.enemiesDefeated >= stateAfterAttack.totalEnemies) {
+              const finalState = { ...stateAfterAttack, isGameActive: false, isGameOver: true, gameResult: 'clear' as const };
+              onGameComplete('clear', finalState);
+              return finalState;
+            }
+            
+            onGameStateChange(stateAfterAttack);
+            return stateAfterAttack;
+          }
+        }
+
+        // 通常のファンタジーモード（シングルパターン）の処理
         // ★ 攻撃処理後の状態を計算する
         let stateAfterAttack = { ...prevState, activeMonsters: monstersAfterInput };
         
@@ -1029,6 +1317,17 @@ export const useFantasyGameEngine = ({
       setEnemyGaugeTimer(null);
     }
     
+    // リズムモードのタイマーをクリーンアップ
+    if (rhythmTimerRef.current) {
+      clearInterval(rhythmTimerRef.current);
+      rhythmTimerRef.current = null;
+    }
+    
+    if (nextQuestionTimerRef.current) {
+      clearTimeout(nextQuestionTimerRef.current);
+      nextQuestionTimerRef.current = null;
+    }
+    
     // if (inputTimeout) { // 削除
     //   clearTimeout(inputTimeout); // 削除
     // } // 削除
@@ -1049,6 +1348,15 @@ export const useFantasyGameEngine = ({
       if (enemyGaugeTimer) {
         devLog.debug('⏰ 敵ゲージタイマー クリーンアップで停止');
         clearInterval(enemyGaugeTimer);
+      }
+      // リズムモードのタイマーもクリーンアップ
+      if (rhythmTimerRef.current) {
+        devLog.debug('⏰ リズムタイマー クリーンアップで停止');
+        clearInterval(rhythmTimerRef.current);
+      }
+      if (nextQuestionTimerRef.current) {
+        devLog.debug('⏰ 次問題タイマー クリーンアップで停止');
+        clearTimeout(nextQuestionTimerRef.current);
       }
       // if (inputTimeout) { // 削除
       //   devLog.debug('⏰ 入力タイムアウト クリーンアップで停止'); // 削除

--- a/src/components/fantasy/__tests__/FantasyGameEngine.rhythm.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyGameEngine.rhythm.test.tsx
@@ -19,7 +19,7 @@ describe('FantasyGameEngine - Rhythm Mode Progression Pattern', () => {
     enemyHp: 2,
     minDamage: 1,
     maxDamage: 2,
-    mode: 'progression',
+    mode: 'rhythm',  // リズムモードを指定
     allowedChords: ['C', 'F', 'G', 'C'],
     chordProgression: ['C', 'F', 'G', 'C'],
     showSheetMusic: false,
@@ -29,9 +29,7 @@ describe('FantasyGameEngine - Rhythm Mode Progression Pattern', () => {
     bpm: 120,
     measureCount: 4,
     countInMeasures: 0,
-    timeSignature: 4,
-    gameType: 'rhythm',
-    rhythmPattern: 'progression'
+    timeSignature: 4
   };
 
   const mockCallbacks = {
@@ -69,7 +67,7 @@ describe('FantasyGameEngine - Rhythm Mode Progression Pattern', () => {
     (useTimeStore as any).getState = vi.fn(() => mockTimeState);
   });
 
-  it('should initialize rhythm mode with empty monsters for progression pattern', async () => {
+  it('should initialize rhythm mode with empty monsters', async () => {
     const { result } = renderHook(() => useFantasyGameEngine({
       stage: null,
       ...mockCallbacks
@@ -80,7 +78,6 @@ describe('FantasyGameEngine - Rhythm Mode Progression Pattern', () => {
     });
 
     expect(result.current.gameState.isRhythmMode).toBe(true);
-    expect(result.current.gameState.rhythmPattern).toBe('progression');
     expect(result.current.gameState.activeMonsters).toHaveLength(0); // No initial monsters
     expect(result.current.gameState.hasCompletedChordInMeasure).toBe(false);
     expect(result.current.gameState.isInNullPeriod).toBe(false);

--- a/src/components/fantasy/__tests__/FantasyGameEngine.rhythm.test.tsx
+++ b/src/components/fantasy/__tests__/FantasyGameEngine.rhythm.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFantasyGameEngine } from '../FantasyGameEngine';
+import { useTimeStore } from '@/stores/timeStore';
+import type { FantasyStage, ChordDefinition, FantasyGameState } from '../FantasyGameEngine';
+
+// Mock the time store
+vi.mock('@/stores/timeStore');
+
+describe('FantasyGameEngine - Rhythm Mode Progression Pattern', () => {
+  const mockStage: FantasyStage = {
+    id: 'test-rhythm',
+    stageNumber: '1',
+    name: 'Test Rhythm Stage',
+    description: 'Testing rhythm mode',
+    maxHp: 3,
+    enemyGaugeSeconds: 10,
+    enemyCount: 4,
+    enemyHp: 2,
+    minDamage: 1,
+    maxDamage: 2,
+    mode: 'progression',
+    allowedChords: ['C', 'F', 'G', 'C'],
+    chordProgression: ['C', 'F', 'G', 'C'],
+    showSheetMusic: false,
+    showGuide: true,
+    monsterIcon: 'test',
+    simultaneousMonsterCount: 4,
+    bpm: 120,
+    measureCount: 4,
+    countInMeasures: 0,
+    timeSignature: 4,
+    gameType: 'rhythm',
+    rhythmPattern: 'progression'
+  };
+
+  const mockCallbacks = {
+    onGameStateChange: vi.fn(),
+    onChordCorrect: vi.fn(),
+    onChordIncorrect: vi.fn(),
+    onGameComplete: vi.fn(),
+    onEnemyAttack: vi.fn()
+  };
+
+  let mockTimeState: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Set up mock time store
+    mockTimeState = {
+      startAt: performance.now(),
+      readyDuration: 2000,
+      timeSignature: 4,
+      bpm: 120,
+      measureCount: 4,
+      countInMeasures: 0,
+      currentBeat: 1,
+      currentMeasure: 1,
+      isCountIn: false,
+      currentBeatDecimal: 1.0,
+      setStart: vi.fn(),
+      tick: vi.fn(),
+      getCurrentBeatDecimal: vi.fn(() => mockTimeState.currentBeatDecimal),
+      getTimeUntilBeat: vi.fn(),
+      getTimeUntilNextMeasureBeat: vi.fn()
+    };
+
+    (useTimeStore as any).getState = vi.fn(() => mockTimeState);
+  });
+
+  it('should initialize rhythm mode with empty monsters for progression pattern', async () => {
+    const { result } = renderHook(() => useFantasyGameEngine({
+      stage: null,
+      ...mockCallbacks
+    }));
+
+    await act(async () => {
+      await result.current.initializeGame(mockStage);
+    });
+
+    expect(result.current.gameState.isRhythmMode).toBe(true);
+    expect(result.current.gameState.rhythmPattern).toBe('progression');
+    expect(result.current.gameState.activeMonsters).toHaveLength(0); // No initial monsters
+    expect(result.current.gameState.hasCompletedChordInMeasure).toBe(false);
+    expect(result.current.gameState.isInNullPeriod).toBe(false);
+  });
+
+  it('should not accept input during NULL period', async () => {
+    const { result } = renderHook(() => useFantasyGameEngine({
+      stage: null,
+      ...mockCallbacks
+    }));
+
+    await act(async () => {
+      await result.current.initializeGame(mockStage);
+    });
+
+    // Manually set NULL period
+    act(() => {
+      result.current.gameState.isInNullPeriod = true;
+      result.current.handleNoteInput(60); // C4
+    });
+
+    // No chord correct callback should be called
+    expect(mockCallbacks.onChordCorrect).not.toHaveBeenCalled();
+  });
+
+  it('should not accept input outside judgment window', async () => {
+    const { result } = renderHook(() => useFantasyGameEngine({
+      stage: null,
+      ...mockCallbacks
+    }));
+
+    await act(async () => {
+      await result.current.initializeGame(mockStage);
+    });
+
+    // Set beat to 4.51 (after judgment cutoff at 4.49)
+    mockTimeState.currentBeatDecimal = 4.51;
+
+    act(() => {
+      result.current.handleNoteInput(60); // C4
+    });
+
+    // No chord correct callback should be called
+    expect(mockCallbacks.onChordCorrect).not.toHaveBeenCalled();
+  });
+
+  it('should enter NULL period after completing all chords', async () => {
+    const { result } = renderHook(() => useFantasyGameEngine({
+      stage: null,
+      ...mockCallbacks
+    }));
+
+    await act(async () => {
+      await result.current.initializeGame(mockStage);
+    });
+
+    // Simulate having active monsters with chords
+    const mockMonsters = [
+      {
+        id: 'monster1',
+        index: 0,
+        position: 'A' as const,
+        currentHp: 2,
+        maxHp: 2,
+        gauge: 0,
+        chordTarget: {
+          id: 'C',
+          displayName: 'C',
+          notes: [60], // Simple C chord for testing
+          noteNames: ['C'],
+          quality: 'major',
+          root: 'C'
+        },
+        correctNotes: [],
+        icon: 'test',
+        name: 'Test Monster'
+      }
+    ];
+
+    // Manually set monsters (in real scenario this happens at beat 4.50)
+    act(() => {
+      result.current.gameState.activeMonsters = mockMonsters;
+      result.current.gameState.isGameActive = true;
+    });
+
+    // Input the correct note
+    mockTimeState.currentBeatDecimal = 2.0; // Within judgment window
+
+    act(() => {
+      result.current.handleNoteInput(60); // C
+    });
+
+    // Should have marked chord as completed
+    expect(result.current.gameState.hasCompletedChordInMeasure).toBe(true);
+  });
+
+  it('should handle automatic progression on judgment timeout', () => {
+    // This would require more complex mocking of the timing system
+    // and interval callbacks, which is beyond the scope of this test
+    // but the logic is implemented in handleRhythmProgression
+    expect(true).toBe(true); // Placeholder
+  });
+
+  it('should respect different time signatures', async () => {
+    const stage3_4 = { ...mockStage, timeSignature: 3 };
+    
+    const { result } = renderHook(() => useFantasyGameEngine({
+      stage: null,
+      ...mockCallbacks
+    }));
+
+    await act(async () => {
+      await result.current.initializeGame(stage3_4);
+    });
+
+    // Time store should be initialized with 3/4 time
+    expect(mockTimeState.setStart).toHaveBeenCalledWith(120, 3, 4, 0);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -635,7 +635,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: 'single' | 'progression' | 'rhythm';  // rhythmを追加
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;

--- a/src/utils/__tests__/rhythm-timing.test.ts
+++ b/src/utils/__tests__/rhythm-timing.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RHYTHM_TIMING,
+  getQuestionAppearanceBeat,
+  getJudgmentCutoffBeat,
+  isWithinJudgmentWindow,
+  getTimeUntilNextQuestion,
+  getRhythmTimingState
+} from '../rhythm-timing';
+
+describe('rhythm-timing utilities', () => {
+  describe('getQuestionAppearanceBeat', () => {
+    it('should return correct beat for 4/4 time signature', () => {
+      expect(getQuestionAppearanceBeat(4)).toBe(4.5);
+    });
+
+    it('should return correct beat for 3/4 time signature', () => {
+      expect(getQuestionAppearanceBeat(3)).toBe(3.5);
+    });
+  });
+
+  describe('getJudgmentCutoffBeat', () => {
+    it('should return correct cutoff beat for 4/4 time signature', () => {
+      expect(getJudgmentCutoffBeat(4)).toBe(4.49);
+    });
+
+    it('should return correct cutoff beat for 3/4 time signature', () => {
+      expect(getJudgmentCutoffBeat(3)).toBe(3.49);
+    });
+  });
+
+  describe('isWithinJudgmentWindow', () => {
+    it('should return true when within judgment window (4/4)', () => {
+      expect(isWithinJudgmentWindow(1.0, 4)).toBe(true);
+      expect(isWithinJudgmentWindow(2.5, 4)).toBe(true);
+      expect(isWithinJudgmentWindow(4.0, 4)).toBe(true);
+      expect(isWithinJudgmentWindow(4.49, 4)).toBe(true);
+    });
+
+    it('should return false when outside judgment window (4/4)', () => {
+      expect(isWithinJudgmentWindow(4.5, 4)).toBe(false);
+      expect(isWithinJudgmentWindow(4.99, 4)).toBe(false);
+    });
+
+    it('should handle beat wrapping correctly', () => {
+      // Beat 5.0 should wrap to 1.0
+      expect(isWithinJudgmentWindow(5.0, 4)).toBe(true);
+      // Beat 8.49 should wrap to 4.49
+      expect(isWithinJudgmentWindow(8.49, 4)).toBe(true);
+      // Beat 8.5 should wrap to 4.5 (outside window)
+      expect(isWithinJudgmentWindow(8.5, 4)).toBe(false);
+    });
+  });
+
+  describe('getTimeUntilNextQuestion', () => {
+    const bpm120 = 120; // 500ms per beat
+    const bpm60 = 60;   // 1000ms per beat
+
+    it('should calculate time within same measure (BPM 120)', () => {
+      // At beat 1.0, next question at 4.5 = 3.5 beats away
+      expect(getTimeUntilNextQuestion(1.0, 4, bpm120)).toBe(3.5 * 500);
+      
+      // At beat 3.0, next question at 4.5 = 1.5 beats away
+      expect(getTimeUntilNextQuestion(3.0, 4, bpm120)).toBe(1.5 * 500);
+    });
+
+    it('should calculate time to next measure (BPM 120)', () => {
+      // At beat 4.6, already past 4.5, so next measure's 4.5
+      // = (4 - 4.6) + 4.5 = 3.9 beats away
+      expect(getTimeUntilNextQuestion(4.6, 4, bpm120)).toBeCloseTo(3.9 * 500);
+    });
+
+    it('should work with different BPM (BPM 60)', () => {
+      // At beat 2.0, next question at 4.5 = 2.5 beats away
+      expect(getTimeUntilNextQuestion(2.0, 4, bpm60)).toBe(2.5 * 1000);
+    });
+
+    it('should work with 3/4 time signature', () => {
+      // At beat 1.0, next question at 3.5 = 2.5 beats away
+      expect(getTimeUntilNextQuestion(1.0, 3, bpm120)).toBe(2.5 * 500);
+      
+      // At beat 3.6, next measure's 3.5 = (3 - 3.6) + 3.5 = 2.9 beats
+      expect(getTimeUntilNextQuestion(3.6, 3, bpm120)).toBeCloseTo(2.9 * 500);
+    });
+  });
+
+  describe('getRhythmTimingState', () => {
+    const bpm120 = 120;
+
+    it('should return judgment phase when in normal play', () => {
+      const state = getRhythmTimingState(2.0, 4, bpm120, false);
+      expect(state.currentPhase).toBe('judgment');
+      expect(state.isQuestionActive).toBe(true);
+      expect(state.isJudgmentActive).toBe(true);
+      expect(state.isInNullPeriod).toBe(false);
+    });
+
+    it('should return null phase when chord is completed', () => {
+      const state = getRhythmTimingState(3.0, 4, bpm120, true);
+      expect(state.currentPhase).toBe('null');
+      expect(state.isQuestionActive).toBe(false);
+      expect(state.isJudgmentActive).toBe(false);
+      expect(state.isInNullPeriod).toBe(true);
+    });
+
+    it('should return transition phase after judgment cutoff', () => {
+      const state = getRhythmTimingState(4.495, 4, bpm120, false);
+      expect(state.currentPhase).toBe('transition');
+      expect(state.isQuestionActive).toBe(true);
+      expect(state.isJudgmentActive).toBe(false);
+    });
+
+    it('should return transition phase after question appearance', () => {
+      const state = getRhythmTimingState(4.55, 4, bpm120, false);
+      expect(state.currentPhase).toBe('transition');
+      expect(state.isQuestionActive).toBe(false);
+      expect(state.isJudgmentActive).toBe(false);
+    });
+
+    it('should calculate correct time until next question', () => {
+      const state = getRhythmTimingState(1.0, 4, bpm120, false);
+      // From beat 1.0 to 4.5 = 3.5 beats = 1750ms at 120 BPM
+      expect(state.timeUntilNextQuestion).toBe(1750);
+    });
+  });
+});

--- a/src/utils/rhythm-timing.ts
+++ b/src/utils/rhythm-timing.ts
@@ -1,0 +1,151 @@
+/**
+ * リズムモード - プログレッションパターンのタイミング定数と関数
+ */
+
+// タイミング定数
+export const RHYTHM_TIMING = {
+  // 出題タイミング: 4拍子の場合、4拍目のウラ (4.50)
+  QUESTION_APPEARANCE_OFFSET: 0.50,
+  
+  // 判定受付終了タイミング: 4拍子の場合、4拍目のウラの直前 (4.49)
+  JUDGMENT_CUTOFF_OFFSET: 0.49,
+  
+  // 判定許容範囲 (ms)
+  JUDGMENT_TOLERANCE_MS: 200,
+} as const;
+
+/**
+ * 指定された拍子における出題タイミングを計算
+ * @param timeSignature 拍子 (例: 4 = 4/4拍子)
+ * @returns 出題タイミングの拍位置 (例: 4.50)
+ */
+export function getQuestionAppearanceBeat(timeSignature: number): number {
+  return timeSignature + RHYTHM_TIMING.QUESTION_APPEARANCE_OFFSET;
+}
+
+/**
+ * 指定された拍子における判定受付終了タイミングを計算
+ * @param timeSignature 拍子 (例: 4 = 4/4拍子)
+ * @returns 判定終了タイミングの拍位置 (例: 4.49)
+ */
+export function getJudgmentCutoffBeat(timeSignature: number): number {
+  return timeSignature + RHYTHM_TIMING.JUDGMENT_CUTOFF_OFFSET;
+}
+
+/**
+ * 現在の拍位置が判定受付期間内かどうかを判定
+ * @param currentBeatDecimal 現在の拍位置 (小数点付き)
+ * @param timeSignature 拍子
+ * @returns 判定受付期間内ならtrue
+ */
+export function isWithinJudgmentWindow(
+  currentBeatDecimal: number,
+  timeSignature: number
+): boolean {
+  const cutoffBeat = getJudgmentCutoffBeat(timeSignature);
+  
+  // 現在の小節内での位置を正規化 (1.0 - timeSignature.99)
+  const normalizedBeat = ((currentBeatDecimal - 1) % timeSignature) + 1;
+  
+  // 判定受付は1拍目から判定終了タイミングまで
+  return normalizedBeat >= 1.0 && normalizedBeat <= cutoffBeat;
+}
+
+/**
+ * 次の出題タイミングまでの時間を計算
+ * @param currentBeatDecimal 現在の拍位置
+ * @param timeSignature 拍子
+ * @param bpm BPM
+ * @returns 次の出題タイミングまでのミリ秒数
+ */
+export function getTimeUntilNextQuestion(
+  currentBeatDecimal: number,
+  timeSignature: number,
+  bpm: number
+): number {
+  const questionBeat = getQuestionAppearanceBeat(timeSignature);
+  const normalizedBeat = ((currentBeatDecimal - 1) % timeSignature) + 1;
+  
+  let beatsUntilQuestion: number;
+  if (normalizedBeat <= questionBeat) {
+    // 今の小節内で出題タイミングがある
+    beatsUntilQuestion = questionBeat - normalizedBeat;
+  } else {
+    // 次の小節の出題タイミングまで
+    beatsUntilQuestion = (timeSignature - normalizedBeat) + questionBeat;
+  }
+  
+  const msPerBeat = 60000 / bpm;
+  return beatsUntilQuestion * msPerBeat;
+}
+
+/**
+ * リズムモードのタイミング状態
+ */
+export interface RhythmTimingState {
+  isQuestionActive: boolean;      // 問題が出題されているか
+  isJudgmentActive: boolean;      // 判定受付中か
+  isInNullPeriod: boolean;        // NULL期間中か
+  timeUntilNextQuestion: number;  // 次の出題までの時間 (ms)
+  currentPhase: 'waiting' | 'judgment' | 'null' | 'transition';
+}
+
+/**
+ * 現在のリズムタイミング状態を取得
+ * @param currentBeatDecimal 現在の拍位置
+ * @param timeSignature 拍子
+ * @param bpm BPM
+ * @param hasCompletedChord 現在のコードが完成しているか
+ * @returns リズムタイミング状態
+ */
+export function getRhythmTimingState(
+  currentBeatDecimal: number,
+  timeSignature: number,
+  bpm: number,
+  hasCompletedChord: boolean
+): RhythmTimingState {
+  const normalizedBeat = ((currentBeatDecimal - 1) % timeSignature) + 1;
+  const questionBeat = getQuestionAppearanceBeat(timeSignature);
+  const cutoffBeat = getJudgmentCutoffBeat(timeSignature);
+  
+  let currentPhase: 'waiting' | 'judgment' | 'null' | 'transition';
+  let isQuestionActive = false;
+  let isJudgmentActive = false;
+  let isInNullPeriod = false;
+  
+  if (normalizedBeat < 1.0) {
+    // 小節の開始前（通常はありえない）
+    currentPhase = 'waiting';
+  } else if (normalizedBeat >= questionBeat) {
+    // 出題タイミング以降 = 次の小節を待っている
+    currentPhase = 'transition';
+    isQuestionActive = false;
+    isJudgmentActive = false;
+  } else if (normalizedBeat >= cutoffBeat) {
+    // 判定終了後、出題タイミングまでの僅かな時間
+    currentPhase = 'transition';
+    isQuestionActive = true;
+    isJudgmentActive = false;
+  } else if (hasCompletedChord) {
+    // コード完成後のNULL期間
+    currentPhase = 'null';
+    isQuestionActive = false;
+    isJudgmentActive = false;
+    isInNullPeriod = true;
+  } else {
+    // 判定受付中
+    currentPhase = 'judgment';
+    isQuestionActive = true;
+    isJudgmentActive = true;
+  }
+  
+  const timeUntilNextQuestion = getTimeUntilNextQuestion(currentBeatDecimal, timeSignature, bpm);
+  
+  return {
+    isQuestionActive,
+    isJudgmentActive,
+    isInNullPeriod,
+    timeUntilNextQuestion,
+    currentPhase
+  };
+}

--- a/supabase/migrations/20250803000000_add_rhythm_mode_to_fantasy_stages.sql
+++ b/supabase/migrations/20250803000000_add_rhythm_mode_to_fantasy_stages.sql
@@ -1,0 +1,12 @@
+-- リズムモードをfantasy_stagesのmodeに追加
+-- 説明: fantasy_stagesテーブルのmode列に'rhythm'を追加し、プログレッションパターンのタイミング機能を有効にする
+
+-- 既存の制約を削除
+ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
+
+-- 新しい制約を追加（'rhythm'を含む）
+ALTER TABLE fantasy_stages ADD CONSTRAINT fantasy_stages_mode_check 
+  CHECK (mode = ANY (ARRAY['single'::text, 'progression'::text, 'rhythm'::text]));
+
+-- コメントを更新
+COMMENT ON COLUMN fantasy_stages.mode IS 'single: 単一コードモード, progression: コード進行モード, rhythm: リズムモード（タイミング判定あり）';


### PR DESCRIPTION
Extend Fantasy Mode progression pattern to support precise beat-based question appearance, judgment, and automatic progression.

This PR introduces a dedicated rhythm timing system, including a precise beat tracker in `timeStore`, rhythm utility functions, and a new `handleRhythmProgression` loop in `FantasyGameEngine`. This ensures that questions appear exactly on the 4.50 beat, judgment closes at 4.49, and the game progresses automatically on failure or enters a NULL period on success, all without affecting existing single-player modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0ae2b6a-79c6-4a56-bb9e-b4f65f1f7402">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0ae2b6a-79c6-4a56-bb9e-b4f65f1f7402">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>