### PR TITLE
Expand fantasy stage modes with new progressions

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -42,15 +42,6 @@ import { FantasyStageMode } from '../../types';
 
 // ===== 型定義 =====
 
-interface ChordDefinition {
-  id: string;          // コードのID（例: 'CM7', 'G7', 'Am'）
-  displayName: string; // 表示名（言語・簡易化設定に応じて変更）
-  notes: number[];     // MIDIノート番号の配列
-  noteNames: string[]; // ★ 理論的に正しい音名配列を追加
-  quality: string;     // コードの性質（'major', 'minor', 'dominant7'など）
-  root: string;        // ルート音（例: 'C', 'G', 'A'）
-}
-
 interface FantasyStage {
   id: string;
   stageNumber: string;

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -20,6 +20,25 @@ import {
   parseSimpleProgressionText
 } from './TaikoNoteSystem';
 import { bgmManager } from '@/utils/BGMManager';
+import {
+  ChordDefinition,
+  getChordAlt,
+  transposeChord,
+  ChordOptions,
+  getChordDisplayInfo,
+  DegreeDisplayOptions,
+  applyDefaultChordOptions,
+  ChordDisplayInfo,
+  ChordCheckResult
+} from '../../services/chordHelpers';
+import { soundEngine } from '../../services/sound';
+import {
+  FantasyMonster,
+  FantasyGameAction,
+  FantasyActionType,
+  DisplayOpts
+} from './types';
+import { FantasyStageMode } from '../../types';
 
 // ===== 型定義 =====
 
@@ -43,7 +62,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: FantasyStageMode;
   allowedChords: string[];
   chordProgression?: string[];
   chordProgressionData?: any; // 拡張版progression用のJSONデータ
@@ -106,6 +125,8 @@ interface FantasyGameState {
   isTaikoMode: boolean; // 太鼓の達人モードかどうか
   taikoNotes: any[]; // 太鼓の達人用のノーツ配列
   currentNoteIndex: number; // 現在判定中のノーツインデックス
+  // progression_random用のシャッフル済み配列
+  shuffledProgression?: string[]; // progression_randomモード用のシャッフル済みコード進行
 }
 
 interface FantasyGameEngineProps {
@@ -364,6 +385,40 @@ const getProgressionChord = (progression: string[], questionIndex: number, displ
   
   const chordId = progression[questionIndex % progression.length];
   return getChordDefinition(chordId, displayOpts) || null;
+};
+
+/**
+ * ステージのモードに応じて次のコードを取得する統合関数
+ */
+const getNextChordForStage = (
+  stage: FantasyStage,
+  qIndex: number,
+  prevChordId?: string,
+  displayOpts?: DisplayOpts,
+  shuffledProgression?: string[]
+): ChordDefinition | null => {
+  // timing モードは TaikoNoteSystem が管理するのでここでは未使用
+  if (stage.mode === 'progression_timing') {
+    return null;
+  }
+  
+  if (stage.mode === 'progression_random') {
+    // ランダムモードの場合は、シャッフル済み配列から順番に取得
+    if (shuffledProgression && shuffledProgression.length > 0) {
+      return getProgressionChord(shuffledProgression, qIndex, displayOpts);
+    }
+    // フォールバック：シャッフル済み配列がない場合は通常のランダム選択
+    const chordsToUse = stage.chord_progression ?? stage.allowed_chords;
+    return selectRandomChord(chordsToUse, prevChordId, displayOpts);
+  }
+  
+  if (stage.mode === 'progression_order') {
+    // 順番固定モード
+    return getProgressionChord(stage.chord_progression ?? [], qIndex, displayOpts);
+  }
+  
+  // single モード
+  return selectRandomChord(stage.allowed_chords, prevChordId, displayOpts);
 };
 
 /**
@@ -660,7 +715,7 @@ export const useFantasyGameEngine = ({
     const totalEnemies = stage.enemyCount;
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
-    const simultaneousCount = stage.mode === 'progression' ? 1 : (stage.simultaneousMonsterCount || 1);
+    const simultaneousCount = (stage.mode === 'progression_order' || stage.mode === 'progression_random' || stage.mode === 'progression_timing') ? 1 : (stage.simultaneousMonsterCount || 1);
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -747,7 +802,7 @@ export const useFantasyGameEngine = ({
     const firstChord = firstMonster ? firstMonster.chordTarget : null;
 
     // 太鼓の達人モードの判定
-    const isTaikoMode = stage.mode === 'progression';
+    const isTaikoMode = stage.mode === 'progression_timing';
     let taikoNotes: TaikoNote[] = [];
     
     if (isTaikoMode) {
@@ -773,6 +828,7 @@ export const useFantasyGameEngine = ({
         );
       } else if (stage.chordProgression) {
         // 基本版：小節の頭でコード出題
+        // progression_timingモードの場合のみ基本タイムラインを生成
         taikoNotes = generateBasicProgressionNotes(
           stage.chordProgression,
           stage.measureCount || 8,
@@ -804,6 +860,21 @@ export const useFantasyGameEngine = ({
         firstNote: taikoNotes[0],
         lastNote: taikoNotes[taikoNotes.length - 1],
         notes: taikoNotes.map(n => ({ measure: n.measure, hitTime: n.hitTime }))
+      });
+    }
+
+    // progression_randomモード用のシャッフル処理
+    let shuffledProgression: string[] | undefined;
+    if (stage.mode === 'progression_random' && stage.chordProgression) {
+      // Fisher-Yatesシャッフルアルゴリズム
+      shuffledProgression = [...stage.chordProgression];
+      for (let i = shuffledProgression.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffledProgression[i], shuffledProgression[j]] = [shuffledProgression[j], shuffledProgression[i]];
+      }
+      devLog.debug('🔀 コード進行をシャッフル:', {
+        original: stage.chordProgression,
+        shuffled: shuffledProgression
       });
     }
 
@@ -839,7 +910,9 @@ export const useFantasyGameEngine = ({
       // 太鼓の達人モード用
       isTaikoMode,
       taikoNotes,
-      currentNoteIndex: 0  // 0から開始（ノーツ配列の最初がM2）
+      currentNoteIndex: 0,  // 0から開始（ノーツ配列の最初がM2）
+      // progression_random用
+      shuffledProgression
     };
 
     setGameState(newState);
@@ -878,16 +951,13 @@ export const useFantasyGameEngine = ({
       } else {
         // 各モンスターに新しいコードを割り当て
         const updatedMonsters = prevState.activeMonsters.map(monster => {
-          let nextChord;
-          if (prevState.currentStage?.mode === 'single') {
-            // ランダムモード：前回と異なるコードを選択
-            nextChord = selectRandomChord(prevState.currentStage.allowedChords, monster.chordTarget?.id, displayOpts);
-          } else {
-            // コード進行モード：ループさせる
-            const progression = prevState.currentStage?.chordProgression || [];
-            const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-            nextChord = getProgressionChord(progression, nextIndex, displayOpts);
-          }
+          const nextChord = getNextChordForStage(
+            prevState.currentStage!,
+            prevState.currentQuestionIndex + 1,
+            monster.chordTarget?.id,
+            displayOpts,
+            prevState.shuffledProgression
+          );
           
           return {
             ...monster,
@@ -981,17 +1051,13 @@ export const useFantasyGameEngine = ({
           return finalState;
         } else {
           // 次の問題（ループ対応）
-          let nextChord;
-          if (prevState.currentStage?.mode === 'single') {
-            // ランダムモード：前回と異なるコードを選択
-            const previousChordId = prevState.currentChordTarget?.id;
-            nextChord = selectRandomChord(prevState.currentStage.allowedChords, previousChordId, displayOpts);
-          } else {
-            // コード進行モード：ループさせる
-            const progression = prevState.currentStage?.chordProgression || [];
-            const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-            nextChord = getProgressionChord(progression, nextIndex, displayOpts);
-          }
+          const nextChord = getNextChordForStage(
+            prevState.currentStage!,
+            prevState.currentQuestionIndex + 1,
+            prevState.currentChordTarget?.id,
+            displayOpts,
+            prevState.shuffledProgression
+          );
           
           const nextState = {
             ...prevState,
@@ -1282,10 +1348,12 @@ export const useFantasyGameEngine = ({
         // 生き残ったモンスターのうち、今回攻撃したモンスターは問題をリセット
         remainingMonsters = remainingMonsters.map(monster => {
           if (completedMonsters.some(cm => cm.id === monster.id)) {
-            const nextChord = selectRandomChord(
-              stateAfterAttack.currentStage!.allowedChords,
+            const nextChord = getNextChordForStage(
+              stateAfterAttack.currentStage!,
+              stateAfterAttack.currentQuestionIndex,
               monster.chordTarget.id,
-              displayOpts
+              displayOpts,
+              stateAfterAttack.shuffledProgression
             );
             return { ...monster, chordTarget: nextChord!, correctNotes: [], gauge: 0 };
           }
@@ -1381,14 +1449,13 @@ export const useFantasyGameEngine = ({
       };
 
       // ★追加：次の問題もここで準備する
-      let nextChord;
-      if (prevState.currentStage?.mode === 'single') {
-        nextChord = selectRandomChord(prevState.currentStage.allowedChords, prevState.currentChordTarget?.id, displayOpts);
-      } else {
-        const progression = prevState.currentStage?.chordProgression || [];
-        const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-        nextChord = getProgressionChord(progression, nextIndex, displayOpts);
-      }
+      const nextChord = getNextChordForStage(
+        prevState.currentStage!,
+        prevState.currentQuestionIndex + 1,
+        prevState.currentChordTarget?.id,
+        displayOpts,
+        prevState.shuffledProgression
+      );
 
       nextState = {
         ...nextState,

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -994,7 +994,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         
         {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-        {stage.mode === 'progression' && getNextChord() && (
+        {(stage.mode === 'progression_order' || stage.mode === 'progression_random' || stage.mode === 'progression_timing') && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -11,7 +11,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useGameStore } from '@/stores/gameStore';
 import { devLog } from '@/utils/logger';
 import type { DisplayLang } from '@/utils/display-note';
-import { LessonContext } from '@/types';
+import { LessonContext, FantasyStageMode } from '@/types';
 import { fetchFantasyStageById } from '@/platform/supabaseFantasyStages';
 import { updateLessonRequirementProgress } from '@/platform/supabaseLessonRequirements';
 
@@ -381,7 +381,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression',
+                        mode: nextStageData.mode as FantasyStageMode,
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { cn } from '@/utils/cn';
 import { FantasyStage } from './FantasyGameEngine';
 import { devLog } from '@/utils/logger';
+import { FantasyStageMode } from '@/types';
 
 // ===== 型定義 =====
 
@@ -159,7 +160,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+                        mode: stage.mode as FantasyStageMode,
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -624,6 +624,12 @@ export interface ClearConditions {
 }
 
 // ファンタジーモード関連の型定義
+export type FantasyStageMode =
+  | 'single'
+  | 'progression_order'
+  | 'progression_random'
+  | 'progression_timing';
+
 export interface FantasyStage {
   id: string;
   stage_number: string;
@@ -635,7 +641,7 @@ export interface FantasyStage {
   enemy_hp: number;
   min_damage: number;
   max_damage: number;
-  mode: 'single' | 'progression';
+  mode: FantasyStageMode;
   allowed_chords: string[];
   chord_progression?: string[];
   show_sheet_music: boolean;

--- a/supabase/migrations/20250805000000_add_fantasy_mode_variants.sql
+++ b/supabase/migrations/20250805000000_add_fantasy_mode_variants.sql
@@ -1,0 +1,38 @@
+-- 20250805000000_add_fantasy_mode_variants.sql
+begin;
+
+-- 1. 型（enum）を使っていた場合  --------------------------
+do $$
+begin
+  if exists (select 1 from pg_type where typname = 'fantasy_stage_mode') then
+    alter type fantasy_stage_mode
+      rename value 'progression' to 'progression_order';
+    alter type fantasy_stage_mode
+      add value if not exists 'progression_random';
+    alter type fantasy_stage_mode
+      add value if not exists 'progression_timing';
+  end if;
+end$$;
+
+-- 2. text＋CHECK 制約だった場合 ---------------------------
+alter table fantasy_stages
+  drop constraint if exists fantasy_stages_mode_check;
+
+alter table fantasy_stages
+  add constraint fantasy_stages_mode_check
+    check ( mode in (
+      'single',
+      'progression_order',
+      'progression_random',
+      'progression_timing'
+    ));
+
+-- 3. 既存レコードをリネーム -------------------------------
+update fantasy_stages
+  set mode = 'progression_order'
+where mode = 'progression';
+
+-- 4. コメントを更新 ---------------------------------------
+comment on column fantasy_stages.mode is 'single: 単一コードモード, progression_order: コード進行順番固定モード, progression_random: コード進行ランダムモード, progression_timing: タイミング付きコード進行モード';
+
+commit;


### PR DESCRIPTION
Expand fantasy stage modes to support ordered, random, and timing-based chord progressions, enhancing gameplay variety.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cf73b63-3ccf-4508-b8c9-680a53441714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cf73b63-3ccf-4508-b8c9-680a53441714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

