### PR TITLE
Add stage card icon images

### DIFF
--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -267,6 +267,15 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         )}
         onClick={() => handleStageSelect(stage)}
       >
+        {/* ステージアイコン */}
+        <div className="flex-shrink-0">
+          <img 
+            src={`/stage_icons/${stage.stageNumber}.png`}
+            alt={`Stage ${stage.stageNumber} icon`}
+            className="w-12 h-12 object-contain"
+          />
+        </div>
+        
         {/* ステージ番号 */}
         <div className="text-white text-xl font-bold flex-shrink-0 w-16 text-center">
           {stage.stageNumber}


### PR DESCRIPTION
Add stage icon image to the left end of the stage card.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1528b35-9060-450a-b926-9905fd186efd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1528b35-9060-450a-b926-9905fd186efd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

