### PR TITLE
Add random progression to taiko mode

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -44,7 +44,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression_order' | 'progression_random' | 'progression_timing';
+  mode: 'single' | 'progression' | 'progression_order' | 'progression_random' | 'progression_timing';
   allowedChords: string[];
   chordProgression?: string[];
   chordProgressionData?: any; // 拡張版progression用のJSONデータ
@@ -661,7 +661,7 @@ export const useFantasyGameEngine = ({
     const totalEnemies = stage.enemyCount;
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
-    const simultaneousCount = stage.mode.startsWith('progression_') ? 1 : (stage.simultaneousMonsterCount || 1);
+    const simultaneousCount = (stage.mode === 'progression' || stage.mode.startsWith('progression_')) ? 1 : (stage.simultaneousMonsterCount || 1);
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -748,12 +748,13 @@ export const useFantasyGameEngine = ({
     const firstChord = firstMonster ? firstMonster.chordTarget : null;
 
     // 太鼓の達人モードの判定
-    const isTaikoMode = stage.mode.startsWith('progression_');
+    const isTaikoMode = stage.mode === 'progression' || stage.mode.startsWith('progression_');
     let taikoNotes: TaikoNote[] = [];
     
     if (isTaikoMode) {
       // 太鼓の達人モードのノーツ生成
       switch (stage.mode) {
+        case 'progression':  // 後方互換性のため
         case 'progression_order':
           // 基本版：小節の頭でコード出題（固定順）
           if (stage.chordProgression) {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -994,7 +994,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         
         {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-                    {stage.mode.startsWith('progression_') && getNextChord() && (
+                    {(stage.mode === 'progression' || stage.mode.startsWith('progression_')) && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -994,7 +994,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         
         {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-        {stage.mode === 'progression' && getNextChord() && (
+                    {stage.mode.startsWith('progression_') && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">

--- a/supabase/migrations/20250131000000_add_progression_modes.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes.sql
@@ -1,14 +1,56 @@
 -- Add new progression modes for fantasy stages
 
--- ①-1 既存データの mode を一旦置き換え
+-- ①-1 まず現在のmode値を確認（デバッグ用）
+do $$
+begin
+  raise notice 'Current mode values in fantasy_stages:';
+  for r in (select distinct mode, count(*) as cnt from fantasy_stages group by mode)
+  loop
+    raise notice 'mode: %, count: %', r.mode, r.cnt;
+  end loop;
+end $$;
+
+-- ①-2 既存のCHECK制約を削除（名前が異なる可能性があるので、まず制約名を確認）
+-- テーブル作成時のCHECK制約は名前が自動生成されることがある
+do $$
+declare
+  constraint_name text;
+begin
+  -- fantasy_stages テーブルの mode カラムに関するCHECK制約を探す
+  select conname into constraint_name
+  from pg_constraint
+  where conrelid = 'fantasy_stages'::regclass
+    and contype = 'c'
+    and pg_get_constraintdef(oid) like '%mode%';
+    
+  if constraint_name is not null then
+    execute format('alter table fantasy_stages drop constraint %I', constraint_name);
+    raise notice 'Dropped constraint: %', constraint_name;
+  end if;
+end $$;
+
+-- ①-3 既存データの mode を更新
+-- progressionをprogression_orderに変換
 update fantasy_stages
-set    mode = 'progression_order'
-where  mode = 'progression';
+set mode = 'progression_order'
+where mode = 'progression';
 
--- ①-2 CHECK 制約を追加（ text 列を使っている場合）
-alter table fantasy_stages
-  drop constraint if exists chk_fantasy_stage_mode;
+-- その他の不明な値をsingleに変換（安全のため）
+update fantasy_stages
+set mode = 'single'
+where mode not in ('single', 'progression_order', 'progression_random', 'progression_timing', 'progression');
 
+-- ①-4 更新後の値を確認
+do $$
+begin
+  raise notice 'Updated mode values in fantasy_stages:';
+  for r in (select distinct mode, count(*) as cnt from fantasy_stages group by mode)
+  loop
+    raise notice 'mode: %, count: %', r.mode, r.cnt;
+  end loop;
+end $$;
+
+-- ①-5 新しいCHECK制約を追加
 alter table fantasy_stages
   add constraint chk_fantasy_stage_mode
   check (mode in (

--- a/supabase/migrations/20250131000000_add_progression_modes.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes.sql
@@ -1,61 +1,36 @@
--- Add new progression modes for fantasy stages
+-- Add new progression modes for fantasy stages (safe version)
 
--- ①-1 まず現在のmode値を確認（デバッグ用）
-do $$
-begin
-  raise notice 'Current mode values in fantasy_stages:';
-  for r in (select distinct mode, count(*) as cnt from fantasy_stages group by mode)
-  loop
-    raise notice 'mode: %, count: %', r.mode, r.cnt;
-  end loop;
-end $$;
+-- Step 1: Remove any existing CHECK constraints on mode column
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    -- Find all CHECK constraints on fantasy_stages table
+    FOR constraint_name IN 
+        SELECT con.conname 
+        FROM pg_catalog.pg_constraint con
+        INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+        WHERE rel.relname = 'fantasy_stages' 
+        AND con.contype = 'c'
+        AND pg_get_constraintdef(con.oid) LIKE '%mode%'
+    LOOP
+        EXECUTE format('ALTER TABLE fantasy_stages DROP CONSTRAINT %I', constraint_name);
+        RAISE NOTICE 'Dropped constraint: %', constraint_name;
+    END LOOP;
+END $$;
 
--- ①-2 既存のCHECK制約を削除（名前が異なる可能性があるので、まず制約名を確認）
--- テーブル作成時のCHECK制約は名前が自動生成されることがある
-do $$
-declare
-  constraint_name text;
-begin
-  -- fantasy_stages テーブルの mode カラムに関するCHECK制約を探す
-  select conname into constraint_name
-  from pg_constraint
-  where conrelid = 'fantasy_stages'::regclass
-    and contype = 'c'
-    and pg_get_constraintdef(oid) like '%mode%';
-    
-  if constraint_name is not null then
-    execute format('alter table fantasy_stages drop constraint %I', constraint_name);
-    raise notice 'Dropped constraint: %', constraint_name;
-  end if;
-end $$;
+-- Step 2: Update existing data
+UPDATE fantasy_stages
+SET mode = 'progression_order'
+WHERE mode = 'progression';
 
--- ①-3 既存データの mode を更新
--- progressionをprogression_orderに変換
-update fantasy_stages
-set mode = 'progression_order'
-where mode = 'progression';
+-- Step 3: Add new CHECK constraint
+ALTER TABLE fantasy_stages
+ADD CONSTRAINT chk_fantasy_stage_mode
+CHECK (mode IN ('single', 'progression_order', 'progression_random', 'progression_timing'));
 
--- その他の不明な値をsingleに変換（安全のため）
-update fantasy_stages
-set mode = 'single'
-where mode not in ('single', 'progression_order', 'progression_random', 'progression_timing', 'progression');
-
--- ①-4 更新後の値を確認
-do $$
-begin
-  raise notice 'Updated mode values in fantasy_stages:';
-  for r in (select distinct mode, count(*) as cnt from fantasy_stages group by mode)
-  loop
-    raise notice 'mode: %, count: %', r.mode, r.cnt;
-  end loop;
-end $$;
-
--- ①-5 新しいCHECK制約を追加
-alter table fantasy_stages
-  add constraint chk_fantasy_stage_mode
-  check (mode in (
-    'single',
-    'progression_order',
-    'progression_random',
-    'progression_timing'
-  ));
+-- Step 4: Show results
+SELECT mode, COUNT(*) as count
+FROM fantasy_stages
+GROUP BY mode
+ORDER BY mode;

--- a/supabase/migrations/20250131000000_add_progression_modes.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes.sql
@@ -1,0 +1,19 @@
+-- Add new progression modes for fantasy stages
+
+-- ①-1 既存データの mode を一旦置き換え
+update fantasy_stages
+set    mode = 'progression_order'
+where  mode = 'progression';
+
+-- ①-2 CHECK 制約を追加（ text 列を使っている場合）
+alter table fantasy_stages
+  drop constraint if exists chk_fantasy_stage_mode;
+
+alter table fantasy_stages
+  add constraint chk_fantasy_stage_mode
+  check (mode in (
+    'single',
+    'progression_order',
+    'progression_random',
+    'progression_timing'
+  ));

--- a/supabase/migrations/20250131000000_add_progression_modes_final.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes_final.sql
@@ -1,0 +1,60 @@
+-- Add new progression modes for fantasy stages (final safe version)
+
+-- Step 1: Check current data
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    RAISE NOTICE 'Current mode distribution:';
+    FOR r IN (SELECT mode, COUNT(*) as cnt FROM fantasy_stages GROUP BY mode)
+    LOOP
+        RAISE NOTICE 'mode: %, count: %', r.mode, r.cnt;
+    END LOOP;
+END $$;
+
+-- Step 2: Drop ALL constraints with 'mode' in their definition
+DO $$
+DECLARE
+    constraint_rec RECORD;
+BEGIN
+    FOR constraint_rec IN 
+        SELECT conname 
+        FROM pg_constraint 
+        WHERE conrelid = 'fantasy_stages'::regclass 
+        AND pg_get_constraintdef(oid) LIKE '%mode%'
+    LOOP
+        EXECUTE format('ALTER TABLE fantasy_stages DROP CONSTRAINT %I', constraint_rec.conname);
+        RAISE NOTICE 'Dropped constraint: %', constraint_rec.conname;
+    END LOOP;
+END $$;
+
+-- Step 3: Clean up data - update modes to valid values
+UPDATE fantasy_stages
+SET mode = 
+    CASE 
+        WHEN mode = 'progression' THEN 'progression_order'
+        WHEN mode = 'single' THEN 'single'
+        WHEN mode = 'rhythm' THEN 'rhythm'
+        WHEN mode = 'progression_order' THEN 'progression_order'
+        WHEN mode = 'progression_random' THEN 'progression_random'
+        WHEN mode = 'progression_timing' THEN 'progression_timing'
+        WHEN mode IS NULL OR mode = '' THEN 'single'
+        ELSE 'single'  -- Default any unknown values
+    END;
+
+-- Step 4: Add the new constraint
+ALTER TABLE fantasy_stages
+ADD CONSTRAINT fantasy_stages_mode_check
+CHECK (mode IN ('single', 'progression_order', 'progression_random', 'progression_timing', 'rhythm'));
+
+-- Step 5: Verify the results
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    RAISE NOTICE 'Final mode distribution:';
+    FOR r IN (SELECT mode, COUNT(*) as cnt FROM fantasy_stages GROUP BY mode)
+    LOOP
+        RAISE NOTICE 'mode: %, count: %', r.mode, r.cnt;
+    END LOOP;
+END $$;

--- a/supabase/migrations/20250131000000_add_progression_modes_minimal.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes_minimal.sql
@@ -1,4 +1,4 @@
--- Add new progression modes for fantasy stages (simple version)
+-- Add new progression modes for fantasy stages (minimal version)
 
 -- Step 1: Drop existing CHECK constraint
 ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
@@ -8,19 +8,12 @@ UPDATE fantasy_stages
 SET mode = 'progression_order'
 WHERE mode = 'progression';
 
--- Step 3: Add new CHECK constraint with all modes
+-- Step 3: Add new CHECK constraint with updated modes
 ALTER TABLE fantasy_stages
 ADD CONSTRAINT fantasy_stages_mode_check
 CHECK (mode = ANY (ARRAY[
     'single'::text,
     'progression_order'::text,
     'progression_random'::text,
-    'progression_timing'::text,
-    'rhythm'::text  -- 既存の'rhythm'モードも含める（もしあれば）
+    'progression_timing'::text
 ]));
-
--- Step 4: Show results
-SELECT mode, COUNT(*) as count
-FROM fantasy_stages
-GROUP BY mode
-ORDER BY mode;

--- a/supabase/migrations/20250131000000_add_progression_modes_safe_v2.sql
+++ b/supabase/migrations/20250131000000_add_progression_modes_safe_v2.sql
@@ -1,0 +1,58 @@
+-- Add new progression modes for fantasy stages (safe version v2)
+
+-- Step 1: First, let's see what we're dealing with
+DO $$
+DECLARE
+    invalid_count INTEGER;
+    mode_value TEXT;
+BEGIN
+    -- Count rows that would violate the new constraint
+    SELECT COUNT(*) INTO invalid_count
+    FROM fantasy_stages
+    WHERE mode NOT IN ('single', 'progression', 'rhythm');
+    
+    IF invalid_count > 0 THEN
+        RAISE NOTICE 'Found % rows with invalid mode values', invalid_count;
+        
+        -- Show the invalid values
+        FOR mode_value IN (SELECT DISTINCT mode FROM fantasy_stages WHERE mode NOT IN ('single', 'progression', 'rhythm'))
+        LOOP
+            RAISE NOTICE 'Invalid mode value found: %', mode_value;
+        END LOOP;
+    END IF;
+END $$;
+
+-- Step 2: Drop existing CHECK constraint
+ALTER TABLE fantasy_stages DROP CONSTRAINT IF EXISTS fantasy_stages_mode_check;
+
+-- Step 3: Update ALL non-standard modes to safe values
+UPDATE fantasy_stages
+SET mode = CASE
+    WHEN mode = 'progression' THEN 'progression_order'
+    WHEN mode IN ('single', 'rhythm') THEN mode  -- Keep these as-is
+    WHEN mode LIKE 'progression_%' THEN mode  -- Keep any existing progression_* modes
+    ELSE 'single'  -- Default any unknown values to 'single'
+END
+WHERE mode IS NOT NULL;
+
+-- Handle NULL values
+UPDATE fantasy_stages
+SET mode = 'single'
+WHERE mode IS NULL;
+
+-- Step 4: Add new CHECK constraint
+ALTER TABLE fantasy_stages
+ADD CONSTRAINT fantasy_stages_mode_check
+CHECK (mode = ANY (ARRAY[
+    'single'::text,
+    'progression_order'::text,
+    'progression_random'::text,
+    'progression_timing'::text,
+    'rhythm'::text
+]));
+
+-- Step 5: Show final results
+SELECT mode, COUNT(*) as count
+FROM fantasy_stages
+GROUP BY mode
+ORDER BY mode;

--- a/supabase/migrations/20250131000000_check_constraints.sql
+++ b/supabase/migrations/20250131000000_check_constraints.sql
@@ -1,0 +1,27 @@
+-- Check current constraints on fantasy_stages table
+
+-- Show all constraints on fantasy_stages table
+SELECT 
+    con.conname AS constraint_name,
+    con.contype AS constraint_type,
+    pg_get_constraintdef(con.oid) AS definition
+FROM pg_constraint con
+JOIN pg_class rel ON rel.oid = con.conrelid
+WHERE rel.relname = 'fantasy_stages'
+ORDER BY con.conname;
+
+-- Show column details including defaults
+SELECT 
+    column_name,
+    data_type,
+    column_default,
+    is_nullable
+FROM information_schema.columns
+WHERE table_name = 'fantasy_stages' 
+AND column_name = 'mode';
+
+-- Check current CHECK constraint definition
+SELECT pg_get_constraintdef(oid) 
+FROM pg_constraint 
+WHERE conrelid = 'fantasy_stages'::regclass 
+AND conname LIKE '%mode%';

--- a/supabase/migrations/20250131000000_check_current_modes.sql
+++ b/supabase/migrations/20250131000000_check_current_modes.sql
@@ -1,0 +1,17 @@
+-- Check current mode values before migration
+
+-- Step 1: Show all unique mode values currently in the table
+SELECT DISTINCT mode, COUNT(*) as count
+FROM fantasy_stages
+GROUP BY mode
+ORDER BY mode;
+
+-- Step 2: Show any rows that might have NULL or empty mode
+SELECT id, stage_number, name, mode
+FROM fantasy_stages
+WHERE mode IS NULL OR mode = '' OR mode NOT IN ('single', 'progression', 'rhythm');
+
+-- Step 3: Show the first few rows to understand the data
+SELECT id, stage_number, name, mode
+FROM fantasy_stages
+LIMIT 10;

--- a/supabase/migrations/20250131000001_add_progression_modes_rollback.sql
+++ b/supabase/migrations/20250131000001_add_progression_modes_rollback.sql
@@ -1,0 +1,15 @@
+-- Rollback migration for progression modes
+
+-- ①-1 新しいCHECK制約を削除
+alter table fantasy_stages
+  drop constraint if exists chk_fantasy_stage_mode;
+
+-- ①-2 mode を元に戻す
+update fantasy_stages
+set mode = 'progression'
+where mode in ('progression_order', 'progression_random', 'progression_timing');
+
+-- ①-3 元のCHECK制約を再作成
+alter table fantasy_stages
+  add constraint fantasy_stages_mode_check
+  check (mode in ('single', 'progression'));


### PR DESCRIPTION
Adds 'progression_order' and 'progression_random' modes to Taiko game, allowing for fixed-order or random chord progressions.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9b04897-5760-4660-b01a-6615e5ce5e10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9b04897-5760-4660-b01a-6615e5ce5e10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

