### PR TITLE
Disable header and remove button for guests

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -411,12 +411,6 @@ const Dashboard: React.FC = () => {
                   コードを覚える
                 </button>
                 <button
-                  onClick={() => { window.location.hash = '#songs'; }}
-                  className="btn btn-primary"
-                >
-                  曲を練習する
-                </button>
-                <button
                   onClick={() => { window.location.hash = '#login'; }}
                   className="btn btn-secondary"
                 >

--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -32,6 +32,7 @@ const GameHeader: React.FC = () => {
             onClick={() => {
               gameActions.setCurrentTab?.('songs');
             }}
+            disabled={isGuest}
           >
             曲選択
           </HashButton>


### PR DESCRIPTION
Disable song selection for guest users and remove the practice songs button from the guest dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-780b4b67-286f-43c7-8ae4-91d8d8e801b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-780b4b67-286f-43c7-8ae4-91d8d8e801b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

