### PR TITLE
ファンタジーモードのUIと進行のバグ修正

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -571,13 +571,17 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     const updateTaikoNotes = () => {
       const currentTime = bgmManager.getCurrentMusicTime();
-      const visibleNotes = getVisibleNotes(gameState.taikoNotes, currentTime);
+      const loopDuration = stage?.measureCount 
+        ? stage.measureCount * (60 / (stage.bpm || 120)) * (stage.timeSignature || 4)
+        : 0;
+      
+      const visibleNotes = getVisibleNotes(gameState.taikoNotes, currentTime, 3, loopDuration);
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
       
       const notesData = visibleNotes.map(note => ({
         id: note.id,
         chord: note.chord.displayName,
-        x: calculateNotePosition(note, currentTime, judgeLinePos.x)
+        x: calculateNotePosition(note, currentTime, judgeLinePos.x, 300, loopDuration)
       }));
       
       fantasyPixiInstance.updateTaikoNotes(notesData);

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -11,6 +11,7 @@ class BGMManager {
   private measureCount = 8
   private countInMeasures = 0
   private isPlaying = false
+  private loopCount = 0  // ループ回数を追跡
 
   play(
     url: string,
@@ -30,6 +31,7 @@ class BGMManager {
     this.timeSignature = timeSig
     this.measureCount = measureCount
     this.countInMeasures = countIn
+    this.loopCount = 0
     
     this.audio = new Audio(url)
     this.audio.volume = volume
@@ -49,6 +51,7 @@ class BGMManager {
       if (this.audio.currentTime >= this.loopEnd) {
         // ループ時はカウントイン後から再生
         this.audio.currentTime = this.loopBegin
+        this.loopCount++
       }
     }
     
@@ -94,9 +97,12 @@ class BGMManager {
     
     const audioTime = this.audio.currentTime
     const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
+    const loopDuration = this.measureCount * (60 / this.bpm) * this.timeSignature
     
-    // カウントイン中は負の値を返す
-    return audioTime - countInDuration
+    // ループ回数分の時間を加算して、全体の音楽的時間を計算
+    const totalMusicTime = audioTime - countInDuration + (this.loopCount * loopDuration)
+    
+    return totalMusicTime
   }
   
   /**


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrects Taiko mode progression by excluding count-in from gameplay, refining loop behavior, and maintaining game state.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR resolves several critical issues in the Taiko mode's progression:
1.  **Incorrect Note Start:** Notes no longer appear during the count-in, ensuring the first question aligns with the actual first measure.
2.  **Looping Issues:** Loops now correctly jump to the first measure (post-count-in) instead of the count-in, and game state (e.g., monster visibility, judgment acceptance) is preserved across loops.
3.  **Synchronization & Visuals:** Improved timing synchronization during loops and enabled pre-rendering of notes across loop boundaries for a smoother visual experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-23b5ff40-b182-4e50-9230-8293ce1da49d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23b5ff40-b182-4e50-9230-8293ce1da49d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>