### PR TITLE
Set default avatar for all user pages

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,5 +2,5 @@
  * アプリケーション全体で使用する定数
  */
 
-// デフォルトアバター（一面真っ青）
-export const DEFAULT_AVATAR_URL = "data:image/svg+xml,%3Csvg width='100' height='100' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='100' height='100' fill='%233b82f6'/%3E%3C/svg%3E"; 
+// デフォルトアバター
+export const DEFAULT_AVATAR_URL = "/default_avater/default-avater.png"; 


### PR DESCRIPTION
Update default avatar image to `public/default_avater/default-avater.png` across all relevant pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e99a689-d302-4f34-aa10-5c48bbb66425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e99a689-d302-4f34-aa10-5c48bbb66425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

