### PR TITLE
Adjust guest player dashboard and header

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -418,7 +418,7 @@ const Dashboard: React.FC = () => {
                 </button>
                 <button
                   onClick={() => { window.location.hash = '#login'; }}
-                  className="btn btn-outline"
+                  className="btn btn-secondary"
                 >
                   ログイン / 会員登録
                 </button>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -405,6 +405,12 @@ const Dashboard: React.FC = () => {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <button
+                  onClick={() => { window.location.hash = '#fantasy'; }}
+                  className="btn btn-primary"
+                >
+                  コードを覚える
+                </button>
+                <button
                   onClick={() => { window.location.hash = '#songs'; }}
                   className="btn btn-primary"
                 >

--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -9,6 +9,7 @@ import { FaHome, FaUserCircle } from 'react-icons/fa';
  */
 const GameHeader: React.FC = () => {
   const gameActions = useGameActions();
+  const { isGuest } = useAuthStore();
 
   return (
     <header className="flex-shrink-0 bg-game-surface border-b border-gray-700 px-3 py-1 z-[60]">
@@ -35,12 +36,12 @@ const GameHeader: React.FC = () => {
             曲選択
           </HashButton>
 
-          <HashButton hash="#lessons">レッスン</HashButton>
+          <HashButton hash="#lessons" disabled={isGuest}>レッスン</HashButton>
           <HashButton hash="#fantasy">ファンタジー</HashButton>
-          <HashButton hash="#ranking">ランキング</HashButton>
-          <HashButton hash="#missions">ミッション</HashButton>
-          <HashButton hash="#diary">日記</HashButton>
-          <HashButton hash="#information">お知らせ</HashButton>
+          <HashButton hash="#ranking" disabled={isGuest}>ランキング</HashButton>
+          <HashButton hash="#missions" disabled={isGuest}>ミッション</HashButton>
+          <HashButton hash="#diary" disabled={isGuest}>日記</HashButton>
+          <HashButton hash="#information" disabled={isGuest}>お知らせ</HashButton>
         </div>
 
         {/* 右側のコントロール */}
@@ -55,9 +56,10 @@ interface HashButtonProps {
   hash: string;
   children: React.ReactNode;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-const HashButton: React.FC<HashButtonProps> = ({ hash, children, onClick }) => {
+const HashButton: React.FC<HashButtonProps> = ({ hash, children, onClick, disabled }) => {
   const [currentHash, setCurrentHash] = useState(window.location.hash);
 
   useEffect(() => {
@@ -71,10 +73,13 @@ const HashButton: React.FC<HashButtonProps> = ({ hash, children, onClick }) => {
   return (
     <button
       onClick={() => {
-        window.location.hash = hash;
-        onClick?.();
+        if (!disabled) {
+          window.location.hash = hash;
+          onClick?.();
+        }
       }}
-      className={`tab-xs ${active ? 'tab-active' : 'tab-inactive'}`}
+      className={`tab-xs ${active ? 'tab-active' : 'tab-inactive'} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+      disabled={disabled}
     >
       {children}
     </button>


### PR DESCRIPTION
Restricts guest user header navigation and adds a 'Learn Chords' button to the guest dashboard.

The 'Learn Chords' button now navigates to Fantasy mode to align with guest access restrictions and provide a relevant chord practice feature, as 'Lessons' are disabled for guests in the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb19c063-ea9b-4f7c-a8db-33e62ab76067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb19c063-ea9b-4f7c-a8db-33e62ab76067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

