### PR TITLE
ファンタジーモードのUIと進行ロジックの修正

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -432,14 +432,8 @@ export const useFantasyGameEngine = ({
   // 太鼓の達人モードの入力処理
   const handleTaikoModeInput = useCallback((prevState: FantasyGameState, note: number): FantasyGameState => {
     if (prevState.currentNoteIndex >= prevState.taikoNotes.length) {
-      // すべてのノーツ処理済み - リピート処理
-      devLog.debug('🔁 太鼓モード：全ノーツ処理済み、リピート処理');
-      
-      // 音楽がループしているので、currentNoteIndexを0に戻す
-      return {
-        ...prevState,
-        currentNoteIndex: 0
-      };
+      // すべてのノーツ処理済み
+      return prevState;
     }
     
     const currentNote = prevState.taikoNotes[prevState.currentNoteIndex];
@@ -506,9 +500,6 @@ export const useFantasyGameEngine = ({
       // 次のノーツへ進む
       const nextNoteIndex = prevState.currentNoteIndex + 1;
       
-      // 次のノーツが範囲外の場合は0に戻す（リピート）
-      const finalNoteIndex = nextNoteIndex >= prevState.taikoNotes.length ? 0 : nextNoteIndex;
-      
       // モンスター更新
       const updatedMonsters = prevState.activeMonsters.map(m => {
         if (m.id === currentMonster.id) {
@@ -529,7 +520,7 @@ export const useFantasyGameEngine = ({
         
         if (newMonsterQueue.length > 0) {
           const monsterIndex = newMonsterQueue.shift()!;
-          const nextNote = prevState.taikoNotes[finalNoteIndex];
+                      const nextNote = prevState.taikoNotes[nextNoteIndex];
           
           if (nextNote) {
             const newMonster = createMonsterFromQueue(
@@ -568,7 +559,7 @@ export const useFantasyGameEngine = ({
           activeMonsters: remainingMonsters,
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
-          currentNoteIndex: finalNoteIndex,
+          currentNoteIndex: nextNoteIndex,
           correctAnswers: prevState.correctAnswers + 1,
           score: prevState.score + 100 * actualDamage,
           enemiesDefeated: newEnemiesDefeated
@@ -579,7 +570,7 @@ export const useFantasyGameEngine = ({
         ...prevState,
         activeMonsters: updatedMonsters,
         playerSp: newSp,
-        currentNoteIndex: finalNoteIndex,
+        currentNoteIndex: nextNoteIndex,
         correctAnswers: prevState.correctAnswers + 1,
         score: prevState.score + 100 * actualDamage
       };
@@ -719,7 +710,8 @@ export const useFantasyGameEngine = ({
           stage.bpm || 120,
           stage.timeSignature || 4,
           (chordId) => getChordDefinition(chordId, displayOpts),
-          stage.countInMeasures || 0
+          stage.countInMeasures || 0,
+          stage.measureCount || 8
         );
       } else if (stage.chordProgression) {
         // 基本版：小節の頭でコード出題
@@ -1001,13 +993,9 @@ export const useFantasyGameEngine = ({
       if (prevState.isTaikoMode && prevState.taikoNotes.length > 0) {
         const currentTime = bgmManager.getCurrentMusicTime();
         
-        // currentNoteIndexが範囲外の場合はリピート処理
+        // currentNoteIndexが範囲外の場合は何もしない
         if (prevState.currentNoteIndex >= prevState.taikoNotes.length) {
-          devLog.debug('🔁 太鼓モード：全ノーツ処理済み（タイマー内）、リピート処理');
-          return {
-            ...prevState,
-            currentNoteIndex: 0
-          };
+          return prevState;
         }
         
         const currentNote = prevState.taikoNotes[prevState.currentNoteIndex];
@@ -1023,12 +1011,9 @@ export const useFantasyGameEngine = ({
           handleEnemyAttack();
           
           // 次のノーツへ進む
-          const nextIndex = prevState.currentNoteIndex + 1;
-          
-          // 次のインデックスが範囲外の場合は0に戻す
           return {
             ...prevState,
-            currentNoteIndex: nextIndex >= prevState.taikoNotes.length ? 0 : nextIndex,
+            currentNoteIndex: prevState.currentNoteIndex + 1,
             activeMonsters: prevState.activeMonsters.map(m => ({
               ...m,
               correctNotes: [],

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -432,8 +432,14 @@ export const useFantasyGameEngine = ({
   // 太鼓の達人モードの入力処理
   const handleTaikoModeInput = useCallback((prevState: FantasyGameState, note: number): FantasyGameState => {
     if (prevState.currentNoteIndex >= prevState.taikoNotes.length) {
-      // すべてのノーツ処理済み
-      return prevState;
+      // すべてのノーツ処理済み - リピート処理
+      devLog.debug('🔁 太鼓モード：全ノーツ処理済み、リピート処理');
+      
+      // 音楽がループしているので、currentNoteIndexを0に戻す
+      return {
+        ...prevState,
+        currentNoteIndex: 0
+      };
     }
     
     const currentNote = prevState.taikoNotes[prevState.currentNoteIndex];
@@ -500,6 +506,9 @@ export const useFantasyGameEngine = ({
       // 次のノーツへ進む
       const nextNoteIndex = prevState.currentNoteIndex + 1;
       
+      // 次のノーツが範囲外の場合は0に戻す（リピート）
+      const finalNoteIndex = nextNoteIndex >= prevState.taikoNotes.length ? 0 : nextNoteIndex;
+      
       // モンスター更新
       const updatedMonsters = prevState.activeMonsters.map(m => {
         if (m.id === currentMonster.id) {
@@ -520,7 +529,7 @@ export const useFantasyGameEngine = ({
         
         if (newMonsterQueue.length > 0) {
           const monsterIndex = newMonsterQueue.shift()!;
-          const nextNote = prevState.taikoNotes[nextNoteIndex];
+          const nextNote = prevState.taikoNotes[finalNoteIndex];
           
           if (nextNote) {
             const newMonster = createMonsterFromQueue(
@@ -559,7 +568,7 @@ export const useFantasyGameEngine = ({
           activeMonsters: remainingMonsters,
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
-          currentNoteIndex: nextNoteIndex,
+          currentNoteIndex: finalNoteIndex,
           correctAnswers: prevState.correctAnswers + 1,
           score: prevState.score + 100 * actualDamage,
           enemiesDefeated: newEnemiesDefeated
@@ -570,7 +579,7 @@ export const useFantasyGameEngine = ({
         ...prevState,
         activeMonsters: updatedMonsters,
         playerSp: newSp,
-        currentNoteIndex: nextNoteIndex,
+        currentNoteIndex: finalNoteIndex,
         correctAnswers: prevState.correctAnswers + 1,
         score: prevState.score + 100 * actualDamage
       };
@@ -709,7 +718,8 @@ export const useFantasyGameEngine = ({
           progressionData,
           stage.bpm || 120,
           stage.timeSignature || 4,
-          (chordId) => getChordDefinition(chordId, displayOpts)
+          (chordId) => getChordDefinition(chordId, displayOpts),
+          stage.countInMeasures || 0
         );
       } else if (stage.chordProgression) {
         // 基本版：小節の頭でコード出題
@@ -718,7 +728,8 @@ export const useFantasyGameEngine = ({
           stage.measureCount || 8,
           stage.bpm || 120,
           stage.timeSignature || 4,
-          (chordId) => getChordDefinition(chordId, displayOpts)
+          (chordId) => getChordDefinition(chordId, displayOpts),
+          stage.countInMeasures || 0
         );
       }
       
@@ -989,6 +1000,16 @@ export const useFantasyGameEngine = ({
       // 太鼓の達人モードの場合は専用のミス判定を行う
       if (prevState.isTaikoMode && prevState.taikoNotes.length > 0) {
         const currentTime = bgmManager.getCurrentMusicTime();
+        
+        // currentNoteIndexが範囲外の場合はリピート処理
+        if (prevState.currentNoteIndex >= prevState.taikoNotes.length) {
+          devLog.debug('🔁 太鼓モード：全ノーツ処理済み（タイマー内）、リピート処理');
+          return {
+            ...prevState,
+            currentNoteIndex: 0
+          };
+        }
+        
         const currentNote = prevState.taikoNotes[prevState.currentNoteIndex];
         
         if (currentNote && currentTime > currentNote.hitTime + 0.3) {
@@ -1002,9 +1023,12 @@ export const useFantasyGameEngine = ({
           handleEnemyAttack();
           
           // 次のノーツへ進む
+          const nextIndex = prevState.currentNoteIndex + 1;
+          
+          // 次のインデックスが範囲外の場合は0に戻す
           return {
             ...prevState,
-            currentNoteIndex: prevState.currentNoteIndex + 1,
+            currentNoteIndex: nextIndex >= prevState.taikoNotes.length ? 0 : nextIndex,
             activeMonsters: prevState.activeMonsters.map(m => ({
               ...m,
               correctNotes: [],

--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -74,17 +74,20 @@ export function judgeTimingWindow(
  * @param measureCount 総小節数
  * @param bpm BPM
  * @param timeSignature 拍子
+ * @param countInMeasures カウントイン小節数
  */
 export function generateBasicProgressionNotes(
   chordProgression: string[],
   measureCount: number,
   bpm: number,
   timeSignature: number,
-  getChordDefinition: (chordId: string) => ChordDefinition | null
+  getChordDefinition: (chordId: string) => ChordDefinition | null,
+  countInMeasures: number = 0
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
+  const countInTime = countInMeasures * secPerMeasure; // カウントイン分の時間
   
   for (let measure = 1; measure <= measureCount; measure++) {
     const chordIndex = (measure - 1) % chordProgression.length;
@@ -92,7 +95,8 @@ export function generateBasicProgressionNotes(
     const chord = getChordDefinition(chordId);
     
     if (chord) {
-      const hitTime = (measure - 1) * secPerMeasure + 0; // 小節の頭（Beat 1 = 0秒目）
+      // カウントイン分の時間を追加
+      const hitTime = countInTime + (measure - 1) * secPerMeasure + 0; // 小節の頭（Beat 1）
       
       notes.push({
         id: `note_${measure}_1`,
@@ -114,22 +118,25 @@ export function generateBasicProgressionNotes(
  * @param progressionData JSON配列
  * @param bpm BPM
  * @param timeSignature 拍子
+ * @param countInMeasures カウントイン小節数
  */
 export function parseChordProgressionData(
   progressionData: ChordProgressionDataItem[],
   bpm: number,
   timeSignature: number,
-  getChordDefinition: (chordId: string) => ChordDefinition | null
+  getChordDefinition: (chordId: string) => ChordDefinition | null,
+  countInMeasures: number = 0
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
+  const countInTime = countInMeasures * secPerMeasure; // カウントイン分の時間
   
   progressionData.forEach((item, index) => {
     const chord = getChordDefinition(item.chord);
     if (chord) {
-      // bar（小節）とbeats（拍）から実際の時刻を計算
-      const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
+      // bar（小節）とbeats（拍）から実際の時刻を計算、カウントイン分の時間を追加
+      const hitTime = countInTime + (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
       
       notes.push({
         id: `note_${item.bar}_${item.beats}_${index}`,

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -88,7 +88,6 @@ class BGMManager {
   /**
    * 現在の音楽的時間を取得（秒単位）
    * カウントイン終了時を0秒とする
-   * ループを考慮して常に0〜ループ長の範囲で返す
    */
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
@@ -97,15 +96,7 @@ class BGMManager {
     const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
     
     // カウントイン中は負の値を返す
-    const musicTime = audioTime - countInDuration
-    
-    // ループを考慮：音楽時間が正の場合、ループ長で剰余を取る
-    if (musicTime >= 0) {
-      const loopLength = this.measureCount * (60 / this.bpm) * this.timeSignature
-      return musicTime % loopLength
-    }
-    
-    return musicTime
+    return audioTime - countInDuration
   }
   
   /**

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -88,6 +88,7 @@ class BGMManager {
   /**
    * 現在の音楽的時間を取得（秒単位）
    * カウントイン終了時を0秒とする
+   * ループを考慮して常に0〜ループ長の範囲で返す
    */
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
@@ -96,7 +97,15 @@ class BGMManager {
     const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
     
     // カウントイン中は負の値を返す
-    return audioTime - countInDuration
+    const musicTime = audioTime - countInDuration
+    
+    // ループを考慮：音楽時間が正の場合、ループ長で剰余を取る
+    if (musicTime >= 0) {
+      const loopLength = this.measureCount * (60 / this.bpm) * this.timeSignature
+      return musicTime % loopLength
+    }
+    
+    return musicTime
   }
   
   /**


### PR DESCRIPTION
Fixes Taiko mode progression by correctly handling count-in, enabling seamless looping, and improving music-beat synchronization.

The Taiko mode had several issues: notes appeared during the count-in, repeats would jump back to the count-in, the game would stop processing notes and judgments at the end of the song, and there were synchronization lags during repeats. This PR addresses these by adjusting note timing for count-in, ensuring `currentNoteIndex` loops correctly, and making `getCurrentMusicTime` loop-aware to maintain beat synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a64f40b-2c75-474f-96d9-f0f73aac04fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a64f40b-2c75-474f-96d9-f0f73aac04fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>