### PR TITLE
Replace fantasy mode emoji with default avatar

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -378,7 +378,9 @@ const Dashboard: React.FC = () => {
                   onClick={() => { window.location.hash = '#fantasy'; }}
                   className="bg-gradient-to-br from-purple-800 to-pink-800 rounded-lg p-6 border border-purple-600 hover:border-purple-400 transition-colors text-left relative overflow-hidden"
                 >
-                  <div className="absolute top-0 right-0 text-6xl opacity-20">🧙‍♂️</div>
+                  <div className="absolute top-0 right-0 opacity-20">
+                    <img src="/default_avater/default-avater.png" alt="ファンタジーモード" className="w-24 h-24" />
+                  </div>
                   <div className="flex items-center space-x-3 mb-3 relative z-10">
                     <FaMagic className="w-6 h-6 text-yellow-400" />
                     <h3 className="text-lg font-semibold text-white">ファンタジーモード</h3>

--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -420,7 +420,9 @@ const FantasyMain: React.FC = () => {
     return (
       <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center overflow-y-auto">
         <div className="text-white text-center max-w-md p-4">
-          <div className="text-6xl mb-6">🧙‍♂️</div>
+          <div className="mb-6">
+            <img src="/default_avater/default-avater.png" alt="ファンタジーモード" className="w-24 h-24 mx-auto" />
+          </div>
           <h2 className="text-3xl font-bold mb-4">ファンタジーモード</h2>
           
           {isGuest ? (

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -358,7 +358,10 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
       <div className="relative z-10 p-6 text-white">
         <div className="flex justify-between items-center">
           <div>
-            <h1 className="text-3xl font-bold mb-2">🧙‍♂️ ファンタジーモード</h1>
+            <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
+              <img src="/default_avater/default-avater.png" alt="ファンタジーモード" className="w-10 h-10" />
+              ファンタジーモード
+            </h1>
             <div className="flex items-center space-x-6 text-sm">
               <div>現在地: <span className="text-blue-300 font-bold">{userProgress?.currentStageNumber}</span></div>
             </div>


### PR DESCRIPTION
Replace wizard emoji with default avatar image in fantasy mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-56a8e70b-427d-496b-900f-2d542676ce14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56a8e70b-427d-496b-900f-2d542676ce14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

