### PR TITLE
Fix taiko mode bugs and improve loop handling

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -829,7 +829,7 @@ export const useFantasyGameEngine = ({
         stage.bpm || 120,
         stage.timeSignature || 4, // デフォルトは4/4拍子
         stage.measureCount ?? 8,
-        stage.countInMeasures ?? 0
+        0 // 変更: countInを常に0に
       );
 
     devLog.debug('✅ ゲーム初期化完了:', {
@@ -1048,6 +1048,14 @@ export const useFantasyGameEngine = ({
         const loopDuration = (prevState.currentStage.measureCount || 8) * 
                             (60 / (prevState.currentStage.bpm || 120)) * 
                             (prevState.currentStage.timeSignature || 4);
+        
+        // ループ境界検知（ループ終端近くでゲージリセット）
+        if (currentTime > loopDuration - 0.1) {
+          return {
+            ...prevState,
+            activeMonsters: prevState.activeMonsters.map(m => ({ ...m, gauge: 0 }))
+          };
+        }
         
         // 現在のノーツインデックスの検証
         let currentNoteIndex = prevState.currentNoteIndex;

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1642,6 +1642,15 @@ export class FantasyPIXIInstance {
           visualState.scale = baseScale * 1.25; // 巨大化（25%増し）
           sprite.tint = 0xFFCCCC;
           
+          // 怒りエフェクト: 赤い輪郭
+          if (!monsterData.outline) {
+            const outline = new PIXI.Graphics();
+            outline.lineStyle(4, 0xFF0000, 1);
+            outline.drawCircle(0, 0, 60);
+            sprite.addChildAt(outline, 0); // 背面に追加
+            monsterData.outline = outline;
+          }
+          
           // 怒りマークを追加（まだない場合）
           if (!monsterData.angerMark) {
             const angerTexture = this.imageTextures.get('angerMark');
@@ -1691,6 +1700,11 @@ export class FantasyPIXIInstance {
           sprite.tint = gameState.isHit ? gameState.hitColor : 0xFFFFFF;
           
           // 怒りエフェクトを削除
+          if (monsterData.outline) {
+            sprite.removeChild(monsterData.outline);
+            monsterData.outline.destroy();
+            monsterData.outline = undefined;
+          }
           if (monsterData.angerMark) {
             sprite.removeChild(monsterData.angerMark);
             monsterData.angerMark.destroy();

--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -84,7 +84,7 @@ export function generateBasicProgressionNotes(
   bpm: number,
   timeSignature: number,
   getChordDefinition: (chordId: string) => ChordDefinition | null,
-  countInMeasures: number = 0
+  countInMeasures: number = 0 // 無視
 ): TaikoNote[] {
   // 入力検証
   if (!chordProgression || chordProgression.length === 0) {
@@ -105,23 +105,21 @@ export function generateBasicProgressionNotes(
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
-  const countInDuration = countInMeasures * secPerMeasure; // カウントインの総時間
   
-  // カウントイン後の小節のみでノーツを生成
-  for (let measure = 1; measure <= measureCount; measure++) {
-    const chordIndex = (measure - 1) % chordProgression.length;
+  // M2から出題（M1は空）
+  for (let measure = 2; measure <= measureCount; measure++) { // 変更: measure=2から開始
+    const chordIndex = (measure - 2) % chordProgression.length; // 変更: indexを調整
     const chordId = chordProgression[chordIndex];
     const chord = getChordDefinition(chordId);
     
     if (chord) {
-      // カウントイン時間を加算して実際のヒットタイミングを計算
-      const hitTime = countInDuration + (measure - 1) * secPerMeasure;
+      const hitTime = (measure - 1) * secPerMeasure; // M1=0s, M2=secPerMeasure
       
       notes.push({
         id: `note_${measure}_1`,
         chord,
         hitTime,
-        measure, // 表示用の小節番号（カウントイン後を1とする）
+        measure, // 表示用の小節番号
         beat: 1,
         isHit: false,
         isMissed: false
@@ -146,18 +144,20 @@ export function parseChordProgressionData(
   bpm: number,
   timeSignature: number,
   getChordDefinition: (chordId: string) => ChordDefinition | null,
-  countInMeasures: number = 0
+  countInMeasures: number = 0 // 無視
 ): TaikoNote[] {
   const notes: TaikoNote[] = [];
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
-  const countInDuration = countInMeasures * secPerMeasure;
   
   progressionData.forEach((item, index) => {
+    // M1はスキップ（休み）
+    if (item.bar === 1) return; // 変更: M1をスキップ
+    
     const chord = getChordDefinition(item.chord);
     if (chord) {
-      // カウントイン時間を加算
-      const hitTime = countInDuration + (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
+      // カウントインなしで直接計算
+      const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
       
       notes.push({
         id: `note_${item.bar}_${item.beats}_${index}`,

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 interface TimeState {
   /* ゲーム開始＝モンスター描画完了時刻 (ms) */
   startAt: number | null
-  /* Ready フェーズ長(ms) – デフォルト 2 秒 */
+  /* Ready フェーズ長(ms) – デフォルト 0 秒（カウントインなし） */
   readyDuration: number
   /* 拍子(4=4/4, 3/4 なら 3) */
   timeSignature: number
@@ -11,12 +11,12 @@ interface TimeState {
   bpm: number
   /* 全小節数(ループ終端) */
   measureCount: number
-  /* イントロ/カウントイン小節数(Ready → Start 迄) */
+  /* イントロ/カウントイン小節数(Ready → Start 迄) - 常に0 */
   countInMeasures: number
   /* 現在の拍(1-timeSignature) と小節(1-measureCount) */
   currentBeat: number
   currentMeasure: number
-  /* カウントイン中かどうか */
+  /* カウントイン中かどうか - 常にfalse */
   isCountIn: boolean
   /* setter 群 */
   setStart: (
@@ -31,21 +31,21 @@ interface TimeState {
 
 export const useTimeStore = create<TimeState>((set, get) => ({
   startAt: null,
-  readyDuration: 2000,
+  readyDuration: 0, // 変更: カウントインを排除
   timeSignature: 4,
   bpm: 120,
   measureCount: 8,
-  countInMeasures: 0,
+  countInMeasures: 0, // 変更: 常に0
   currentBeat: 1,
   currentMeasure: 1,
-  isCountIn: false,
+  isCountIn: false, // 変更: 常にfalse
   setStart: (bpm, ts, mc, ci, now = performance.now()) =>
     set({
       startAt: now,
       bpm,
       timeSignature: ts,
       measureCount: mc,
-      countInMeasures: ci,
+      countInMeasures: 0, // 変更: countInを無視
       currentBeat: 1,
       currentMeasure: 1,
       isCountIn: false
@@ -55,42 +55,21 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     if (s.startAt === null) return
     const elapsed = performance.now() - s.startAt
 
-    /* Ready 中は beat/measure を初期値に固定 */
-    if (elapsed < s.readyDuration) {
-      set({
-        currentBeat: 1,
-        currentMeasure: 1,
-        isCountIn: false // Ready中はカウントインでもない
-      })
-      return
-    }
+    // Ready中処理を削除（即座にメイン開始）
 
     const msecPerBeat = 60000 / s.bpm
-    const beatsFromStart = Math.floor(
-      (elapsed - s.readyDuration) / msecPerBeat
-    )
+    const beatsFromStart = Math.floor(elapsed / msecPerBeat)
 
     const totalMeasures = Math.floor(beatsFromStart / s.timeSignature)
     const currentBeatInMeasure = (beatsFromStart % s.timeSignature) + 1
-    
-    /* カウントイン中かどうかを判定 */
-    if (totalMeasures < s.countInMeasures) {
-      // カウントイン中
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: -(s.countInMeasures - totalMeasures), // 負の値でカウントイン表示
-        isCountIn: true
-      })
-    } else {
-      // メイン部分（カウントイン後）
-      const measuresAfterCountIn = totalMeasures - s.countInMeasures
-      const displayMeasure = (measuresAfterCountIn % s.measureCount) + 1
-      
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: displayMeasure, // カウントイン後を1から表示
-        isCountIn: false
-      })
-    }
+
+    // カウントインなしで直接メイン小節を計算（M1から開始）
+    const displayMeasure = (totalMeasures % s.measureCount) + 1
+
+    set({
+      currentBeat: currentBeatInMeasure,
+      currentMeasure: displayMeasure,
+      isCountIn: false
+    })
   }
 }))

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -32,7 +32,7 @@ class BGMManager {
     this.bpm = bpm
     this.timeSignature = timeSig
     this.measureCount = measureCount
-    this.countInMeasures = countIn
+    this.countInMeasures = 0 // 変更: カウントインを無視
     
     this.audio = new Audio(url)
     this.audio.preload = 'auto'
@@ -41,8 +41,8 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    this.loopBegin = countIn * secPerMeas
-    this.loopEnd = (countIn + measureCount) * secPerMeas
+    this.loopBegin = 0 // 変更: カウントインなし
+    this.loopEnd = measureCount * secPerMeas
 
     // 初回再生は最初から（カウントインを含む）
     this.audio.currentTime = 0
@@ -161,11 +161,7 @@ class BGMManager {
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
     
-    const audioTime = this.audio.currentTime
-    const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
-    
-    // カウントイン後の時間を返す（カウントイン中は負の値）
-    return audioTime - countInDuration
+    return this.audio.currentTime // 変更: カウントイン調整なし
   }
   
   /**


### PR DESCRIPTION
Fix game loop and note timing issues by removing count-in and adjusting note generation.

This PR addresses several bugs including multi-hits during loops, invalid judgments, and notes not appearing on retry. It achieves this by eliminating the count-in period, ensuring notes consistently start from the second measure (M2), and implementing proper gauge resets at loop boundaries, leading to a smoother and more predictable gameplay experience. Additionally, it enhances the visual feedback for enraged monsters.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e8912be-ca0f-4b4f-b8b0-8e2b5b587376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e8912be-ca0f-4b4f-b8b0-8e2b5b587376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>