### PR TITLE
ファンタジーモードのUIと進行のバグ修正

### DIFF
--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -80,25 +80,28 @@ export function generateBasicProgressionNotes(
   measureCount: number,
   bpm: number,
   timeSignature: number,
-  getChordDefinition: (chordId: string) => ChordDefinition | null
+  getChordDefinition: (chordId: string) => ChordDefinition | null,
+  countInMeasures: number = 0 // カウントイン小節数を追加
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
   
+  // カウントイン後から問題を生成（1から開始）
   for (let measure = 1; measure <= measureCount; measure++) {
     const chordIndex = (measure - 1) % chordProgression.length;
     const chordId = chordProgression[chordIndex];
     const chord = getChordDefinition(chordId);
     
     if (chord) {
-      const hitTime = (measure - 1) * secPerMeasure + 0; // 小節の頭（Beat 1 = 0秒目）
+      // hitTimeはカウントイン分を加算
+      const hitTime = (countInMeasures + measure - 1) * secPerMeasure + 0; // 小節の頭（Beat 1 = 0秒目）
       
       notes.push({
         id: `note_${measure}_1`,
         chord,
         hitTime,
-        measure,
+        measure: countInMeasures + measure, // 実際の小節番号
         beat: 1,
         isHit: false,
         isMissed: false
@@ -119,7 +122,8 @@ export function parseChordProgressionData(
   progressionData: ChordProgressionDataItem[],
   bpm: number,
   timeSignature: number,
-  getChordDefinition: (chordId: string) => ChordDefinition | null
+  getChordDefinition: (chordId: string) => ChordDefinition | null,
+  countInMeasures: number = 0 // カウントイン小節数を追加
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
@@ -128,14 +132,14 @@ export function parseChordProgressionData(
   progressionData.forEach((item, index) => {
     const chord = getChordDefinition(item.chord);
     if (chord) {
-      // bar（小節）とbeats（拍）から実際の時刻を計算
-      const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
+      // hitTimeはカウントイン分を加算
+      const hitTime = (countInMeasures + item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
       
       notes.push({
         id: `note_${item.bar}_${item.beats}_${index}`,
         chord,
         hitTime,
-        measure: item.bar,
+        measure: countInMeasures + item.bar, // 実際の小節番号
         beat: item.beats,
         isHit: false,
         isMissed: false


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes multiple Taiko UI bugs in Fantasy Mode, including count-in, looping, monster display, and judgment persistence.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation incorrectly handled count-in periods and song looping, causing notes to appear too early, monsters to disappear, and judgments to fail. This PR ensures accurate note generation, seamless loop transitions, persistent monster display, and continuous judgment, improving the overall gameplay flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-11f09595-e0b2-4180-b85c-9e8bcfa8d8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11f09595-e0b2-4180-b85c-9e8bcfa8d8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>