### PR TITLE
Configure Netlify staging branch deployment

### DIFF
--- a/NETLIFY_STAGING_SETUP.md
+++ b/NETLIFY_STAGING_SETUP.md
@@ -1,0 +1,103 @@
+# Netlify ステージング環境セットアップ手順
+
+## 概要
+`stg`ブランチを`stg.jazzify.jp`ドメインにデプロイするための設定手順です。
+
+## 設定手順
+
+### 1. Netlify管理画面での設定
+
+1. [Netlify](https://app.netlify.com/)にログインし、対象のサイトを選択
+2. **Site settings** → **Domain management** に移動
+
+### 2. カスタムドメインの追加
+
+1. **Add custom domain** をクリック
+2. `stg.jazzify.jp` を入力して **Verify** をクリック
+3. ドメインの所有権確認後、**Add domain** をクリック
+
+### 3. DNS設定
+
+DNSプロバイダー（ドメインを管理しているサービス）で以下の設定を行います：
+
+#### CNAMEレコードの追加
+- **ホスト名**: `stg`
+- **タイプ**: `CNAME`
+- **値**: `[your-site-name].netlify.app` （Netlifyで割り当てられたデフォルトドメイン）
+
+例:
+```
+stg.jazzify.jp. CNAME your-site-name.netlify.app.
+```
+
+### 4. ブランチデプロイの設定
+
+1. Netlify管理画面で **Site settings** → **Build & deploy** → **Continuous Deployment** に移動
+2. **Branch deploys** セクションで **Edit settings** をクリック
+3. 以下の設定を行います：
+   - **Branch deploys**: `All` または `Let me add individual branches` を選択
+   - 個別設定の場合は `stg` ブランチを追加
+   - **Deploy preview** をオンにする（任意）
+
+### 5. ブランチサブドメインの設定
+
+1. **Domain management** → **Branch subdomains** セクションに移動
+2. **Add branch subdomain** をクリック
+3. 以下を設定：
+   - **Branch**: `stg`
+   - **Subdomain**: `stg`
+4. **Save** をクリック
+
+### 6. SSL証明書の設定
+
+1. **Domain management** → **HTTPS** セクションを確認
+2. Netlifyが自動的にSSL証明書を発行します（数分かかる場合があります）
+3. 証明書が発行されたら、HTTPSでのアクセスが可能になります
+
+## 環境変数の設定（オプション）
+
+ステージング環境専用の環境変数を設定する場合：
+
+1. **Site settings** → **Environment variables** に移動
+2. **Add a variable** をクリック
+3. 以下のように設定：
+   - **Key**: 環境変数名（例: `API_URL`）
+   - **Values**: 
+     - **Production**: 本番環境の値
+     - **Deploy previews**: プレビュー環境の値
+     - **Branch deploys (stg)**: ステージング環境の値
+
+## netlify.tomlの設定
+
+`netlify.toml`には以下の設定が追加済みです：
+
+```toml
+# ステージングブランチ用の設定
+[context.stg]
+  command = "npm ci && npm run build"
+  
+[context.stg.environment]
+  NODE_ENV = "staging"
+  VITE_APP_ENV = "staging"
+```
+
+## 動作確認
+
+1. `stg`ブランチに変更をプッシュ
+2. Netlifyのデプロイログを確認
+3. `https://stg.jazzify.jp` にアクセスして動作を確認
+
+## トラブルシューティング
+
+### DNS設定が反映されない場合
+- DNS設定の反映には最大48時間かかる場合があります
+- `nslookup stg.jazzify.jp` コマンドでDNS設定を確認
+
+### デプロイが失敗する場合
+- Netlifyのデプロイログを確認
+- `netlify.toml`の設定を確認
+- ビルドコマンドが正しいか確認
+
+### SSL証明書が発行されない場合
+- DNS設定が正しく完了しているか確認
+- Netlify管理画面で手動で証明書の再発行を試みる

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,14 @@
   NODE_VERSION = "20"
   NPM_VERSION = "10"
 
+# ステージングブランチ用の設定
+[context.stg]
+  command = "npm ci && npm run build"
+  
+[context.stg.environment]
+  NODE_ENV = "staging"
+  VITE_APP_ENV = "staging"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import AuthCallback from '@/components/auth/AuthCallback';
 import VerifyOtpPage from '@/components/auth/VerifyOtpPage';
 import AuthGate from '@/components/auth/AuthGate';
 import ToastContainer from '@/components/ui/ToastContainer';
+import { EnvironmentBadge } from '@/components/ui/EnvironmentBadge';
 
 // LegacyApp はバンドルサイズが大きいため遅延読み込みする
 const LegacyApp = React.lazy(() => import('./LegacyApp'));
@@ -40,6 +41,7 @@ const App: React.FC = () => {
         </Routes>
       </Suspense>
       <ToastContainer />
+      <EnvironmentBadge />
     </>
   );
 };

--- a/src/components/ui/EnvironmentBadge.tsx
+++ b/src/components/ui/EnvironmentBadge.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { getEnvironment, getEnvConfig } from '@/utils/environment';
+
+export const EnvironmentBadge: React.FC = () => {
+  const env = getEnvironment();
+  const config = getEnvConfig();
+  
+  // 本番環境または表示しない設定の場合は非表示
+  if (!config.showEnvBadge || env === 'production') {
+    return null;
+  }
+  
+  const getBadgeStyles = () => {
+    switch (env) {
+      case 'staging':
+        return {
+          backgroundColor: '#ff9800',
+          color: '#fff',
+          label: 'STAGING'
+        };
+      case 'development':
+        return {
+          backgroundColor: '#4caf50',
+          color: '#fff',
+          label: 'DEV'
+        };
+      default:
+        return {
+          backgroundColor: '#666',
+          color: '#fff',
+          label: env.toUpperCase()
+        };
+    }
+  };
+  
+  const { backgroundColor, color, label } = getBadgeStyles();
+  
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '20px',
+        right: '20px',
+        padding: '8px 16px',
+        backgroundColor,
+        color,
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: 'bold',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+        zIndex: 9999,
+        pointerEvents: 'none',
+        userSelect: 'none'
+      }}
+    >
+      {label}
+    </div>
+  );
+};

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_ENV?: 'development' | 'staging' | 'production'
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
+  readonly VITE_SUPABASE_REDIRECT_URL?: string
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,57 @@
+/**
+ * 環境設定のユーティリティ
+ */
+
+export type Environment = 'development' | 'staging' | 'production';
+
+export const getEnvironment = (): Environment => {
+  // VITE_APP_ENVが設定されている場合はそれを使用
+  if (import.meta.env.VITE_APP_ENV) {
+    return import.meta.env.VITE_APP_ENV as Environment;
+  }
+  
+  // MODE値に基づいて判定
+  if (import.meta.env.MODE === 'production') {
+    return 'production';
+  }
+  
+  return 'development';
+};
+
+export const isStaging = (): boolean => {
+  return getEnvironment() === 'staging';
+};
+
+export const isProduction = (): boolean => {
+  return getEnvironment() === 'production';
+};
+
+export const isDevelopment = (): boolean => {
+  return getEnvironment() === 'development';
+};
+
+// 環境に応じた設定値を返す
+export const getEnvConfig = () => {
+  const env = getEnvironment();
+  
+  switch (env) {
+    case 'staging':
+      return {
+        apiUrl: import.meta.env.VITE_API_URL || 'https://stg-api.jazzify.jp',
+        debugMode: true,
+        showEnvBadge: true,
+      };
+    case 'production':
+      return {
+        apiUrl: import.meta.env.VITE_API_URL || 'https://api.jazzify.jp',
+        debugMode: false,
+        showEnvBadge: false,
+      };
+    default: // development
+      return {
+        apiUrl: import.meta.env.VITE_API_URL || 'http://localhost:3000',
+        debugMode: true,
+        showEnvBadge: true,
+      };
+  }
+};


### PR DESCRIPTION
Configure Netlify for `stg` branch deployment to `stg.jazzify.jp` and implement a visual environment badge.

---
<a href="https://cursor.com/background-agent?bcId=bc-a851ea1d-eaef-4d6c-9129-75f2851d8763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a851ea1d-eaef-4d6c-9129-75f2851d8763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

