### PR TITLE
Fix taiko mode progression bugs

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -438,11 +438,19 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理開始');
       
-      const firstNote = prevState.taikoNotes[0];
-      const nextNote = prevState.taikoNotes.length > 1 ? prevState.taikoNotes[1] : firstNote;
+      // ノーツの状態をリセット
+      const resetNotes = prevState.taikoNotes.map(note => ({
+        ...note,
+        isHit: false,
+        isMissed: false
+      }));
+      
+      const firstNote = resetNotes[0];
+      const nextNote = resetNotes.length > 1 ? resetNotes[1] : firstNote;
       
       return {
         ...prevState,
+        taikoNotes: resetNotes,
         currentNoteIndex: 0,
         activeMonsters: prevState.activeMonsters.map(m => ({
           ...m,
@@ -508,6 +516,9 @@ export const useFantasyGameEngine = ({
         timing: judgment.timing,
         noteIndex: prevState.currentNoteIndex
       });
+      
+      // 現在のノーツにヒットフラグを設定
+      currentNote.isHit = true;
       
       // 次のノーツインデックス
       const nextNoteIndex = prevState.currentNoteIndex + 1;
@@ -1080,18 +1091,24 @@ export const useFantasyGameEngine = ({
           // 敵の攻撃を発動（非同期）
           setTimeout(() => handleEnemyAttack(), 0);
           
+          // ノーツにミスフラグを設定
+          const updatedNotes = prevState.taikoNotes.map((note, idx) => 
+            idx === currentNoteIndex ? { ...note, isMissed: true } : note
+          );
+          
           // 次のノーツへ進む
           const nextIndex = currentNoteIndex + 1;
-          const nextNote = nextIndex < prevState.taikoNotes.length 
-            ? prevState.taikoNotes[nextIndex]
-            : prevState.taikoNotes[0];
+          const nextNote = nextIndex < updatedNotes.length 
+            ? updatedNotes[nextIndex]
+            : updatedNotes[0];
           
-          const nextNextNote = (nextIndex + 1) < prevState.taikoNotes.length
-            ? prevState.taikoNotes[nextIndex + 1]
-            : prevState.taikoNotes[(nextIndex < prevState.taikoNotes.length) ? 1 : 0];
+          const nextNextNote = (nextIndex + 1) < updatedNotes.length
+            ? updatedNotes[nextIndex + 1]
+            : updatedNotes[(nextIndex < updatedNotes.length) ? 1 : 0];
           
           return {
             ...prevState,
+            taikoNotes: updatedNotes,
             currentNoteIndex: nextIndex,
             activeMonsters: prevState.activeMonsters.map(m => ({
               ...m,
@@ -1128,7 +1145,7 @@ export const useFantasyGameEngine = ({
         // 怒り状態をストアに通知
         const { setEnrage } = useEnemyStore.getState();
         setEnrage(attackingMonster.id, true);
-        setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
+        setTimeout(() => setEnrage(attackingMonster.id, false), 800); // 0.8秒後にOFF
         
         // 攻撃したモンスターのゲージをリセット
         const resetMonsters = updatedMonsters.map(m => 
@@ -1373,7 +1390,9 @@ export const useFantasyGameEngine = ({
   const stopGame = useCallback(() => {
     setGameState(prevState => ({
       ...prevState,
-      isGameActive: false
+      isGameActive: false,
+      taikoNotes: [],
+      currentNoteIndex: 0
     }));
     
     // ステージを抜けるたびにアイコン配列を初期化

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -393,7 +393,7 @@ export class FantasyPIXIInstance {
       }
       
       // 怒りマークSVGを追加
-      magicAssets['angerMark'] = `${import.meta.env.BASE_URL}data/anger.svg`;
+      magicAssets['angerMark'] = new URL('/data/anger.svg', import.meta.url).href;
       
       // 音符吹き出しを追加
       magicAssets['fukidashi'] = `${import.meta.env.BASE_URL}attack_icons/fukidashi_onpu_white.png`;
@@ -1692,9 +1692,30 @@ export class FantasyPIXIInstance {
           
           // 怒りエフェクトを削除
           if (monsterData.angerMark) {
-            sprite.removeChild(monsterData.angerMark);
-            monsterData.angerMark.destroy();
-            monsterData.angerMark = undefined;
+            // フェードアウトアニメーション
+            const fadeOutDuration = 300; // 300ms
+            const startAlpha = monsterData.angerMark.alpha;
+            const startTime = Date.now();
+            
+            const fadeOut = () => {
+              const elapsed = Date.now() - startTime;
+              const progress = Math.min(elapsed / fadeOutDuration, 1);
+              
+              if (monsterData.angerMark) {
+                monsterData.angerMark.alpha = startAlpha * (1 - progress);
+                
+                if (progress >= 1) {
+                  // フェードアウト完了後に削除
+                  sprite.removeChild(monsterData.angerMark);
+                  monsterData.angerMark.destroy();
+                  monsterData.angerMark = undefined;
+                } else {
+                  requestAnimationFrame(fadeOut);
+                }
+              }
+            };
+            
+            requestAnimationFrame(fadeOut);
           }
         }
         
@@ -2057,7 +2078,7 @@ export class FantasyPIXIInstance {
     
     // エフェクトの安全な削除
     try {
-      this.magicCircles.forEach((circle, id) => {
+      for (const [id, circle] of this.magicCircles) {
         try {
           if (circle && typeof circle.destroy === 'function' && !circle.destroyed) {
             if (circle.parent) {
@@ -2068,11 +2089,11 @@ export class FantasyPIXIInstance {
         } catch (error) {
           devLog.debug(`⚠️ 魔法陣削除エラー ${id}:`, error);
         }
-      });
+      }
       this.magicCircles.clear();
       this.magicCircleData.clear();
       
-      this.damageNumbers.forEach((text, id) => {
+      for (const [id, text] of this.damageNumbers) {
         try {
           if (text && typeof text.destroy === 'function' && !text.destroyed) {
             if (text.parent) {
@@ -2083,7 +2104,7 @@ export class FantasyPIXIInstance {
         } catch (error) {
           devLog.debug(`⚠️ ダメージ数値削除エラー ${id}:`, error);
         }
-      });
+      }
       this.damageNumbers.clear();
       this.damageData.clear();
     } catch (error) {

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -74,7 +74,7 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     const currentBeatInMeasure = (beatsFromStart % s.timeSignature) + 1
     
     /* カウントイン中かどうかを判定 */
-    if (totalMeasures < s.countInMeasures) {
+    if (s.countInMeasures === 0 || totalMeasures < s.countInMeasures) {
       // カウントイン中
       set({
         currentBeat: currentBeatInMeasure,


### PR DESCRIPTION
Fix multiple Fantasy Mode Taiko UI bugs related to count-in timing, note judgment on loops, anger mark display, and retry functionality.

This PR addresses several long-standing bugs: correcting the count-in measure calculation, ensuring note hit/miss states are properly reset for looping, fixing the display and lifecycle of the 'anger' effect, and ensuring notes correctly appear when retrying a stage. It also includes minor performance improvements for PIXI object cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-be820ad4-6747-47d7-9095-7d448e2ba11b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be820ad4-6747-47d7-9095-7d448e2ba11b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>