### PR TITLE
ファンタジーモードを太鼓の達人風UIに拡張

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@stripe/stripe-js": "^2.4.0",
         "@supabase/supabase-js": "^2.39.5",
+        "@types/uuid": "^10.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.2.6",
+        "gsap": "^3.13.0",
         "immer": "^10.1.1",
         "lucide-react": "^0.525.0",
         "marked": "^16.0.0",
@@ -31,6 +33,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tonal": "^6.4.2",
         "tone": "^14.7.77",
+        "uuid": "^11.1.0",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -50,7 +53,7 @@
         "supabase": "^2.30.4",
         "tailwindcss": "^3.4.0",
         "ts-prune": "^0.10.3",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.2",
         "vite": "^5.0.8"
       },
       "engines": {
@@ -2391,6 +2394,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@types/vexflow": {
       "version": "1.2.42",
@@ -5209,6 +5218,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -9302,9 +9317,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9446,6 +9461,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vexflow": {
       "version": "1.2.93",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@stripe/stripe-js": "^2.4.0",
     "@supabase/supabase-js": "^2.39.5",
+    "@types/uuid": "^10.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.6",
+    "gsap": "^3.13.0",
     "immer": "^10.1.1",
     "lucide-react": "^0.525.0",
     "marked": "^16.0.0",
@@ -46,6 +48,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tonal": "^6.4.2",
     "tone": "^14.7.77",
+    "uuid": "^11.1.0",
     "zustand": "^4.4.7"
   },
   "devDependencies": {
@@ -65,7 +68,7 @@
     "supabase": "^2.30.4",
     "tailwindcss": "^3.4.0",
     "ts-prune": "^0.10.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "^5.0.8"
   },
   "engines": {

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -46,6 +46,7 @@ interface FantasyStage {
   measureCount?: number;
   countInMeasures?: number;
   timeSignature?: number;
+  chordProgressionData?: any; // 拡張版太鼓の達人用のコード進行データ
 }
 
 interface MonsterState {
@@ -1077,4 +1078,4 @@ export const useFantasyGameEngine = ({
 };
 
 export type { ChordDefinition, FantasyStage, FantasyGameState, FantasyGameEngineProps, MonsterState };
-export { ENEMY_LIST, getCurrentEnemy };
+export { ENEMY_LIST, getCurrentEnemy, getChordDefinition };

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2034,7 +2034,19 @@ export class FantasyPIXIInstance {
   private isSpriteInvalid = (s: PIXI.DisplayObject | null | undefined) =>
     !s || (s as any).destroyed || !(s as any).transform;
 
+  /**
+   * 太鼓の達人モード用：monsterContainerを取得
+   */
+  getMonsterContainer(): PIXI.Container {
+    return this.monsterContainer;
+  }
 
+  /**
+   * 太鼓の達人モード用：ステージ幅を取得
+   */
+  getStageWidth(): number {
+    return this.app.screen.width;
+  }
 }
 
 // ===== Reactコンポーネント =====

--- a/src/components/fantasy/taiko/TaikoJudge.ts
+++ b/src/components/fantasy/taiko/TaikoJudge.ts
@@ -1,0 +1,149 @@
+/**
+ * TaikoJudge
+ * 太鼓の達人風の判定処理
+ */
+
+import type { TaikoNote, TaikoJudgeResult } from '@/types/taiko';
+import type { ChordDefinition } from '../FantasyGameEngine';
+import { checkChordMatch } from './checkChordMatch';
+import { devLog } from '@/utils/logger';
+
+interface InputBuffer {
+  notes: number[];
+  timestamp: number;
+}
+
+export class TaikoJudge {
+  private judgeWindowMs = 300; // ±300ms
+  private inputBuffer: InputBuffer = { notes: [], timestamp: 0 };
+  private processedNotes: Set<string> = new Set(); // 処理済みノーツID
+  private onJudgeCallback?: (result: TaikoJudgeResult) => void;
+  private onEnemyAttackCallback?: () => void;
+
+  /**
+   * 判定コールバックを設定
+   */
+  setOnJudge(callback: (result: TaikoJudgeResult) => void) {
+    this.onJudgeCallback = callback;
+  }
+
+  /**
+   * 敵攻撃コールバックを設定
+   */
+  setOnEnemyAttack(callback: () => void) {
+    this.onEnemyAttackCallback = callback;
+  }
+
+  /**
+   * 入力を受け取る
+   */
+  onInput(midiNote: number, timestamp: number) {
+    // 既存の入力に追加
+    this.inputBuffer.notes.push(midiNote);
+    this.inputBuffer.timestamp = timestamp;
+    
+    devLog.debug('TaikoJudge input:', {
+      note: midiNote,
+      totalNotes: this.inputBuffer.notes.length,
+      timestamp
+    });
+  }
+
+  /**
+   * 入力をクリア
+   */
+  clearInput() {
+    this.inputBuffer = { notes: [], timestamp: 0 };
+  }
+
+  /**
+   * 判定処理
+   */
+  judge(currentNotes: TaikoNote[], currentTimeMs: number, getChordDefinition: (id: string) => ChordDefinition | null) {
+    // 判定ウィンドウ内のノーツを処理
+    for (const note of currentNotes) {
+      // すでに処理済みの場合はスキップ
+      if (this.processedNotes.has(note.id)) {
+        continue;
+      }
+
+      const timeDiff = currentTimeMs - note.absTimeMs;
+      
+      // 判定ウィンドウ内かチェック（-300ms ~ +300ms）
+      if (Math.abs(timeDiff) <= this.judgeWindowMs) {
+        // コード定義を取得
+        const chordDef = getChordDefinition(note.chordId);
+        if (!chordDef) {
+          continue;
+        }
+
+        // 入力されたコードをチェック
+        if (this.inputBuffer.notes.length > 0 && checkChordMatch(this.inputBuffer.notes, chordDef)) {
+          // GOOD判定
+          this.processedNotes.add(note.id);
+          this.clearInput();
+          
+          const result: TaikoJudgeResult = {
+            type: 'good',
+            timestamp: currentTimeMs,
+            noteId: note.id
+          };
+          
+          this.onJudgeCallback?.(result);
+          
+          devLog.debug('TaikoJudge GOOD:', {
+            noteId: note.id,
+            chord: note.chordId,
+            timeDiff
+          });
+        }
+      }
+      // 判定ウィンドウを過ぎた場合（+300ms以上）
+      else if (timeDiff > this.judgeWindowMs) {
+        // まだ処理されていない場合はBAD判定
+        if (!this.processedNotes.has(note.id)) {
+          this.processedNotes.add(note.id);
+          
+          const result: TaikoJudgeResult = {
+            type: 'bad',
+            timestamp: currentTimeMs,
+            noteId: note.id
+          };
+          
+          this.onJudgeCallback?.(result);
+          
+          // 敵の攻撃を発生させる
+          this.onEnemyAttackCallback?.();
+          
+          devLog.debug('TaikoJudge BAD (timeout):', {
+            noteId: note.id,
+            chord: note.chordId,
+            timeDiff
+          });
+        }
+      }
+    }
+
+    // 古い入力を削除（300ms以上前の入力は無効）
+    if (this.inputBuffer.timestamp > 0 && currentTimeMs - this.inputBuffer.timestamp > this.judgeWindowMs) {
+      this.clearInput();
+    }
+  }
+
+  /**
+   * 処理済みノーツをクリア（ループ時など）
+   */
+  clearProcessedNotes() {
+    this.processedNotes.clear();
+  }
+
+  /**
+   * クリーンアップ
+   */
+  destroy() {
+    this.clearInput();
+    this.processedNotes.clear();
+    this.onJudgeCallback = undefined;
+    this.onEnemyAttackCallback = undefined;
+  }
+}

--- a/src/components/fantasy/taiko/TaikoNoteScheduler.ts
+++ b/src/components/fantasy/taiko/TaikoNoteScheduler.ts
@@ -1,0 +1,198 @@
+/**
+ * TaikoNoteScheduler
+ * コード進行情報を太鼓の達人風のノーツ列に変換
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { TaikoNote, TaikoSchedule, ChordProgressionData } from '@/types/taiko';
+import type { FantasyStage } from '../FantasyGameEngine';
+import { devLog } from '@/utils/logger';
+
+export class TaikoNoteScheduler {
+  private schedule: TaikoSchedule | null = null;
+
+  /**
+   * ステージ情報からノーツスケジュールを生成
+   */
+  generateSchedule(stage: FantasyStage): TaikoSchedule | null {
+    if (stage.mode !== 'progression') {
+      return null;
+    }
+
+    const bpm = stage.bpm || 120;
+    const timeSig = stage.timeSignature || 4;
+    const measureCount = stage.measureCount || 8;
+    const countIn = stage.countInMeasures || 0;
+    
+    const msPerBeat = (60 / bpm) * 1000;
+    const msPerMeasure = msPerBeat * timeSig;
+    const loopStartMs = countIn * msPerMeasure;
+    const loopEndMs = (countIn + measureCount) * msPerMeasure;
+
+    let notes: TaikoNote[] = [];
+
+    // 拡張版（chord_progression_dataがある場合）
+    if (stage.chordProgressionData) {
+      try {
+        const progressionData = this.parseProgressionData(stage.chordProgressionData);
+        notes = this.generateNotesFromData(progressionData, countIn, msPerBeat, timeSig);
+      } catch (error) {
+        devLog.error('Failed to parse chord_progression_data:', error);
+        // パースエラーの場合は基本版にフォールバック
+        if (stage.chordProgression) {
+          notes = this.generateNotesFromBasic(stage.chordProgression, measureCount, countIn, msPerBeat, timeSig);
+        }
+      }
+    }
+    // 基本版（chord_progressionのみの場合）
+    else if (stage.chordProgression) {
+      notes = this.generateNotesFromBasic(stage.chordProgression, measureCount, countIn, msPerBeat, timeSig);
+    }
+
+    if (notes.length === 0) {
+      return null;
+    }
+
+    this.schedule = {
+      notes,
+      measureCount,
+      bpm,
+      timeSig,
+      loopStartMs,
+      loopEndMs
+    };
+
+    return this.schedule;
+  }
+
+  /**
+   * 基本版：各小節の頭にコードを配置
+   */
+  private generateNotesFromBasic(
+    chordProgression: string[],
+    measureCount: number,
+    countIn: number,
+    msPerBeat: number,
+    timeSig: number
+  ): TaikoNote[] {
+    const notes: TaikoNote[] = [];
+    const msPerMeasure = msPerBeat * timeSig;
+
+    for (let measure = 0; measure < measureCount; measure++) {
+      const chordIndex = measure % chordProgression.length;
+      const chord = chordProgression[chordIndex];
+      const bar = countIn + measure + 1; // 1開始
+      const absTimeMs = (countIn + measure) * msPerMeasure;
+
+      notes.push({
+        id: uuidv4(),
+        bar,
+        beat: 1, // 小節の頭
+        absTimeMs,
+        chordId: chord,
+        displayName: chord
+      });
+    }
+
+    return notes;
+  }
+
+  /**
+   * 拡張版：chord_progression_dataから詳細なタイミングでノーツを生成
+   */
+  private generateNotesFromData(
+    progressionData: ChordProgressionData[],
+    countIn: number,
+    msPerBeat: number,
+    timeSig: number
+  ): TaikoNote[] {
+    const notes: TaikoNote[] = [];
+    const msPerMeasure = msPerBeat * timeSig;
+
+    for (const data of progressionData) {
+      // カウントイン後の小節として計算
+      const actualBar = countIn + data.bar;
+      const measureStartMs = (actualBar - 1) * msPerMeasure;
+      const beatOffsetMs = (data.beat - 1) * msPerBeat;
+      const absTimeMs = measureStartMs + beatOffsetMs;
+
+      notes.push({
+        id: uuidv4(),
+        bar: actualBar,
+        beat: data.beat,
+        absTimeMs,
+        chordId: data.chord,
+        displayName: data.chord
+      });
+    }
+
+    // 小節番号でソート
+    notes.sort((a, b) => a.absTimeMs - b.absTimeMs);
+
+    return notes;
+  }
+
+  /**
+   * chord_progression_dataのパース
+   * 簡易テキスト形式をサポート
+   * 例: "bar 1 beats 3 chord C\nbar 2 beats 1 chord F"
+   */
+  private parseProgressionData(data: any): ChordProgressionData[] {
+    // すでに配列形式の場合はそのまま返す
+    if (Array.isArray(data)) {
+      return data;
+    }
+
+    // 文字列形式の簡易パース
+    if (typeof data === 'string') {
+      const lines = data.trim().split('\n');
+      const result: ChordProgressionData[] = [];
+
+      for (const line of lines) {
+        const match = line.match(/bar\s+(\d+)\s+beats?\s+(\d+)\s+chord\s+(\S+)/i);
+        if (match) {
+          result.push({
+            bar: parseInt(match[1], 10),
+            beat: parseInt(match[2], 10),
+            chord: match[3]
+          });
+        }
+      }
+
+      return result;
+    }
+
+    // JSONオブジェクト形式
+    if (typeof data === 'object' && data.notes) {
+      return data.notes;
+    }
+
+    throw new Error('Invalid chord_progression_data format');
+  }
+
+  /**
+   * 現在のスケジュールを取得
+   */
+  getSchedule(): TaikoSchedule | null {
+    return this.schedule;
+  }
+
+  /**
+   * 特定時刻のノーツを取得
+   */
+  getNotesAt(currentTimeMs: number, windowMs: number = 300): TaikoNote[] {
+    if (!this.schedule) return [];
+
+    return this.schedule.notes.filter(note => {
+      const diff = Math.abs(note.absTimeMs - currentTimeMs);
+      return diff <= windowMs;
+    });
+  }
+
+  /**
+   * クリーンアップ
+   */
+  destroy() {
+    this.schedule = null;
+  }
+}

--- a/src/components/fantasy/taiko/TaikoRenderer.ts
+++ b/src/components/fantasy/taiko/TaikoRenderer.ts
@@ -1,0 +1,276 @@
+/**
+ * TaikoRenderer
+ * 太鼓の達人風UIのレンダリング
+ */
+
+import * as PIXI from 'pixi.js';
+import { gsap } from 'gsap';
+import type { TaikoNote } from '@/types/taiko';
+import { devLog } from '@/utils/logger';
+
+interface NoteSprite {
+  container: PIXI.Container;
+  circle: PIXI.Graphics;
+  text: PIXI.Text;
+  note: TaikoNote;
+  tween?: gsap.core.Tween;
+}
+
+export class TaikoRenderer {
+  private container: PIXI.Container;
+  private taikoLayer: PIXI.Container;
+  private judgeLine: PIXI.Graphics;
+  private notePool: NoteSprite[] = [];
+  private activeNotes: Map<string, NoteSprite> = new Map();
+  private judgeLineX = 80; // 判定ラインのX座標
+  private noteRadius = 40; // ノーツの半径
+  private noteSpeed = 400; // ピクセル/秒
+  private stageWidth = 800;
+  private startTimeMs: number = 0;
+
+  constructor(parentContainer: PIXI.Container, stageWidth: number) {
+    this.container = parentContainer;
+    this.stageWidth = stageWidth;
+    
+    // 太鼓レイヤーを作成（モンスターの手前に表示）
+    this.taikoLayer = new PIXI.Container();
+    this.taikoLayer.zIndex = 10; // モンスターより前
+    this.container.addChild(this.taikoLayer);
+
+    // 判定ラインを作成
+    this.judgeLine = this.createJudgeLine();
+    this.taikoLayer.addChild(this.judgeLine);
+  }
+
+  /**
+   * 判定ラインの作成
+   */
+  private createJudgeLine(): PIXI.Graphics {
+    const graphics = new PIXI.Graphics();
+    
+    // 外側の円（白）
+    graphics.beginFill(0xffffff, 0.8);
+    graphics.drawCircle(0, 0, this.noteRadius + 5);
+    graphics.endFill();
+    
+    // 内側の円（赤）
+    graphics.beginFill(0xff0000, 0.9);
+    graphics.drawCircle(0, 0, this.noteRadius);
+    graphics.endFill();
+    
+    // 中心の十字
+    graphics.lineStyle(3, 0xffffff);
+    graphics.moveTo(-20, 0);
+    graphics.lineTo(20, 0);
+    graphics.moveTo(0, -20);
+    graphics.lineTo(0, 20);
+    
+    graphics.position.set(this.judgeLineX, 300); // 画面中央の高さ
+    
+    return graphics;
+  }
+
+  /**
+   * ノーツスプライトの作成（オブジェクトプール用）
+   */
+  private createNoteSprite(): NoteSprite {
+    const container = new PIXI.Container();
+    
+    // ノーツの円
+    const circle = new PIXI.Graphics();
+    circle.beginFill(0x4169e1, 0.7); // 青色、半透明
+    circle.lineStyle(3, 0xffffff);
+    circle.drawCircle(0, 0, this.noteRadius);
+    circle.endFill();
+    
+    // コード名のテキスト
+    const text = new PIXI.Text('', {
+      fontFamily: 'Arial',
+      fontSize: 24,
+      fontWeight: 'bold' as any,
+      fill: 0xffffff,
+      align: 'center'
+    });
+    text.anchor.set(0.5);
+    
+    container.addChild(circle);
+    container.addChild(text);
+    container.position.y = 300; // 判定ラインと同じ高さ
+    
+    return {
+      container,
+      circle,
+      text,
+      note: null as any
+    };
+  }
+
+  /**
+   * オブジェクトプールからノーツを取得
+   */
+  private getNoteFromPool(): NoteSprite {
+    let noteSprite = this.notePool.pop();
+    if (!noteSprite) {
+      noteSprite = this.createNoteSprite();
+    }
+    return noteSprite;
+  }
+
+  /**
+   * ノーツをプールに返却
+   */
+  private returnToPool(noteSprite: NoteSprite) {
+    if (noteSprite.tween) {
+      noteSprite.tween.kill();
+      noteSprite.tween = undefined;
+    }
+    noteSprite.container.visible = false;
+    this.notePool.push(noteSprite);
+  }
+
+  /**
+   * ゲーム開始時刻を設定
+   */
+  setStartTime(startTimeMs: number) {
+    this.startTimeMs = startTimeMs;
+  }
+
+  /**
+   * ノーツをスケジュール
+   */
+  scheduleNote(note: TaikoNote, currentTimeMs: number) {
+    // すでにアクティブな場合はスキップ
+    if (this.activeNotes.has(note.id)) {
+      return;
+    }
+
+    const noteSprite = this.getNoteFromPool();
+    noteSprite.note = note;
+    noteSprite.text.text = note.displayName;
+    
+    // 初期位置を画面右端外に設定
+    const startX = this.stageWidth + 100;
+    noteSprite.container.position.x = startX;
+    noteSprite.container.visible = true;
+    
+    // 判定タイミングまでの時間を計算
+    const timeUntilJudge = note.absTimeMs - currentTimeMs;
+    const duration = timeUntilJudge / 1000; // 秒に変換
+    
+    // アニメーション設定
+    noteSprite.tween = gsap.to(noteSprite.container, {
+      x: this.judgeLineX,
+      duration: duration,
+      ease: 'none',
+      onComplete: () => {
+        // 判定ラインに到達
+        this.onNoteReachJudgeLine(noteSprite);
+      }
+    });
+    
+    this.taikoLayer.addChild(noteSprite.container);
+    this.activeNotes.set(note.id, noteSprite);
+    
+    devLog.debug('Scheduled note:', {
+      id: note.id,
+      chord: note.displayName,
+      timeUntilJudge,
+      duration
+    });
+  }
+
+  /**
+   * ノーツが判定ラインに到達した時の処理
+   */
+  private onNoteReachJudgeLine(noteSprite: NoteSprite) {
+    // 判定ウィンドウを過ぎたら自動的に削除
+    setTimeout(() => {
+      this.removeNote(noteSprite.note.id);
+    }, 300); // +300ms後に削除
+  }
+
+  /**
+   * ノーツを削除
+   */
+  removeNote(noteId: string) {
+    const noteSprite = this.activeNotes.get(noteId);
+    if (!noteSprite) return;
+
+    this.taikoLayer.removeChild(noteSprite.container);
+    this.activeNotes.delete(noteId);
+    this.returnToPool(noteSprite);
+  }
+
+  /**
+   * 判定エフェクトを表示
+   */
+  showJudgeEffect(type: 'good' | 'bad') {
+    const effect = new PIXI.Text(
+      type === 'good' ? 'GOOD!' : 'BAD',
+      {
+        fontFamily: 'Arial',
+        fontSize: 48,
+        fontWeight: 'bold' as any,
+        fill: type === 'good' ? 0x00ff00 : 0xff0000,
+        stroke: 0xffffff,
+        strokeThickness: 4
+      }
+    );
+    
+    effect.anchor.set(0.5);
+    effect.position.set(this.judgeLineX, 200);
+    this.taikoLayer.addChild(effect);
+    
+    // エフェクトアニメーション
+    gsap.to(effect, {
+      y: 150,
+      alpha: 0,
+      duration: 0.8,
+      ease: 'power2.out',
+      onComplete: () => {
+        this.taikoLayer.removeChild(effect);
+        effect.destroy();
+      }
+    });
+  }
+
+  /**
+   * 現在の時刻を更新してノーツを管理
+   */
+  update(currentTimeMs: number) {
+    // 画面外に出たノーツを削除
+    this.activeNotes.forEach((noteSprite, noteId) => {
+      if (noteSprite.container.x < -100) {
+        this.removeNote(noteId);
+      }
+    });
+  }
+
+  /**
+   * クリーンアップ
+   */
+  destroy() {
+    // すべてのアクティブノーツを削除
+    this.activeNotes.forEach((_, noteId) => {
+      this.removeNote(noteId);
+    });
+    
+    // 判定ラインを削除
+    if (this.judgeLine) {
+      this.taikoLayer.removeChild(this.judgeLine);
+      this.judgeLine.destroy();
+    }
+    
+    // レイヤーを削除
+    if (this.container && this.taikoLayer) {
+      this.container.removeChild(this.taikoLayer);
+      this.taikoLayer.destroy();
+    }
+    
+    // オブジェクトプールをクリア
+    this.notePool.forEach(noteSprite => {
+      noteSprite.container.destroy();
+    });
+    this.notePool = [];
+  }
+}

--- a/src/components/fantasy/taiko/TaikoUIStrategy.ts
+++ b/src/components/fantasy/taiko/TaikoUIStrategy.ts
@@ -1,0 +1,141 @@
+/**
+ * TaikoUIStrategy
+ * 太鼓の達人モード用UI戦略
+ */
+
+import type { UIStrategy } from './UIStrategy';
+import type { FantasyStage, ChordDefinition } from '../FantasyGameEngine';
+import { TaikoNoteScheduler } from './TaikoNoteScheduler';
+import { TaikoRenderer } from './TaikoRenderer';
+import { TaikoJudge } from './TaikoJudge';
+import type { TaikoNote, TaikoJudgeResult, TaikoSchedule } from '@/types/taiko';
+import { bgmManager } from '@/utils/BGMManager';
+import { devLog } from '@/utils/logger';
+import * as PIXI from 'pixi.js';
+
+interface TaikoUIStrategyDeps {
+  container: PIXI.Container;
+  stageWidth: number;
+  onPlayerHit: (chordId: string) => void;
+  onEnemyAttack: () => void;
+  getChordDefinition: (id: string) => ChordDefinition | null;
+}
+
+export class TaikoUIStrategy implements UIStrategy {
+  private scheduler: TaikoNoteScheduler;
+  private renderer: TaikoRenderer;
+  private judge: TaikoJudge;
+  private deps: TaikoUIStrategyDeps;
+  private schedule: TaikoSchedule | null = null;
+  private startTimeMs: number = 0;
+  private scheduledNotes: Set<string> = new Set();
+  private lookAheadMs = 3000; // 3秒先までのノーツをスケジュール
+
+  constructor(deps: TaikoUIStrategyDeps) {
+    this.deps = deps;
+    this.scheduler = new TaikoNoteScheduler();
+    this.renderer = new TaikoRenderer(deps.container, deps.stageWidth);
+    this.judge = new TaikoJudge();
+
+    // 判定コールバックを設定
+    this.judge.setOnJudge(this.handleJudgeResult.bind(this));
+    this.judge.setOnEnemyAttack(deps.onEnemyAttack);
+  }
+
+  init(stage: FantasyStage): void {
+    devLog.debug('TaikoUIStrategy init:', { stage });
+
+    // スケジュールを生成
+    this.schedule = this.scheduler.generateSchedule(stage);
+    if (!this.schedule) {
+      devLog.error('Failed to generate taiko schedule');
+      return;
+    }
+
+    // 開始時刻を設定
+    this.startTimeMs = performance.now();
+    this.renderer.setStartTime(this.startTimeMs);
+
+    // BGMManagerにビートコールバックを設定
+    bgmManager.setBeatCallback((bar, beat, absMs) => {
+      devLog.debug('Beat callback:', { bar, beat, absMs });
+    });
+
+    devLog.debug('TaikoUIStrategy initialized:', {
+      notesCount: this.schedule.notes.length,
+      measureCount: this.schedule.measureCount,
+      bpm: this.schedule.bpm
+    });
+  }
+
+  onPlayerInput(midi: number, timestamp: number): void {
+    // 太鼓の達人モードでは判定ウィンドウ外の入力は無視
+    const currentTimeMs = performance.now() - this.startTimeMs;
+    const notesInWindow = this.scheduler.getNotesAt(currentTimeMs, 300);
+    
+    if (notesInWindow.length > 0) {
+      this.judge.onInput(midi, timestamp);
+    }
+  }
+
+  update(currentTimeMs: number): void {
+    if (!this.schedule) return;
+
+    const relativeTimeMs = currentTimeMs - this.startTimeMs;
+
+    // ループ処理
+    if (relativeTimeMs > this.schedule.loopEndMs) {
+      this.startTimeMs += (this.schedule.loopEndMs - this.schedule.loopStartMs);
+      this.scheduledNotes.clear();
+      this.judge.clearProcessedNotes();
+      devLog.debug('Loop reset');
+    }
+
+    // 先読みしてノーツをスケジュール
+    const futureNotes = this.schedule.notes.filter(note => {
+      const timeDiff = note.absTimeMs - relativeTimeMs;
+      return timeDiff > 0 && timeDiff <= this.lookAheadMs && !this.scheduledNotes.has(note.id);
+    });
+
+    for (const note of futureNotes) {
+      this.renderer.scheduleNote(note, relativeTimeMs);
+      this.scheduledNotes.add(note.id);
+    }
+
+    // レンダラーを更新
+    this.renderer.update(relativeTimeMs);
+
+    // 判定処理
+    const currentNotes = this.scheduler.getNotesAt(relativeTimeMs, 300);
+    this.judge.judge(currentNotes, relativeTimeMs, this.deps.getChordDefinition);
+  }
+
+  private handleJudgeResult(result: TaikoJudgeResult): void {
+    // 判定エフェクトを表示（noneタイプは除外）
+    if (result.type === 'good' || result.type === 'bad') {
+      this.renderer.showJudgeEffect(result.type);
+    }
+
+    // GOODの場合はプレイヤーのヒット処理を呼ぶ
+    if (result.type === 'good' && result.noteId) {
+      const note = this.schedule?.notes.find(n => n.id === result.noteId);
+      if (note) {
+        this.deps.onPlayerHit(note.chordId);
+      }
+    }
+
+    // ノーツを削除
+    if (result.noteId) {
+      this.renderer.removeNote(result.noteId);
+    }
+  }
+
+  destroy(): void {
+    bgmManager.setBeatCallback(null);
+    this.scheduler.destroy();
+    this.renderer.destroy();
+    this.judge.destroy();
+    this.schedule = null;
+    this.scheduledNotes.clear();
+  }
+}

--- a/src/components/fantasy/taiko/UIStrategy.ts
+++ b/src/components/fantasy/taiko/UIStrategy.ts
@@ -1,0 +1,34 @@
+/**
+ * UIStrategy
+ * FantasyGameEngineのUI戦略パターン
+ */
+
+import type { FantasyStage } from '../FantasyGameEngine';
+
+export interface UIStrategy {
+  init(stage: FantasyStage): void;
+  onPlayerInput(midi: number, timestamp: number): void;
+  update(currentTimeMs: number): void;
+  destroy(): void;
+}
+
+/**
+ * シングルモード用UI戦略（既存のUI）
+ */
+export class SingleUIStrategy implements UIStrategy {
+  init(stage: FantasyStage): void {
+    // 既存のシングルモード初期化処理
+  }
+
+  onPlayerInput(midi: number, timestamp: number): void {
+    // 既存の入力処理
+  }
+
+  update(currentTimeMs: number): void {
+    // 既存の更新処理
+  }
+
+  destroy(): void {
+    // クリーンアップ処理
+  }
+}

--- a/src/components/fantasy/taiko/checkChordMatch.ts
+++ b/src/components/fantasy/taiko/checkChordMatch.ts
@@ -1,0 +1,44 @@
+/**
+ * コード判定関数
+ * 構成音が全て押されていれば正解（順番・オクターブ不問、転回形も正解、余分な音があっても構成音が含まれていれば正解）
+ */
+
+import type { ChordDefinition } from '../FantasyGameEngine';
+import { devLog } from '@/utils/logger';
+
+export const checkChordMatch = (inputNotes: number[], targetChord: ChordDefinition): boolean => {
+  if (inputNotes.length === 0) {
+    devLog.debug('❌ 入力なし - 不正解');
+    return false;
+  }
+  
+  // 重複を除去し、mod 12で正規化（オクターブ無視）
+  const inputNotesMod12 = [...new Set(inputNotes.map(note => note % 12))]; // 重複除去も追加
+  const targetNotesMod12 = [...new Set(targetChord.notes.map(note => note % 12))]; // 重複除去も追加
+  
+  // 転回形も考慮：すべての構成音が含まれているかチェック
+  const hasAllTargetNotes = targetNotesMod12.every(targetNote => 
+    inputNotesMod12.includes(targetNote)
+  );
+  
+  devLog.debug('🎯 コード判定詳細:', { 
+    targetChord: targetChord.displayName,
+    targetMod12Names: targetNotesMod12.map(note => {
+      const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+      return noteNames[note];
+    }),
+    inputNotes: inputNotes,
+    inputNotesMod12: inputNotesMod12,
+    inputMod12Names: inputNotesMod12.map(note => {
+      const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+      return noteNames[note];
+    }),
+    hasAllTargetNotes,
+    matchDetails: targetNotesMod12.map(targetNote => ({
+      note: targetNote,
+      found: inputNotesMod12.includes(targetNote)
+    }))
+  });
+  
+  return hasAllTargetNotes;
+};

--- a/src/types/taiko.ts
+++ b/src/types/taiko.ts
@@ -1,0 +1,37 @@
+/**
+ * 太鼓の達人モード用の型定義
+ */
+
+export interface TaikoNote {
+  id: string;          // UUID
+  bar: number;         // 小節番号（1開始）
+  beat: number;        // 拍番号（1開始、1-timeSignature）
+  absTimeMs: number;   // 楽曲開始からの絶対時間（ミリ秒）
+  chordId: string;     // コードID（例: 'C', 'Am', 'G7'）
+  displayName: string; // 表示用コード名
+}
+
+export interface TaikoSchedule {
+  notes: TaikoNote[];
+  measureCount: number;
+  bpm: number;
+  timeSig: number;
+  loopStartMs: number;  // ループ開始時間（カウントイン後）
+  loopEndMs: number;    // ループ終了時間
+}
+
+export interface TaikoJudgeResult {
+  type: 'good' | 'bad' | 'none';
+  timestamp: number;
+  noteId?: string;
+}
+
+// 拡張版用のコード進行データ形式
+export interface ChordProgressionData {
+  bar: number;
+  beat: number;
+  chord: string;
+}
+
+// BGMManagerのビートコールバック型
+export type BeatCallback = (bar: number, beat: number, absMs: number) => void;


### PR DESCRIPTION
Implement Taiko no Tatsujin-style UI for Fantasy Mode progression stages to introduce a new rhythm-game experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-1086ddfd-8b9d-4c65-a231-6023f90866e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1086ddfd-8b9d-4c65-a231-6023f90866e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>