### PR TITLE
Update user display in ranking list

### DIFF
--- a/src/components/ranking/LevelRanking.tsx
+++ b/src/components/ranking/LevelRanking.tsx
@@ -189,7 +189,7 @@ const LevelRanking: React.FC = () => {
             <thead>
               <tr className="border-b border-slate-700 text-left">
                 <th className="py-2 px-2 min-w-[3rem]">#</th>
-                <th className="py-2 px-2 min-w-[12rem] sm:min-w-[10rem]">ユーザー</th>
+                <th className="py-2 px-2 min-w-[12rem] sm:min-w-[10rem]">ユーザー(タップで詳細)</th>
                 <th className="py-2 px-2 whitespace-nowrap min-w-[8rem] sm:min-w-[6rem]">称号</th>
                 <th className="py-2 px-2 min-w-[3rem]">Lv</th>
                 <th className="py-2 px-2 min-w-[4rem]">レッスン</th>
@@ -210,8 +210,8 @@ const LevelRanking: React.FC = () => {
                   <td className="py-1 px-2">
                     <button
                       onClick={()=>{window.location.hash=`#diary-user?id=${e.id}`;}}
-                      className={`flex items-center gap-2 hover:text-blue-400 transition-colors w-full ${
-                        isCurrentUser ? 'text-primary-400 font-bold' : ''
+                      className={`flex items-center gap-2 text-blue-400 hover:text-blue-300 hover:underline transition-colors w-full ${
+                        isCurrentUser ? 'font-bold' : ''
                       }`}
                     >
                       <img 
@@ -219,7 +219,7 @@ const LevelRanking: React.FC = () => {
                         alt="avatar"
                         className="w-6 h-6 rounded-full object-cover flex-shrink-0"
                       />
-                      <span className="truncate min-w-0 flex-1">{e.nickname}</span>
+                      <span className="truncate min-w-0 flex-1 underline">{e.nickname}</span>
                     </button>
                   </td>
                   <td className="py-1 px-2 whitespace-nowrap">

--- a/src/components/ranking/MissionRanking.tsx
+++ b/src/components/ranking/MissionRanking.tsx
@@ -134,7 +134,7 @@ const MissionRanking: React.FC = () => {
                   <thead>
                     <tr className="bg-slate-700 border-b border-slate-600">
                       <th className="py-3 px-4 text-left font-medium min-w-[4rem]">順位</th>
-                      <th className="py-3 px-4 text-left font-medium min-w-[12rem] sm:min-w-[10rem]">ユーザー</th>
+                      <th className="py-3 px-4 text-left font-medium min-w-[12rem] sm:min-w-[10rem]">ユーザー(タップで詳細)</th>
                       <th className="py-3 px-4 text-left font-medium min-w-[6rem] sm:min-w-[5rem]">クリア回数</th>
                       <th className="py-3 px-4 text-left font-medium min-w-[4rem]">レベル</th>
                       <th className="py-3 px-4 text-left font-medium min-w-[6rem] sm:min-w-[5rem]">ランク</th>
@@ -150,14 +150,17 @@ const MissionRanking: React.FC = () => {
                           </div>
                         </td>
                         <td className="py-3 px-4">
-                          <div className="flex items-center space-x-3 min-w-0">
+                          <button
+                            onClick={() => {window.location.hash = `#diary-user?id=${entry.user_id}`;}}
+                            className="flex items-center space-x-3 min-w-0 w-full text-blue-400 hover:text-blue-300 hover:underline transition-colors"
+                          >
                             <img 
                               src={entry.avatar_url || DEFAULT_AVATAR_URL} 
                               className="w-8 h-8 rounded-full border-2 border-slate-600 flex-shrink-0"
                               alt="アバター"
                             />
-                            <span className="font-medium truncate min-w-0 flex-1">{entry.nickname}</span>
-                          </div>
+                            <span className="font-medium truncate min-w-0 flex-1 underline">{entry.nickname}</span>
+                          </button>
                         </td>
                         <td className="py-3 px-4">
                           <span className="font-mono text-primary-400">{entry.clear_count}</span>


### PR DESCRIPTION
Rename 'ユーザー' column to 'ユーザー(タップで詳細)' and style all usernames as clickable links in ranking tables to improve clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-80ab8f41-02ac-4ea4-aa2b-09d2dc6516f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80ab8f41-02ac-4ea4-aa2b-09d2dc6516f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

