### PR TITLE
Fix music loop time reset

### DIFF
--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -13,6 +13,7 @@ class BGMManager {
   private loopScheduled = false
   private nextLoopTime = 0
   private loopTimeoutId: number | null = null // タイムアウトIDを保持
+  private monitorId: number | null = null // requestAnimationFrame ID
 
   play(
     url: string,
@@ -65,6 +66,8 @@ class BGMManager {
         this.loopTimeoutId = window.setTimeout(() => {
           if (this.audio && this.isPlaying) {
             this.audio.currentTime = this.nextLoopTime
+            // ループした瞬間のデバイス時刻を取り直す
+            this.startTime = performance.now()
             console.log(`🔄 BGM Loop (scheduled): → ${this.nextLoopTime.toFixed(2)}s`)
           }
           this.loopScheduled = false
@@ -85,6 +88,8 @@ class BGMManager {
       playPromise
         .then(() => {
           console.log('🎵 BGM再生開始:', { url, bpm, loopBegin: this.loopBegin, loopEnd: this.loopEnd })
+          // requestAnimationFrameによるループ監視を開始（iOS/Safari対策）
+          this.monitorId = requestAnimationFrame(this.monitorLoop)
         })
         .catch((error) => {
           console.warn('BGM playback failed:', error)
@@ -107,6 +112,12 @@ class BGMManager {
     if (this.loopTimeoutId !== null) {
       clearTimeout(this.loopTimeoutId)
       this.loopTimeoutId = null
+    }
+    
+    // requestAnimationFrameのクリア
+    if (this.monitorId !== null) {
+      cancelAnimationFrame(this.monitorId)
+      this.monitorId = null
     }
     
     if (this.audio) {
@@ -146,6 +157,8 @@ class BGMManager {
   private handleEnded = () => {
     if (this.loopEnd > 0) {
       this.audio!.currentTime = this.loopBegin
+      // ループした瞬間のデバイス時刻を取り直す
+      this.startTime = performance.now()
       this.audio!.play().catch(console.error)
     }
   }
@@ -280,6 +293,30 @@ class BGMManager {
    */
   getIsCountIn(): boolean {
     return false
+  }
+  
+  /**
+   * requestAnimationFrameによるループ監視（iOS/Safari対策）
+   * timeupdateイベントの精度が低い環境でも確実にループさせる
+   */
+  private monitorLoop = () => {
+    if (this.audio && this.isPlaying) {
+      const currentTime = this.audio.currentTime
+      const timeToEnd = this.loopEnd - currentTime
+      
+      // ループエンドから30ms以内になったらループ実行
+      if (timeToEnd < 0.03 && timeToEnd > -0.03) {
+        if (!this.loopScheduled) {
+          this.audio.currentTime = this.loopBegin
+          // ループした瞬間のデバイス時刻を取り直す
+          this.startTime = performance.now()
+          console.log(`🔄 BGM Loop (monitor): ${currentTime.toFixed(2)}s → ${this.loopBegin.toFixed(2)}s`)
+        }
+      }
+      
+      // 継続監視
+      this.monitorId = requestAnimationFrame(this.monitorLoop)
+    }
   }
 }
 


### PR DESCRIPTION
Update BGM `startTime` on loop and add `requestAnimationFrame` monitoring to fix UI time display and improve loop accuracy.

Previously, `startTime` was not reset when BGM looped, causing UI elements (like measure/beat displays) to continue advancing based on an old `startTime`. This PR synchronizes `startTime` with the audio loop and adds a `requestAnimationFrame`-based monitor for more reliable loop handling, especially on iOS/Safari where `timeupdate` events can be imprecise.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea5d2ddd-f9d4-4f7b-8122-7e42225cc916">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea5d2ddd-f9d4-4f7b-8122-7e42225cc916">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>