### PR TITLE
Enable fantasy mode for free and guest users

### DIFF
--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -100,16 +100,26 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           id: stage.id,
           stageNumber: stage.stage_number,
           name: stage.name,
-          description: stage.description,
+          description: stage.description || '',
           maxHp: stage.max_hp,
           enemyCount: stage.enemy_count,
           enemyHp: stage.enemy_hp,
           minDamage: stage.min_damage,
           maxDamage: stage.max_damage,
           enemyGaugeSeconds: stage.enemy_gauge_seconds,
-          mode: stage.mode,
-          allowedChords: stage.allowed_chords,
-          monsterIcon: stage.monster_icon
+          mode: stage.mode as 'single' | 'progression_order' | 'progression_random' | 'progression_timing',
+          allowedChords: Array.isArray(stage.allowed_chords) ? stage.allowed_chords : [],
+          chordProgression: Array.isArray(stage.chord_progression) ? stage.chord_progression : undefined,
+          chordProgressionData: stage.chord_progression_data,
+          showSheetMusic: stage.show_sheet_music || false,
+          showGuide: stage.show_guide || false,
+          monsterIcon: stage.monster_icon,
+          bgmUrl: stage.bgm_url || stage.mp3_url,
+          simultaneousMonsterCount: stage.simultaneous_monster_count || 1,
+          bpm: stage.bpm || 120,
+          measureCount: stage.measure_count,
+          countInMeasures: stage.count_in_measures,
+          timeSignature: stage.time_signature
         }));
         
         setStages(convertedStages);


### PR DESCRIPTION
Enable Fantasy mode access for free and guest users, limiting playable stages to 1-1 through 1-3 and preventing progress saving.

---
<a href="https://cursor.com/background-agent?bcId=bc-8254fb36-760a-483f-81c2-129cafa9e45a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8254fb36-760a-483f-81c2-129cafa9e45a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

