### PR TITLE
Taiko no tatsujin progression mode extension

### DIFF
--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -1,0 +1,210 @@
+/**
+ * 太鼓の達人風ノーツシステム
+ * コード進行モードでのノーツ管理とタイミング判定
+ */
+
+import { ChordDefinition } from './FantasyGameEngine';
+
+// ノーツの型定義
+export interface TaikoNote {
+  id: string;
+  chord: ChordDefinition;
+  hitTime: number; // ヒットすべきタイミング（音楽時間、秒）
+  measure: number; // 小節番号（1始まり）
+  beat: number; // 拍番号（1始まり、小数可）
+  isHit: boolean; // 既にヒットされたか
+  isMissed: boolean; // ミスしたか
+}
+
+// chord_progression_data のJSON形式
+export interface ChordProgressionDataItem {
+  bar: number; // 小節番号（1始まり）
+  beats: number; // 拍番号（1始まり、小数可）
+  chord: string; // コード名
+}
+
+// タイミング判定の結果
+export interface TimingJudgment {
+  isHit: boolean;
+  timing: 'early' | 'perfect' | 'late' | 'miss';
+  timingDiff: number; // ミリ秒単位の差
+}
+
+/**
+ * タイミング判定を行う
+ * @param currentTime 現在の音楽時間（秒）
+ * @param targetTime ターゲットの音楽時間（秒）
+ * @param windowMs 判定ウィンドウ（ミリ秒）
+ */
+export function judgeTimingWindow(
+  currentTime: number,
+  targetTime: number,
+  windowMs: number = 300
+): TimingJudgment {
+  const diffMs = (currentTime - targetTime) * 1000;
+  
+  if (Math.abs(diffMs) > windowMs) {
+    return {
+      isHit: false,
+      timing: 'miss',
+      timingDiff: diffMs
+    };
+  }
+  
+  // 判定ウィンドウ内
+  let timing: 'early' | 'perfect' | 'late';
+  if (Math.abs(diffMs) <= 50) {
+    timing = 'perfect';
+  } else if (diffMs < 0) {
+    timing = 'early';
+  } else {
+    timing = 'late';
+  }
+  
+  return {
+    isHit: true,
+    timing,
+    timingDiff: diffMs
+  };
+}
+
+/**
+ * 基本版progression用：小節の頭(Beat 1)でコードを配置
+ * @param chordProgression コード進行配列
+ * @param measureCount 総小節数
+ * @param bpm BPM
+ * @param timeSignature 拍子
+ */
+export function generateBasicProgressionNotes(
+  chordProgression: string[],
+  measureCount: number,
+  bpm: number,
+  timeSignature: number,
+  getChordDefinition: (chordId: string) => ChordDefinition | null
+): TaikoNote[] {
+  const notes: TaikoNote[] = [];
+  const secPerBeat = 60 / bpm;
+  const secPerMeasure = secPerBeat * timeSignature;
+  
+  for (let measure = 1; measure <= measureCount; measure++) {
+    const chordIndex = (measure - 1) % chordProgression.length;
+    const chordId = chordProgression[chordIndex];
+    const chord = getChordDefinition(chordId);
+    
+    if (chord) {
+      const hitTime = (measure - 1) * secPerMeasure + 0; // 小節の頭（Beat 1 = 0秒目）
+      
+      notes.push({
+        id: `note_${measure}_1`,
+        chord,
+        hitTime,
+        measure,
+        beat: 1,
+        isHit: false,
+        isMissed: false
+      });
+    }
+  }
+  
+  return notes;
+}
+
+/**
+ * 拡張版progression用：chord_progression_dataのJSONを解析
+ * @param progressionData JSON配列
+ * @param bpm BPM
+ * @param timeSignature 拍子
+ */
+export function parseChordProgressionData(
+  progressionData: ChordProgressionDataItem[],
+  bpm: number,
+  timeSignature: number,
+  getChordDefinition: (chordId: string) => ChordDefinition | null
+): TaikoNote[] {
+  const notes: TaikoNote[] = [];
+  const secPerBeat = 60 / bpm;
+  const secPerMeasure = secPerBeat * timeSignature;
+  
+  progressionData.forEach((item, index) => {
+    const chord = getChordDefinition(item.chord);
+    if (chord) {
+      // bar（小節）とbeats（拍）から実際の時刻を計算
+      const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
+      
+      notes.push({
+        id: `note_${item.bar}_${item.beats}_${index}`,
+        chord,
+        hitTime,
+        measure: item.bar,
+        beat: item.beats,
+        isHit: false,
+        isMissed: false
+      });
+    }
+  });
+  
+  // 時間順にソート
+  notes.sort((a, b) => a.hitTime - b.hitTime);
+  
+  return notes;
+}
+
+/**
+ * 現在の時間で表示すべきノーツを取得
+ * @param notes 全ノーツ
+ * @param currentTime 現在の音楽時間（秒）
+ * @param lookAheadTime 先読み時間（秒）デフォルト3秒
+ */
+export function getVisibleNotes(
+  notes: TaikoNote[],
+  currentTime: number,
+  lookAheadTime: number = 3
+): TaikoNote[] {
+  return notes.filter(note => {
+    // 既にヒットまたはミスしたノーツは表示しない
+    if (note.isHit || note.isMissed) return false;
+    
+    // 現在時刻から lookAheadTime 秒先までのノーツを表示
+    const timeUntilHit = note.hitTime - currentTime;
+    return timeUntilHit >= -0.5 && timeUntilHit <= lookAheadTime;
+  });
+}
+
+/**
+ * ノーツの画面上のX位置を計算（太鼓の達人風）
+ * @param note ノーツ
+ * @param currentTime 現在の音楽時間（秒）
+ * @param judgeLineX 判定ラインのX座標
+ * @param speed ノーツの移動速度（ピクセル/秒）
+ */
+export function calculateNotePosition(
+  note: TaikoNote,
+  currentTime: number,
+  judgeLineX: number,
+  speed: number = 300
+): number {
+  const timeUntilHit = note.hitTime - currentTime;
+  return judgeLineX + timeUntilHit * speed;
+}
+
+/**
+ * 拡張版用のサンプルJSON文字列をパース
+ * 簡易形式：各行が "bar X beats Y chord Z" の形式
+ */
+export function parseSimpleProgressionText(text: string): ChordProgressionDataItem[] {
+  const lines = text.trim().split('\n');
+  const result: ChordProgressionDataItem[] = [];
+  
+  for (const line of lines) {
+    const match = line.match(/bar\s+(\d+)\s+beats\s+([\d.]+)\s+chord\s+(\S+)/);
+    if (match) {
+      result.push({
+        bar: parseInt(match[1]),
+        beats: parseFloat(match[2]),
+        chord: match[3]
+      });
+    }
+  }
+  
+  return result;
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement Taiko no Tatsujin-style progression mode with new UI and rhythm-based mechanics.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces a new game mode that transforms the existing chord progression into a rhythm game experience. Key changes include:
- A new `TaikoNoteSystem` for generating and judging notes based on `chord_progression` or `chord_progression_data`.
- UI updates in `FantasyPIXIRenderer` to display a judgment line and moving circular notes with chord names.
- Enhanced `BGMManager` for precise music timing synchronization.
- Modified `FantasyGameEngine` to handle Taiko mode game state, input, and miss logic (±300ms judgment window).
- Hides traditional chord/guide displays under monsters when in Taiko mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-28ab6104-a638-41ca-841e-145f4a7e972f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28ab6104-a638-41ca-841e-145f4a7e972f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>