### PR TITLE
Fantasy mode chord root sound

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -31,12 +31,13 @@ type StageMode =
   | 'progression_timing';
 
 interface ChordDefinition {
-  id: string;          // コードのID（例: 'CM7', 'G7', 'Am'）
+  id: string;          // コードのID（例: 'CM7', 'G7', 'Am', 'C/E'）
   displayName: string; // 表示名（言語・簡易化設定に応じて変更）
   notes: number[];     // MIDIノート番号の配列
   noteNames: string[]; // ★ 理論的に正しい音名配列を追加
   quality: string;     // コードの性質（'major', 'minor', 'dominant7'など）
   root: string;        // ルート音（例: 'C', 'G', 'A'）
+  bass?: string;       // オンコードのベース音（例: 'E', 'G'）
 }
 
 interface FantasyStage {
@@ -154,7 +155,8 @@ const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDe
     notes: midiNotes,
     noteNames: resolved.notes, // 理論的に正しい音名配列を追加
     quality: resolved.quality,
-    root: resolved.root
+    root: resolved.root,
+    bass: resolved.bass // オンコードのベース音を追加
   };
 };
 

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -277,10 +277,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     }
 
     // ルート音を再生（非同期対応）
+    // オンコードの場合は分母のベース音を、通常のコードはルート音を再生
     if (settings.playRootSound) {
       try {
         const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-        await FantasySoundManager.playRootNote(chord.root);
+        const noteToPlay = chord.bass || chord.root; // オンコードならベース音、通常ならルート音
+        await FantasySoundManager.playRootNote(noteToPlay);
       } catch (error) {
         console.error('Failed to play root note:', error);
       }


### PR DESCRIPTION
Add support for on-chords (slash chords) in Fantasy Mode, allowing players to play only the numerator chord while the denominator's root note is used for the correct answer sound.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea40953c-bc2b-4fd0-a5f5-7545e2af3f72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea40953c-bc2b-4fd0-a5f5-7545e2af3f72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

