### PR TITLE
Fix taiko mode bugs and improve loop handling

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -829,7 +829,7 @@ export const useFantasyGameEngine = ({
         stage.bpm || 120,
         stage.timeSignature || 4, // デフォルトは4/4拍子
         stage.measureCount ?? 8,
-        stage.countInMeasures ?? 0
+        0 // 変更: countInを常に0に
       );
 
     devLog.debug('✅ ゲーム初期化完了:', {
@@ -1048,6 +1048,14 @@ export const useFantasyGameEngine = ({
         const loopDuration = (prevState.currentStage.measureCount || 8) * 
                             (60 / (prevState.currentStage.bpm || 120)) * 
                             (prevState.currentStage.timeSignature || 4);
+        
+        // ループ境界検知（ループ終端近くでゲージリセット）
+        if (currentTime > loopDuration - 0.1) {
+          return {
+            ...prevState,
+            activeMonsters: prevState.activeMonsters.map(m => ({ ...m, gauge: 0 }))
+          };
+        }
         
         // 現在のノーツインデックスの検証
         let currentNoteIndex = prevState.currentNoteIndex;

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1675,6 +1675,15 @@ export class FantasyPIXIInstance {
             }
           }
           
+          // エフェクト: 赤い輪郭
+          if (!monsterData.outline) {
+            const outline = new PIXI.Graphics();
+            outline.lineStyle(4, 0xFF0000, 1);
+            outline.drawCircle(0, 0, 60);
+            monsterData.outline = outline;
+            sprite.addChild(outline);
+          }
+          
           // パルスアニメーション（怒りの脈動）
           const pulse = Math.sin(Date.now() * 0.005) * 0.05 + 1;
           sprite.scale.set(visualState.scale * pulse);
@@ -1695,6 +1704,11 @@ export class FantasyPIXIInstance {
             sprite.removeChild(monsterData.angerMark);
             monsterData.angerMark.destroy();
             monsterData.angerMark = undefined;
+          }
+          if (monsterData.outline) {
+            sprite.removeChild(monsterData.outline);
+            monsterData.outline.destroy();
+            monsterData.outline = undefined;
           }
         }
         

--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -69,8 +69,8 @@ export function judgeTimingWindow(
 }
 
 /**
- * 基本版progression用：小節の頭(Beat 1)でコードを配置
- * カウントインを考慮して正しいタイミングを計算
+ * Basic版：chord_progressionをparseして、各小節冒頭に1つずつノーツを配置
+ * カウントインを考慮（カウントイン後の最初の小節を1とする）
  * @param chordProgression コード進行配列
  * @param measureCount 総小節数
  * @param bpm BPM
@@ -84,7 +84,7 @@ export function generateBasicProgressionNotes(
   bpm: number,
   timeSignature: number,
   getChordDefinition: (chordId: string) => ChordDefinition | null,
-  countInMeasures: number = 0
+  countInMeasures: number = 0 // 無視
 ): TaikoNote[] {
   // 入力検証
   if (!chordProgression || chordProgression.length === 0) {
@@ -105,23 +105,21 @@ export function generateBasicProgressionNotes(
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
-  const countInDuration = countInMeasures * secPerMeasure; // カウントインの総時間
   
-  // カウントイン後の小節のみでノーツを生成
-  for (let measure = 1; measure <= measureCount; measure++) {
-    const chordIndex = (measure - 1) % chordProgression.length;
+  // M2から出題（M1は空）
+  for (let measure = 2; measure <= measureCount; measure++) { // 変更: measure=2から開始
+    const chordIndex = (measure - 2) % chordProgression.length; // 変更: indexを調整
     const chordId = chordProgression[chordIndex];
     const chord = getChordDefinition(chordId);
     
     if (chord) {
-      // カウントイン時間を加算して実際のヒットタイミングを計算
-      const hitTime = countInDuration + (measure - 1) * secPerMeasure;
+      const hitTime = (measure - 1) * secPerMeasure; // M1=0s, M2=secPerMeasure
       
       notes.push({
         id: `note_${measure}_1`,
         chord,
         hitTime,
-        measure, // 表示用の小節番号（カウントイン後を1とする）
+        measure, // 表示用の小節番号
         beat: 1,
         isHit: false,
         isMissed: false
@@ -146,18 +144,20 @@ export function parseChordProgressionData(
   bpm: number,
   timeSignature: number,
   getChordDefinition: (chordId: string) => ChordDefinition | null,
-  countInMeasures: number = 0
+  countInMeasures: number = 0 // 無視
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
-  const countInDuration = countInMeasures * secPerMeasure;
   
   progressionData.forEach((item, index) => {
+    // M1をスキップ（M2から出題）
+    if (item.bar === 1) return; // 変更: bar=1の場合はスキップ
+    
     const chord = getChordDefinition(item.chord);
     if (chord) {
-      // カウントイン時間を加算
-      const hitTime = countInDuration + (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
+      // カウントインなし
+      const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
       
       notes.push({
         id: `note_${item.bar}_${item.beats}_${index}`,

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -32,7 +32,7 @@ class BGMManager {
     this.bpm = bpm
     this.timeSignature = timeSig
     this.measureCount = measureCount
-    this.countInMeasures = countIn
+    this.countInMeasures = 0 // 変更: カウントインを無視
     
     this.audio = new Audio(url)
     this.audio.preload = 'auto'
@@ -41,8 +41,8 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    this.loopBegin = countIn * secPerMeas
-    this.loopEnd = (countIn + measureCount) * secPerMeas
+    this.loopBegin = 0 // 変更: カウントインなし
+    this.loopEnd = measureCount * secPerMeas
 
     // 初回再生は最初から（カウントインを含む）
     this.audio.currentTime = 0
@@ -161,11 +161,7 @@ class BGMManager {
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
     
-    const audioTime = this.audio.currentTime
-    const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
-    
-    // カウントイン後の時間を返す（カウントイン中は負の値）
-    return audioTime - countInDuration
+    return this.audio.currentTime // 変更: カウントイン調整なし
   }
   
   /**
@@ -174,7 +170,6 @@ class BGMManager {
    */
   getCurrentMeasure(): number {
     const musicTime = this.getCurrentMusicTime()
-    if (musicTime < 0) return 0 // カウントイン中
     
     const secPerMeasure = (60 / this.bpm) * this.timeSignature
     const measure = Math.floor(musicTime / secPerMeasure) + 1
@@ -217,10 +212,9 @@ class BGMManager {
   getMusicTimeAt(measure: number, beat: number): number {
     const secPerBeat = 60 / this.bpm
     const secPerMeasure = secPerBeat * this.timeSignature
-    const countInDuration = this.countInMeasures * secPerMeasure
     
-    // カウントイン + 指定小節までの時間 + 拍の時間
-    return countInDuration + (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
+    // 指定小節までの時間 + 拍の時間（カウントインなし）
+    return (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
   }
   
   /**


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Removes count-in, adjusts note timing to M2, and enhances enemy rage effects to fix loop-related bugs and improve game flow.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous count-in logic caused inconsistencies in note generation and loop boundaries, leading to multi-hits and invalid judgments. By eliminating the count-in and shifting the first note to M2, the loop behavior is simplified and stabilized. Additionally, visual feedback for enraged enemies is improved.

---
<a href="https://cursor.com/background-agent?bcId=bc-051e2044-2270-48f3-88b5-9d6db6a99122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-051e2044-2270-48f3-88b5-9d6db6a99122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>