### PR TITLE
Unlock fantasy mode rank 1 for free and guest users

### DIFF
--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -481,63 +481,8 @@ const FantasyMain: React.FC = () => {
     window.location.hash = '#dashboard';
   }, []);
   
-  // プレミアムプラン未加入の場合
-  if (isGuest || !isPremiumOrHigher) {
-    return (
-      <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-pink-900 flex items-center justify-center overflow-y-auto">
-        <div className="text-white text-center max-w-md p-4">
-          <div className="mb-6">
-            <img src="/default_avater/default-avater.png" alt="ファンタジーモード" className="w-24 h-24 mx-auto" />
-          </div>
-          <h2 className="text-3xl font-bold mb-4">ファンタジーモード</h2>
-          
-          {isGuest ? (
-            <>
-              <p className="text-indigo-200 mb-6">
-                ファンタジーモードはログイン後にご利用いただけます。
-              </p>
-              <div className="space-y-4">
-                <button
-                  onClick={() => window.location.hash = '#login'}
-                  className="w-full px-6 py-3 bg-purple-600 hover:bg-purple-500 rounded-lg font-medium transition-colors"
-                >
-                  ログイン
-                </button>
-                <button
-                  onClick={handleBackToMenu}
-                  className="w-full px-6 py-2 bg-gray-600 hover:bg-gray-500 rounded-lg font-medium transition-colors"
-                >
-                  メニューに戻る
-                </button>
-              </div>
-            </>
-          ) : (
-            <>
-              <p className="text-indigo-200 mb-6">
-                ファンタジーモードはプレミアムプラン以上でご利用いただけます。
-                <br />
-                現在のプラン: <span className="text-yellow-300 font-bold capitalize">{profile?.rank}</span>
-              </p>
-              <div className="space-y-4">
-                <button
-                  onClick={() => window.location.hash = '#pricing'}
-                  className="w-full px-6 py-3 bg-purple-600 hover:bg-purple-500 rounded-lg font-medium transition-colors"
-                >
-                  プランをアップグレード
-                </button>
-                <button
-                  onClick={handleBackToMenu}
-                  className="w-full px-6 py-2 bg-gray-600 hover:bg-gray-500 rounded-lg font-medium transition-colors"
-                >
-                  メニューに戻る
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-      </div>
-    );
-  }
+  // ゲストとフリーユーザーはランク1のみプレイ可能なので、ここでは制限しない
+  // ランク2以降の制限はFantasyStageSelectコンポーネント内で行う
   
   // ゲーム結果画面
   if (showResult && gameResult) {

--- a/src/utils/fantasyLocalStorage.ts
+++ b/src/utils/fantasyLocalStorage.ts
@@ -1,0 +1,168 @@
+/**
+ * ゲストユーザー用ファンタジーモード進捗管理
+ * ローカルストレージを使用してステージ進捗を保存
+ */
+
+const FANTASY_PROGRESS_KEY = 'fantasy_guest_progress';
+const FANTASY_CLEARS_KEY = 'fantasy_guest_clears';
+
+export interface LocalFantasyProgress {
+  currentStageNumber: string;
+  totalClearedStages: number;
+  wizardRank: string;
+}
+
+export interface LocalFantasyClear {
+  stageId: string;
+  stageNumber: string;
+  clearedAt: string;
+  score: number;
+  clearType: 'clear' | 'gameover';
+  remainingHp?: number;
+  totalQuestions: number;
+  correctAnswers: number;
+}
+
+/**
+ * ゲストユーザーの進捗を取得
+ */
+export function getGuestFantasyProgress(): LocalFantasyProgress {
+  try {
+    const stored = localStorage.getItem(FANTASY_PROGRESS_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (error) {
+    console.error('ゲスト進捗の読み込みエラー:', error);
+  }
+  
+  // デフォルトの進捗（ランク1-1から開始）
+  return {
+    currentStageNumber: '1-1',
+    totalClearedStages: 0,
+    wizardRank: 'F'
+  };
+}
+
+/**
+ * ゲストユーザーの進捗を保存
+ */
+export function saveGuestFantasyProgress(progress: LocalFantasyProgress): void {
+  try {
+    localStorage.setItem(FANTASY_PROGRESS_KEY, JSON.stringify(progress));
+  } catch (error) {
+    console.error('ゲスト進捗の保存エラー:', error);
+  }
+}
+
+/**
+ * ゲストユーザーのクリア記録を取得
+ */
+export function getGuestFantasyClears(): LocalFantasyClear[] {
+  try {
+    const stored = localStorage.getItem(FANTASY_CLEARS_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (error) {
+    console.error('ゲストクリア記録の読み込みエラー:', error);
+  }
+  
+  return [];
+}
+
+/**
+ * ゲストユーザーのクリア記録を追加
+ */
+export function addGuestFantasyClear(clear: LocalFantasyClear): void {
+  try {
+    const clears = getGuestFantasyClears();
+    // 同じステージのクリア記録があれば更新、なければ追加
+    const existingIndex = clears.findIndex(c => c.stageId === clear.stageId);
+    if (existingIndex >= 0) {
+      clears[existingIndex] = clear;
+    } else {
+      clears.push(clear);
+    }
+    localStorage.setItem(FANTASY_CLEARS_KEY, JSON.stringify(clears));
+  } catch (error) {
+    console.error('ゲストクリア記録の保存エラー:', error);
+  }
+}
+
+/**
+ * ゲストユーザーの次のステージ番号を更新
+ */
+export function updateGuestNextStage(nextStageNumber: string): void {
+  const progress = getGuestFantasyProgress();
+  const [currentRank] = progress.currentStageNumber.split('-').map(Number);
+  const [nextRank] = nextStageNumber.split('-').map(Number);
+  
+  // ランク2以降は進めない（ゲストユーザー制限）
+  if (nextRank > 1) {
+    return;
+  }
+  
+  progress.currentStageNumber = nextStageNumber;
+  progress.totalClearedStages += 1;
+  saveGuestFantasyProgress(progress);
+}
+
+/**
+ * ステージがゲストユーザーにとってアンロックされているかチェック
+ */
+export function isStageUnlockedForGuest(stageNumber: string): boolean {
+  const [rank] = stageNumber.split('-').map(Number);
+  
+  // ランク2以降はロック
+  if (rank > 1) {
+    return false;
+  }
+  
+  const progress = getGuestFantasyProgress();
+  const clears = getGuestFantasyClears();
+  
+  // クリア済みならアンロック
+  if (clears.some(c => c.stageNumber === stageNumber && c.clearType === 'clear')) {
+    return true;
+  }
+  
+  // 現在地より前ならアンロック
+  const [currR, currS] = progress.currentStageNumber.split('-').map(Number);
+  const [r, s] = stageNumber.split('-').map(Number);
+  
+  if (r < currR) return true;
+  if (r === currR && s <= currS) return true;
+  
+  return false;
+}
+
+/**
+ * フリーユーザーにとってステージがアンロックされているかチェック
+ */
+export function isStageUnlockedForFreeUser(stageNumber: string, userProgress: any, stageClears: any[]): boolean {
+  const [rank] = stageNumber.split('-').map(Number);
+  
+  // ランク2以降はロック（フリーユーザー制限）
+  if (rank > 1) {
+    return false;
+  }
+  
+  // ランク1内では通常のロジックを適用
+  if (!userProgress) return false;
+  
+  // クリア済みならアンロック
+  const stageId = stageClears.find(c => c.stageNumber === stageNumber)?.stageId;
+  if (stageId && stageClears.some(c => c.stageId === stageId && c.clearType === 'clear')) {
+    return true;
+  }
+  
+  // 現在地より前ならアンロック
+  const [currR, currS] = userProgress.currentStageNumber.split('-').map(Number);
+  const [r, s] = stageNumber.split('-').map(Number);
+  
+  if (r < currR) return true;
+  if (r === currR && s <= currS) return true;
+  
+  return false;
+}


### PR DESCRIPTION
Allow free and guest users to play Fantasy Mode Rank 1 (stages 1-1 to 1-10) with local storage progress tracking, locking Rank 2 onwards.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c51feb4-69d1-4c27-a336-138a67b5e65a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c51feb4-69d1-4c27-a336-138a67b5e65a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

