### PR TITLE
Changes from background agent bc-687f136c-15c1-4efd-8d96-0d316b77b43d

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -438,12 +438,20 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理開始');
       
-      const firstNote = prevState.taikoNotes[0];
-      const nextNote = prevState.taikoNotes.length > 1 ? prevState.taikoNotes[1] : firstNote;
+      // ノーツのヒット状態をリセット
+      const resetNotes = prevState.taikoNotes.map(n => ({
+        ...n,
+        isHit: false,
+        isMissed: false
+      }));
+      
+      const firstNote = resetNotes[0];
+      const nextNote = resetNotes.length > 1 ? resetNotes[1] : firstNote;
       
       return {
         ...prevState,
         currentNoteIndex: 0,
+        taikoNotes: resetNotes,
         activeMonsters: prevState.activeMonsters.map(m => ({
           ...m,
           correctNotes: [],
@@ -510,16 +518,24 @@ export const useFantasyGameEngine = ({
       });
       
       // 次のノーツインデックス
-      const nextNoteIndex = prevState.currentNoteIndex + 1;
+      let nextNoteIndex = prevState.currentNoteIndex + 1;
+      let updatedTaikoNotes = prevState.taikoNotes;
+      
+      // ループ処理: 最後のノーツを完了した場合
+      if (nextNoteIndex >= prevState.taikoNotes.length) {
+        nextNoteIndex = 0;
+        // ノーツのヒット状態をリセット
+        updatedTaikoNotes = prevState.taikoNotes.map(n => ({
+          ...n,
+          isHit: false,
+          isMissed: false
+        }));
+      }
       
       // 次のノーツ情報（ループ対応）
-      const nextNote = nextNoteIndex < prevState.taikoNotes.length 
-        ? prevState.taikoNotes[nextNoteIndex]
-        : prevState.taikoNotes[0];
-      
-      const nextNextNote = nextNoteIndex + 1 < prevState.taikoNotes.length
-        ? prevState.taikoNotes[nextNoteIndex + 1]
-        : prevState.taikoNotes[(nextNoteIndex < prevState.taikoNotes.length) ? 1 : 0];
+      const nextNote = updatedTaikoNotes[nextNoteIndex];
+      const nextNextIndex = (nextNoteIndex + 1) % updatedTaikoNotes.length;
+      const nextNextNote = updatedTaikoNotes[nextNextIndex];
       
       // ダメージ計算
       const stage = prevState.currentStage!;
@@ -601,6 +617,7 @@ export const useFantasyGameEngine = ({
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
           currentNoteIndex: nextNoteIndex,
+          taikoNotes: updatedTaikoNotes,
           correctAnswers: prevState.correctAnswers + 1,
           score: prevState.score + 100 * actualDamage,
           enemiesDefeated: newEnemiesDefeated
@@ -612,6 +629,7 @@ export const useFantasyGameEngine = ({
         activeMonsters: updatedMonsters,
         playerSp: newSp,
         currentNoteIndex: nextNoteIndex,
+        taikoNotes: updatedTaikoNotes,
         correctAnswers: prevState.correctAnswers + 1,
         score: prevState.score + 100 * actualDamage
       };
@@ -751,7 +769,8 @@ export const useFantasyGameEngine = ({
           stage.bpm || 120,
           stage.timeSignature || 4,
           (chordId) => getChordDefinition(chordId, displayOpts),
-          stage.countInMeasures || 0 // カウントインを渡す
+          stage.countInMeasures || 0, // カウントインを渡す
+          stage.measureCount || 8 // 小節数を渡す
         );
       } else if (stage.chordProgression) {
         // 基本版：小節の頭でコード出題

--- a/src/stores/timeStore.ts
+++ b/src/stores/timeStore.ts
@@ -11,12 +11,12 @@ interface TimeState {
   bpm: number
   /* 全小節数(ループ終端) */
   measureCount: number
-  /* イントロ/カウントイン小節数(Ready → Start 迄) */
+  /* イントロ/カウントイン小節数(互換性のため残すが使用しない) */
   countInMeasures: number
   /* 現在の拍(1-timeSignature) と小節(1-measureCount) */
   currentBeat: number
   currentMeasure: number
-  /* カウントイン中かどうか */
+  /* カウントイン中かどうか（常にfalse） */
   isCountIn: boolean
   /* setter 群 */
   setStart: (
@@ -45,7 +45,7 @@ export const useTimeStore = create<TimeState>((set, get) => ({
       bpm,
       timeSignature: ts,
       measureCount: mc,
-      countInMeasures: ci,
+      countInMeasures: 0, // カウントインは常に0として扱う
       currentBeat: 1,
       currentMeasure: 1,
       isCountIn: false
@@ -60,7 +60,7 @@ export const useTimeStore = create<TimeState>((set, get) => ({
       set({
         currentBeat: 1,
         currentMeasure: 1,
-        isCountIn: false // Ready中はカウントインでもない
+        isCountIn: false
       })
       return
     }
@@ -73,24 +73,13 @@ export const useTimeStore = create<TimeState>((set, get) => ({
     const totalMeasures = Math.floor(beatsFromStart / s.timeSignature)
     const currentBeatInMeasure = (beatsFromStart % s.timeSignature) + 1
     
-    /* カウントイン中かどうかを判定 */
-    if (totalMeasures < s.countInMeasures) {
-      // カウントイン中
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: -(s.countInMeasures - totalMeasures), // 負の値でカウントイン表示
-        isCountIn: true
-      })
-    } else {
-      // メイン部分（カウントイン後）
-      const measuresAfterCountIn = totalMeasures - s.countInMeasures
-      const displayMeasure = (measuresAfterCountIn % s.measureCount) + 1
-      
-      set({
-        currentBeat: currentBeatInMeasure,
-        currentMeasure: displayMeasure, // カウントイン後を1から表示
-        isCountIn: false
-      })
-    }
+    // カウントインなしで直接メイン部分
+    const displayMeasure = (totalMeasures % s.measureCount) + 1
+    
+    set({
+      currentBeat: currentBeatInMeasure,
+      currentMeasure: displayMeasure,
+      isCountIn: false
+    })
   }
 }))

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -41,10 +41,11 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    this.loopBegin = countIn * secPerMeas
-    this.loopEnd = (countIn + measureCount) * secPerMeas
+    // カウントインは無視し、常に0から全長までループ
+    this.loopBegin = 0
+    this.loopEnd = measureCount * secPerMeas
 
-    // 初回再生は最初から（カウントインを含む）
+    // 初回再生は最初から
     this.audio.currentTime = 0
     
     // エラーハンドリング
@@ -156,26 +157,21 @@ class BGMManager {
   
   /**
    * 現在の音楽的時間を取得（秒単位）
-   * カウントイン終了時を0秒とする
+   * BGM開始時を0秒とする（カウントインの概念を排除）
    */
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
     
-    const audioTime = this.audio.currentTime
-    const countInDuration = this.countInMeasures * (60 / this.bpm) * this.timeSignature
-    
-    // カウントイン後の時間を返す（カウントイン中は負の値）
-    return audioTime - countInDuration
+    // そのままのオーディオ時間を返す
+    return this.audio.currentTime
   }
   
   /**
    * 現在の小節番号を取得（1始まり）
-   * カウントイン中は0を返す
+   * ループを考慮した実際の小節番号
    */
   getCurrentMeasure(): number {
     const musicTime = this.getCurrentMusicTime()
-    if (musicTime < 0) return 0 // カウントイン中
-    
     const secPerMeasure = (60 / this.bpm) * this.timeSignature
     const measure = Math.floor(musicTime / secPerMeasure) + 1
     


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor Fantasy mode timing and loop logic to fix count-in, multi-hit, and retry issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, Fantasy mode suffered from misaligned note timing due to count-in, multi-hits and invalid judgments during song loops, and notes failing to appear on retry. This PR resolves these by eliminating the count-in concept, making the first and last measures rest periods, centralizing loop management in `BGMManager`, and ensuring proper game engine re-initialization on retry.

---
<a href="https://cursor.com/background-agent?bcId=bc-687f136c-15c1-4efd-8d96-0d316b77b43d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-687f136c-15c1-4efd-8d96-0d316b77b43d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>