### PR TITLE
Synchronize bgm loop with game progression

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -437,6 +437,9 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理（input時）');
       
+      // ★ 追加: BGMをリセット
+      bgmManager.resetToStart();
+      
       // 全てのノーツのisHit/isMissedをリセット
       const resetNotes = prevState.taikoNotes.map(note => ({
         ...note,
@@ -1068,6 +1071,9 @@ export const useFantasyGameEngine = ({
             isHit: false,
             isMissed: false
           }));
+          
+          // ★ 追加: BGMをリセット
+          bgmManager.resetToStart();
           
           devLog.debug('🔄 太鼓の達人：ループ処理（tick）');
           

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -125,6 +125,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         0,
         settings.bgmVolume ?? 0.7
       );
+      
+      // ★ 追加: 初期化時にBGMを確実に0秒からスタート
+      bgmManager.resetToStart();
     }
     return () => bgmManager.stop();
   }, [isReady, stage, settings.bgmVolume]);

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -281,6 +281,21 @@ class BGMManager {
   getIsCountIn(): boolean {
     return false
   }
+  
+  /**
+   * BGMを即座に開始地点（0秒）にリセット
+   * ゲームの小節ループと同期するために使用
+   */
+  resetToStart() {
+    if (!this.audio || !this.isPlaying) return;
+    
+    try {
+      this.audio.currentTime = 0;
+      console.log('🔄 BGMを0秒にリセット');
+    } catch (error) {
+      console.warn('BGMリセットエラー:', error);
+    }
+  }
 }
 
 export const bgmManager = new BGMManager()


### PR DESCRIPTION
Synchronize BGM loop with game progression in Fantasy Mode by resetting BGM to start when game measures loop.

Previously, BGM looped independently of the game's measure progression, leading to audio desynchronization (e.g., game at M1 while BGM was mid-song). This fix ensures BGM restarts precisely when the game's measures loop back to the beginning.

---
<a href="https://cursor.com/background-agent?bcId=bc-39819664-5b20-41c8-b7d4-c57838765180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39819664-5b20-41c8-b7d4-c57838765180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>