### PR TITLE
Fix taiko mode bugs and improve stability

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -438,11 +438,19 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理開始');
       
-      const firstNote = prevState.taikoNotes[0];
-      const nextNote = prevState.taikoNotes.length > 1 ? prevState.taikoNotes[1] : firstNote;
+      // ノーツのフラグをリセット
+      const resetNotes = prevState.taikoNotes.map(n => ({
+        ...n,
+        isHit: false,
+        isMissed: false
+      }));
+      
+      const firstNote = resetNotes[0];
+      const nextNote = resetNotes.length > 1 ? resetNotes[1] : firstNote;
       
       return {
         ...prevState,
+        taikoNotes: resetNotes,
         currentNoteIndex: 0,
         activeMonsters: prevState.activeMonsters.map(m => ({
           ...m,
@@ -455,7 +463,7 @@ export const useFantasyGameEngine = ({
     }
     
     const currentNote = prevState.taikoNotes[prevState.currentNoteIndex];
-    if (!currentNote) return prevState;
+    if (!currentNote || currentNote.isHit || currentNote.isMissed) return prevState;
     
     const currentTime = bgmManager.getCurrentMusicTime();
     const loopDuration = (prevState.currentStage?.measureCount || 8) * 
@@ -508,6 +516,13 @@ export const useFantasyGameEngine = ({
         timing: judgment.timing,
         noteIndex: prevState.currentNoteIndex
       });
+      
+      // 現在のノーツをヒット済みにマーク
+      const updatedTaikoNotes = [...prevState.taikoNotes];
+      updatedTaikoNotes[prevState.currentNoteIndex] = {
+        ...currentNote,
+        isHit: true
+      };
       
       // 次のノーツインデックス
       const nextNoteIndex = prevState.currentNoteIndex + 1;
@@ -581,6 +596,7 @@ export const useFantasyGameEngine = ({
         if (newEnemiesDefeated >= prevState.totalEnemies) {
           const finalState = {
             ...prevState,
+            taikoNotes: updatedTaikoNotes,
             activeMonsters: [],
             isGameActive: false,
             isGameOver: true,
@@ -597,6 +613,7 @@ export const useFantasyGameEngine = ({
         
         return {
           ...prevState,
+          taikoNotes: updatedTaikoNotes,
           activeMonsters: remainingMonsters,
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
@@ -609,6 +626,7 @@ export const useFantasyGameEngine = ({
       
       return {
         ...prevState,
+        taikoNotes: updatedTaikoNotes,
         activeMonsters: updatedMonsters,
         playerSp: newSp,
         currentNoteIndex: nextNoteIndex,
@@ -1058,7 +1076,7 @@ export const useFantasyGameEngine = ({
         }
         
         const currentNote = prevState.taikoNotes[currentNoteIndex];
-        if (!currentNote) return prevState;
+        if (!currentNote || currentNote.isMissed) return prevState;
         
         // ミス判定（判定ウィンドウを過ぎた場合）
         let timeDiff = currentTime - currentNote.hitTime;
@@ -1077,6 +1095,13 @@ export const useFantasyGameEngine = ({
             targetTime: currentNote.hitTime.toFixed(3)
           });
           
+          // 現在のノーツをミス済みにマーク
+          const updatedTaikoNotes = [...prevState.taikoNotes];
+          updatedTaikoNotes[currentNoteIndex] = {
+            ...currentNote,
+            isMissed: true
+          };
+          
           // 敵の攻撃を発動（非同期）
           setTimeout(() => handleEnemyAttack(), 0);
           
@@ -1092,6 +1117,7 @@ export const useFantasyGameEngine = ({
           
           return {
             ...prevState,
+            taikoNotes: updatedTaikoNotes,
             currentNoteIndex: nextIndex,
             activeMonsters: prevState.activeMonsters.map(m => ({
               ...m,
@@ -1128,7 +1154,7 @@ export const useFantasyGameEngine = ({
         // 怒り状態をストアに通知
         const { setEnrage } = useEnemyStore.getState();
         setEnrage(attackingMonster.id, true);
-        setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
+        setTimeout(() => setEnrage(attackingMonster.id, false), 800); // 0.8秒後にOFF
         
         // 攻撃したモンスターのゲージをリセット
         const resetMonsters = updatedMonsters.map(m => 
@@ -1373,7 +1399,9 @@ export const useFantasyGameEngine = ({
   const stopGame = useCallback(() => {
     setGameState(prevState => ({
       ...prevState,
-      isGameActive: false
+      isGameActive: false,
+      taikoNotes: [],
+      currentNoteIndex: 0
     }));
     
     // ステージを抜けるたびにアイコン配列を初期化

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -393,7 +393,7 @@ export class FantasyPIXIInstance {
       }
       
       // 怒りマークSVGを追加
-      magicAssets['angerMark'] = `${import.meta.env.BASE_URL}data/anger.svg`;
+      magicAssets['angerMark'] = new URL('/data/anger.svg', import.meta.url).href;
       
       // 音符吹き出しを追加
       magicAssets['fukidashi'] = `${import.meta.env.BASE_URL}attack_icons/fukidashi_onpu_white.png`;
@@ -1656,6 +1656,21 @@ export class FantasyPIXIInstance {
               );
               sprite.addChild(angerMark);
               monsterData.angerMark = angerMark;
+              
+              // フェードアウトアニメーションを追加
+              gsap.to(angerMark, {
+                alpha: 0,
+                duration: 0.8,
+                delay: 0.5,
+                ease: "power2.out",
+                onComplete: () => {
+                  if (monsterData.angerMark === angerMark) {
+                    sprite.removeChild(angerMark);
+                    angerMark.destroy();
+                    monsterData.angerMark = undefined;
+                  }
+                }
+              });
             } else {
               // テクスチャが無い場合は絵文字でフォールバック
               const angerMark = new PIXI.Text('💢', {
@@ -1672,6 +1687,21 @@ export class FantasyPIXIInstance {
               );
               sprite.addChild(angerMark);
               monsterData.angerMark = angerMark;
+              
+              // フェードアウトアニメーションを追加
+              gsap.to(angerMark, {
+                alpha: 0,
+                duration: 0.8,
+                delay: 0.5,
+                ease: "power2.out",
+                onComplete: () => {
+                  if (monsterData.angerMark === angerMark) {
+                    sprite.removeChild(angerMark);
+                    angerMark.destroy();
+                    monsterData.angerMark = undefined;
+                  }
+                }
+              });
             }
           }
           

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -74,14 +74,8 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     const currentBeatInMeasure = (beatsFromStart % s.timeSignature) + 1
     
     /* カウントイン中かどうかを判定 */
-    if (totalMeasures < s.countInMeasures) {
-      // カウントイン中
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: -(s.countInMeasures - totalMeasures), // 負の値でカウントイン表示
-        isCountIn: true
-      })
-    } else {
+    // 修正: カウントインが0小節の場合は常にカウントイン終了、それ以外は <= で判定
+    if (s.countInMeasures === 0 || totalMeasures > s.countInMeasures - 1) {
       // メイン部分（カウントイン後）
       const measuresAfterCountIn = totalMeasures - s.countInMeasures
       const displayMeasure = (measuresAfterCountIn % s.measureCount) + 1
@@ -90,6 +84,13 @@ export const useTimeStore = create<TimeState>((set, get) => ({
         currentBeat: currentBeatInMeasure,
         currentMeasure: displayMeasure, // カウントイン後を1から表示
         isCountIn: false
+      })
+    } else {
+      // カウントイン中
+      set({
+        currentBeat: currentBeatInMeasure,
+        currentMeasure: -(s.countInMeasures - totalMeasures), // 負の値でカウントイン表示
+        isCountIn: true
       })
     }
   }


### PR DESCRIPTION
Fixes multiple Taiko UI bugs affecting count-in timing, note looping, anger mark display, and retry functionality.

This PR addresses:
*   Incorrect count-in measure calculation causing notes to appear one beat early.
*   Notes not resetting `isHit`/`isMissed` flags on loop, leading to missed first notes or multi-hits.
*   Anger mark not displaying correctly due to asset path issues, short display duration, and lack of fade-out.
*   Notes not appearing on game retry due to improper state reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf7ac2a9-211f-4bb9-935c-7dba0dbd0c44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf7ac2a9-211f-4bb9-935c-7dba0dbd0c44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>