### PR TITLE
Fix fantasy mode monster defeat error and UI bug

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -755,6 +755,7 @@ export const useFantasyGameEngine = ({
 
     // 太鼓の達人モードの判定
     const isTaikoMode = 
+      stage.mode === 'progression' ||  // Changed from specific progression types
       stage.mode === 'progression_order' ||
       stage.mode === 'progression_random' ||
       stage.mode === 'progression_timing';

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2115,7 +2115,22 @@ export class FantasyPIXIInstance {
     // PIXIアプリケーションの破棄
     if (this.app) {
       try {
-        this.app.destroy(true, { children: true });
+        // ステージから全ての子要素を削除（PIXIの内部エラーを防ぐため）
+        if (this.app.stage) {
+          // Remove all event listeners first to prevent null reference errors
+          this.app.stage.removeAllListeners?.();
+          
+          // Remove all children safely
+          while (this.app.stage.children.length > 0) {
+            const child = this.app.stage.children[0];
+            if (child) {
+              this.app.stage.removeChild(child);
+            }
+          }
+        }
+        
+        // Destroy the app
+        this.app.destroy(true, { children: true, texture: true, baseTexture: true });
       } catch (error) {
         devLog.debug('⚠️ PIXI破棄エラー:', error);
       }


### PR DESCRIPTION
Fixes PIXI.js destroy error by safely cleaning up resources and corrects Taiko UI display logic for progression modes.

The PIXI error occurred because `off()` was called on a null object during renderer destruction. The Taiko UI issue was due to a mismatch between database mode types ('progression') and specific code checks ('progression_order', etc.), causing the UI to incorrectly appear in 'single' mode stages.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed1f9fe5-450e-4d9b-bfd8-430794aad552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed1f9fe5-450e-4d9b-bfd8-430794aad552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

