### PR TITLE
Implement random chord progression for taiko

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -16,12 +16,19 @@ import {
   judgeTimingWindow,
   judgeTimingWindowWithLoop,
   generateBasicProgressionNotes,
+  generateRandomProgressionNotes,
   parseChordProgressionData,
   parseSimpleProgressionText
 } from './TaikoNoteSystem';
 import { bgmManager } from '@/utils/BGMManager';
 
 // ===== 型定義 =====
+
+type StageMode = 
+  | 'single'
+  | 'progression_order'
+  | 'progression_random'
+  | 'progression_timing';
 
 interface ChordDefinition {
   id: string;          // コードのID（例: 'CM7', 'G7', 'Am'）
@@ -43,7 +50,7 @@ interface FantasyStage {
   enemyHp: number;
   minDamage: number;
   maxDamage: number;
-  mode: 'single' | 'progression';
+  mode: StageMode;
   allowedChords: string[];
   chordProgression?: string[];
   chordProgressionData?: any; // 拡張版progression用のJSONデータ
@@ -660,7 +667,7 @@ export const useFantasyGameEngine = ({
     const totalEnemies = stage.enemyCount;
     const enemyHp = stage.enemyHp;
     const totalQuestions = totalEnemies * enemyHp;
-    const simultaneousCount = stage.mode === 'progression' ? 1 : (stage.simultaneousMonsterCount || 1);
+    const simultaneousCount = stage.mode.startsWith('progression') ? 1 : (stage.simultaneousMonsterCount || 1);
 
     // ステージで使用するモンスターIDを決定（シャッフルして必要数だけ取得）
     const monsterIds = getStageMonsterIds(totalEnemies);
@@ -747,40 +754,64 @@ export const useFantasyGameEngine = ({
     const firstChord = firstMonster ? firstMonster.chordTarget : null;
 
     // 太鼓の達人モードの判定
-    const isTaikoMode = stage.mode === 'progression';
+    const isTaikoMode = 
+      stage.mode === 'progression_order' ||
+      stage.mode === 'progression_random' ||
+      stage.mode === 'progression_timing';
     let taikoNotes: TaikoNote[] = [];
     
     if (isTaikoMode) {
       // 太鼓の達人モードのノーツ生成
-      if (stage.chordProgressionData) {
-        // 拡張版：JSON形式のデータを解析
-        let progressionData: ChordProgressionDataItem[];
-        
-        if (typeof stage.chordProgressionData === 'string') {
-          // 簡易テキスト形式の場合
-          progressionData = parseSimpleProgressionText(stage.chordProgressionData);
-        } else {
-          // JSON配列の場合
-          progressionData = stage.chordProgressionData as ChordProgressionDataItem[];
-        }
-        
-        taikoNotes = parseChordProgressionData(
-          progressionData,
-          stage.bpm || 120,
-          stage.timeSignature || 4,
-          (chordId) => getChordDefinition(chordId, displayOpts),
-          0 // カウントインを渡す
-        );
-      } else if (stage.chordProgression) {
-        // 基本版：小節の頭でコード出題
-        taikoNotes = generateBasicProgressionNotes(
-          stage.chordProgression,
-          stage.measureCount || 8,
-          stage.bpm || 120,
-          stage.timeSignature || 4,
-          (chordId) => getChordDefinition(chordId, displayOpts),
-          0 // カウントインを渡す
-        );
+      switch (stage.mode) {
+        case 'progression_timing':
+          // 拡張版：JSON形式のデータを解析
+          if (stage.chordProgressionData) {
+            let progressionData: ChordProgressionDataItem[];
+            
+            if (typeof stage.chordProgressionData === 'string') {
+              // 簡易テキスト形式の場合
+              progressionData = parseSimpleProgressionText(stage.chordProgressionData);
+            } else {
+              // JSON配列の場合
+              progressionData = stage.chordProgressionData as ChordProgressionDataItem[];
+            }
+            
+            taikoNotes = parseChordProgressionData(
+              progressionData,
+              stage.bpm || 120,
+              stage.timeSignature || 4,
+              (chordId) => getChordDefinition(chordId, displayOpts),
+              0 // カウントインを渡す
+            );
+          }
+          break;
+
+        case 'progression_random':
+          // ランダムプログレッション：各小節ごとにランダムでコードを決定
+          taikoNotes = generateRandomProgressionNotes(
+            stage.allowedChords.length ? stage.allowedChords : (stage.chordProgression || []),
+            stage.measureCount || 8,
+            stage.bpm || 120,
+            stage.timeSignature || 4,
+            (chordId) => getChordDefinition(chordId, displayOpts),
+            0
+          );
+          break;
+
+        case 'progression_order':
+        default:
+          // 基本版：小節の頭でコード出題
+          if (stage.chordProgression) {
+            taikoNotes = generateBasicProgressionNotes(
+              stage.chordProgression,
+              stage.measureCount || 8,
+              stage.bpm || 120,
+              stage.timeSignature || 4,
+              (chordId) => getChordDefinition(chordId, displayOpts),
+              0 // カウントインを渡す
+            );
+          }
+          break;
       }
       
       // ループ対応：最初のノーツの情報を設定

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -703,7 +703,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
-    if (stage.mode !== 'progression' || !stage.chordProgression) return null;
+    if (!stage.mode.startsWith('progression') || !stage.chordProgression) return null;
     
     const nextIndex = (gameState.currentQuestionIndex + 1) % stage.chordProgression.length;
     return stage.chordProgression[nextIndex];
@@ -993,8 +993,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           </div>
         </div>
         
-        {/* NEXTコード表示（コード進行モード、サイズを縮小） */}
-        {stage.mode === 'progression' && getNextChord() && (
+        {/* NEXTコード表示（固定進行モードのみ、サイズを縮小） */}
+        {stage.mode === 'progression_order' && getNextChord() && (
           <div className="mb-1 text-right">
             <div className="text-white text-xs">NEXT:</div>
             <div className="text-blue-300 text-sm font-bold">


### PR DESCRIPTION
Adds `progression_order`, `progression_random`, and `progression_timing` stage modes to enable diverse chord progression gameplay.

This PR implements the frontend logic for the newly defined `stage.mode` types. `progression_random` introduces per-measure random chord generation (without immediate duplicates), while `progression_order` and `progression_timing` (JSON-based) are integrated into the new mode structure. UI elements like 'NEXT chord' are now conditionally displayed based on the mode's predictability.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ded55ee-37b8-42ec-b7d2-21a6846d6d14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ded55ee-37b8-42ec-b7d2-21a6846d6d14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

