### PR TITLE
Update fantasy game progression modes

### DIFF
--- a/example_update_to_timing_mode.sql
+++ b/example_update_to_timing_mode.sql
@@ -1,0 +1,24 @@
+-- ステージ4-2を太鼓の達人モード（progression_timing）に変更する例
+
+UPDATE fantasy_stages
+SET 
+  mode = 'progression_timing',
+  -- 簡易テキスト形式の例（1小節ごとにコードが変わる）
+  chord_progression_data = 'C Am G F'
+WHERE stage_number = '4-2';
+
+-- または、詳細なJSON形式の例（タイミングを細かく制御）
+UPDATE fantasy_stages
+SET 
+  mode = 'progression_timing',
+  chord_progression_data = '[
+    {"measure": 2, "beat": 1, "chord": "C"},
+    {"measure": 3, "beat": 1, "chord": "Am"},
+    {"measure": 4, "beat": 1, "chord": "G"},
+    {"measure": 5, "beat": 1, "chord": "F"},
+    {"measure": 6, "beat": 1, "chord": "C"},
+    {"measure": 7, "beat": 1, "chord": "Am"},
+    {"measure": 8, "beat": 1, "chord": "G"},
+    {"measure": 9, "beat": 1, "chord": "F"}
+  ]'::jsonb
+WHERE stage_number = '4-2';

--- a/src/components/admin/FantasyStageSelector.tsx
+++ b/src/components/admin/FantasyStageSelector.tsx
@@ -94,7 +94,13 @@ export const FantasyStageSelector: React.FC<FantasyStageSelectorProps> = ({
                   </div>
                   <div className="flex flex-wrap gap-2 mt-2">
                     <span className="text-xs px-2 py-1 bg-gray-100 rounded">
-                      モード: {stage.mode === 'single' ? 'シングル' : 'プログレッション'}
+                      モード: {
+                        stage.mode === 'single' ? 'シングル' :
+                        stage.mode === 'progression_order' ? '順番進行' :
+                        stage.mode === 'progression_random' ? 'ランダム進行' :
+                        stage.mode === 'progression_timing' ? 'タイミング進行' :
+                        stage.mode
+                      }
                     </span>
                     <span className="text-xs px-2 py-1 bg-gray-100 rounded">
                       敵数: {stage.enemy_count}

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -703,7 +703,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
-    if (stage.mode !== 'progression' || !stage.chordProgression) return null;
+    if ((stage.mode !== 'progression_order' && stage.mode !== 'progression_timing') || !stage.chordProgression) return null;
     
     const nextIndex = (gameState.currentQuestionIndex + 1) % stage.chordProgression.length;
     return stage.chordProgression[nextIndex];
@@ -994,7 +994,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         </div>
         
         {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-        {stage.mode === 'progression' && getNextChord() && (
+        {(stage.mode === 'progression_order' || stage.mode === 'progression_timing') && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -381,7 +381,7 @@ const FantasyMain: React.FC = () => {
         enemyHp: nextStageData.enemy_hp,
         minDamage: nextStageData.min_damage,
         maxDamage: nextStageData.max_damage,
-        mode: nextStageData.mode as 'single' | 'progression',
+        mode: nextStageData.mode as 'single' | 'progression_order' | 'progression_random' | 'progression_timing',
         allowedChords: Array.isArray(nextStageData.allowed_chords) ? nextStageData.allowed_chords : [],
         chordProgression: Array.isArray(nextStageData.chord_progression) ? nextStageData.chord_progression : undefined,
         showSheetMusic: nextStageData.show_sheet_music,

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -159,7 +159,7 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         enemyHp: stage.enemy_hp,
         minDamage: stage.min_damage,
         maxDamage: stage.max_damage,
-        mode: stage.mode as 'single' | 'progression',
+        mode: stage.mode as 'single' | 'progression_order' | 'progression_random' | 'progression_timing',
         allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
         chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
         showSheetMusic: stage.show_sheet_music,

--- a/update_progression_mode.sql
+++ b/update_progression_mode.sql
@@ -1,0 +1,11 @@
+-- Migration script to update existing 'progression' mode values to 'progression_order'
+-- Run this script against your Supabase database
+
+UPDATE fantasy_stages
+SET mode = 'progression_order'
+WHERE mode = 'progression';
+
+-- Verify the update
+SELECT id, name, mode
+FROM fantasy_stages
+WHERE mode IN ('progression_order', 'progression_random', 'progression_timing');


### PR DESCRIPTION
Introduce `progression_order`, `progression_random`, and `progression_timing` modes to Fantasy Game stages for diverse chord progression gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-231e0215-cc26-40ab-b781-f0bad4bbb08d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-231e0215-cc26-40ab-b781-f0bad4bbb08d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

