### PR TITLE
Remove count-in measure from game logic

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -55,7 +55,7 @@ interface FantasyStage {
   simultaneousMonsterCount: number; // 同時出現モンスター数 (1-8)
   bpm: number;
   measureCount?: number;
-  countInMeasures?: number;
+
   timeSignature?: number;
 }
 
@@ -438,12 +438,20 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理開始');
       
-      const firstNote = prevState.taikoNotes[0];
-      const nextNote = prevState.taikoNotes.length > 1 ? prevState.taikoNotes[1] : firstNote;
+      // ノーツのリセット処理を追加
+      const resetNotes = prevState.taikoNotes.map(note => ({
+        ...note,
+        isHit: false,
+        isMissed: false
+      }));
+      
+      const firstNote = resetNotes[0];
+      const nextNote = resetNotes.length > 1 ? resetNotes[1] : firstNote;
       
       return {
         ...prevState,
         currentNoteIndex: 0,
+        taikoNotes: resetNotes,
         activeMonsters: prevState.activeMonsters.map(m => ({
           ...m,
           correctNotes: [],
@@ -751,7 +759,7 @@ export const useFantasyGameEngine = ({
           stage.bpm || 120,
           stage.timeSignature || 4,
           (chordId) => getChordDefinition(chordId, displayOpts),
-          stage.countInMeasures || 0 // カウントインを渡す
+          0 // カウントインを渡す
         );
       } else if (stage.chordProgression) {
         // 基本版：小節の頭でコード出題
@@ -761,7 +769,7 @@ export const useFantasyGameEngine = ({
           stage.bpm || 120,
           stage.timeSignature || 4,
           (chordId) => getChordDefinition(chordId, displayOpts),
-          stage.countInMeasures || 0 // カウントインを渡す
+          0 // カウントインを渡す
         );
       }
       
@@ -779,8 +787,7 @@ export const useFantasyGameEngine = ({
       
       devLog.debug('🥁 太鼓の達人モード初期化:', {
         noteCount: taikoNotes.length,
-        firstNote: taikoNotes[0],
-        countInMeasures: stage.countInMeasures
+        firstNote: taikoNotes[0]
       });
     }
 
@@ -828,8 +835,7 @@ export const useFantasyGameEngine = ({
       .setStart(
         stage.bpm || 120,
         stage.timeSignature || 4, // デフォルトは4/4拍子
-        stage.measureCount ?? 8,
-        stage.countInMeasures ?? 0
+        stage.measureCount ?? 8
       );
 
     devLog.debug('✅ ゲーム初期化完了:', {
@@ -1055,6 +1061,24 @@ export const useFantasyGameEngine = ({
         // ループ処理
         if (currentNoteIndex >= prevState.taikoNotes.length) {
           currentNoteIndex = 0;
+          // ループ時にノーツをリセット
+          const resetNotes = prevState.taikoNotes.map(note => ({
+            ...note,
+            isHit: false,
+            isMissed: false
+          }));
+          return {
+            ...prevState,
+            currentNoteIndex,
+            taikoNotes: resetNotes,
+            activeMonsters: prevState.activeMonsters.map(m => ({
+              ...m,
+              correctNotes: [],
+              gauge: 0,
+              chordTarget: resetNotes[0]?.chord || m.chordTarget,
+              nextChord: resetNotes[1]?.chord || m.nextChord
+            }))
+          };
         }
         
         const currentNote = prevState.taikoNotes[currentNoteIndex];

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -108,7 +108,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         stage.bpm || 120,
         stage.timeSignature || 4,
         stage.measureCount ?? 8,
-        stage.countInMeasures ?? 0,
+        0,
         settings.bgmVolume ?? 0.7
       );
     } else {
@@ -543,7 +543,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     // ループ情報を事前計算
     const stage = gameState.currentStage!;
     const loopDuration = stage.measureCount * (60 / stage.bpm) * stage.timeSignature;
-    const countInDuration = (stage.countInMeasures || 0) * (60 / stage.bpm) * stage.timeSignature;
+    const countInDuration = 0;
     
     const updateTaikoNotes = (timestamp: number) => {
       // フレームレート制御

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -107,7 +107,7 @@ const FantasyMain: React.FC = () => {
             bpm: stage.bpm || 120,
             bgmUrl: stage.bgm_url || stage.mp3_url,
             measureCount: stage.measure_count,
-            countInMeasures: stage.count_in_measures,
+            countInMeasures: 0,
             timeSignature: stage.time_signature
           };
           devLog.debug('🎮 FantasyStage形式に変換:', fantasyStage);
@@ -391,7 +391,7 @@ const FantasyMain: React.FC = () => {
         simultaneousMonsterCount: nextStageData.simultaneous_monster_count || 1,
         bpm: nextStageData.bpm || 120,
         measureCount: nextStageData.measure_count,
-        countInMeasures: nextStageData.count_in_measures,
+                      countInMeasures: 0,
         timeSignature: nextStageData.time_signature
       };
 

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -169,7 +169,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         simultaneousMonsterCount: stage.simultaneous_monster_count || 1,
         bpm: stage.bpm || 120,
         measureCount: stage.measure_count,
-        countInMeasures: stage.count_in_measures,
+                      countInMeasures: 0,
         timeSignature: stage.time_signature
       }));
       

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -11,19 +11,15 @@ interface TimeState {
   bpm: number
   /* 全小節数(ループ終端) */
   measureCount: number
-  /* イントロ/カウントイン小節数(Ready → Start 迄) */
-  countInMeasures: number
+  /* カウントインという概念を排除したので不要 */
   /* 現在の拍(1-timeSignature) と小節(1-measureCount) */
   currentBeat: number
   currentMeasure: number
-  /* カウントイン中かどうか */
-  isCountIn: boolean
   /* setter 群 */
   setStart: (
     bpm: number,
     ts: number,
     measure: number,
-    countIn: number,
     now?: number
   ) => void
   tick: () => void
@@ -35,20 +31,17 @@ export const useTimeStore = create<TimeState>((set, get) => ({
   timeSignature: 4,
   bpm: 120,
   measureCount: 8,
-  countInMeasures: 0,
+  /* 削除 */
   currentBeat: 1,
   currentMeasure: 1,
-  isCountIn: false,
-  setStart: (bpm, ts, mc, ci, now = performance.now()) =>
+  setStart: (bpm, ts, mc, now = performance.now()) =>
     set({
       startAt: now,
       bpm,
       timeSignature: ts,
       measureCount: mc,
-      countInMeasures: ci,
       currentBeat: 1,
-      currentMeasure: 1,
-      isCountIn: false
+      currentMeasure: 1
     }),
   tick: () => {
     const s = get()
@@ -59,8 +52,7 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     if (elapsed < s.readyDuration) {
       set({
         currentBeat: 1,
-        currentMeasure: 1,
-        isCountIn: false // Ready中はカウントインでもない
+        currentMeasure: 1
       })
       return
     }
@@ -73,24 +65,12 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     const totalMeasures = Math.floor(beatsFromStart / s.timeSignature)
     const currentBeatInMeasure = (beatsFromStart % s.timeSignature) + 1
     
-    /* カウントイン中かどうかを判定 */
-    if (totalMeasures < s.countInMeasures) {
-      // カウントイン中
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: -(s.countInMeasures - totalMeasures), // 負の値でカウントイン表示
-        isCountIn: true
-      })
-    } else {
-      // メイン部分（カウントイン後）
-      const measuresAfterCountIn = totalMeasures - s.countInMeasures
-      const displayMeasure = (measuresAfterCountIn % s.measureCount) + 1
-      
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: displayMeasure, // カウントイン後を1から表示
-        isCountIn: false
-      })
-    }
+    /* Ready が終わったらただ回すだけ */
+    const displayMeasure = (totalMeasures % s.measureCount) + 1
+    
+    set({
+      currentBeat: currentBeatInMeasure,
+      currentMeasure: displayMeasure
+    })
   }
 }))

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -41,8 +41,8 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    this.loopBegin = countIn * secPerMeas
-    this.loopEnd = (countIn + measureCount) * secPerMeas
+    this.loopBegin = 0                        // 0 秒からループ
+    this.loopEnd = measureCount * secPerMeas
 
     // 初回再生は最初から（カウントインを含む）
     this.audio.currentTime = 0
@@ -162,10 +162,9 @@ class BGMManager {
     if (!this.isPlaying || !this.audio) return 0
     
     const audioTime = this.audio.currentTime
-    const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
     
     // カウントイン後の時間を返す（カウントイン中は負の値）
-    return audioTime - countInDuration
+    return audioTime
   }
   
   /**
@@ -217,10 +216,9 @@ class BGMManager {
   getMusicTimeAt(measure: number, beat: number): number {
     const secPerBeat = 60 / this.bpm
     const secPerMeasure = secPerBeat * this.timeSignature
-    const countInDuration = this.countInMeasures * secPerMeasure
     
-    // カウントイン + 指定小節までの時間 + 拍の時間
-    return countInDuration + (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
+    // 指定小節までの時間 + 拍の時間
+    return (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
   }
   
   /**


### PR DESCRIPTION
Eliminate the "count-in" measure concept to fix various timing, looping, and display bugs.

This change resolves issues such as the first note appearing on M2 instead of M1, judgment failures on looped M1, abnormal enemy gauge increases, missing attack/anger icons, and notes sometimes not flowing after retries.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdad1a5e-a655-4271-af46-81bc5cb6137b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fdad1a5e-a655-4271-af46-81bc5cb6137b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>