### PR TITLE
Fix fantasy mode BGM and question loop

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -474,6 +474,7 @@ export const useFantasyGameEngine = ({
     const currentTime = bgmManager.getCurrentMusicTime();
     const stage = prevState.currentStage;
     const secPerMeasure = (60 / (stage?.bpm || 120)) * (stage?.timeSignature || 4);
+    // M1開始を0sとした1周の長さ
     const loopDuration = (stage?.measureCount || 8) * secPerMeasure;
     
     // ループ対応の判定を使用

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -444,9 +444,6 @@ export const useFantasyGameEngine = ({
       // ループ: 最初に戻る
       devLog.debug('🔄 太鼓の達人：ループ処理（input時）');
       
-      // ★ 追加: BGMをリセット
-      bgmManager.resetToStart();
-      
       // 全てのノーツのisHit/isMissedをリセット
       const resetNotes = prevState.taikoNotes.map(note => ({
         ...note,
@@ -802,7 +799,7 @@ export const useFantasyGameEngine = ({
 
         case 'progression_order':
         default:
-          // 基本版：小節の頭でコード出題
+          // 基本版：小節の頭でコード出題（Measure 1 から）
           if (stage.chordProgression) {
             taikoNotes = generateBasicProgressionNotes(
               stage.chordProgression,
@@ -810,7 +807,7 @@ export const useFantasyGameEngine = ({
               stage.bpm || 120,
               stage.timeSignature || 4,
               (chordId) => getChordDefinition(chordId, displayOpts),
-              0 // カウントインを渡す
+              0
             );
           }
           break;
@@ -819,16 +816,10 @@ export const useFantasyGameEngine = ({
       // ループ対応：最初のノーツの情報を設定
       if (taikoNotes.length > 0) {
         // 最初のモンスターのコードを設定（M2から開始）
-        if (activeMonsters.length > 0 && taikoNotes.length > 0) { // 修正：taikoNotes.length > 1ではなく > 0
-          // 基本版の場合、最初のノーツ（インデックス0）がM2
-          activeMonsters[0].chordTarget = taikoNotes[0].chord; // 最初のノーツ（M2）
-          // 2番目のノーツがある場合は次のコードとして設定
-          if (taikoNotes.length > 1) {
-            activeMonsters[0].nextChord = taikoNotes[1].chord;
-          } else {
-            // ループする場合は最初に戻る
-            activeMonsters[0].nextChord = taikoNotes[0].chord;
-          }
+        if (activeMonsters.length > 0 && taikoNotes.length > 0) {
+          // 最初のノーツ（Measure 1）を現在コード、次をnextに設定
+          activeMonsters[0].chordTarget = taikoNotes[0].chord;
+          activeMonsters[0].nextChord = taikoNotes.length > 1 ? taikoNotes[1].chord : taikoNotes[0].chord;
         }
       }
       
@@ -1086,12 +1077,7 @@ export const useFantasyGameEngine = ({
         return prevState;
       }
       
-      // modeがsingle以外の場合はゲージを更新しない
-      if (prevState.currentStage.mode !== 'single') {
-        return prevState;
-      }
-      
-      // 太鼓の達人モードの場合は専用のミス判定を行う
+      // 太鼓の達人モードの場合は専用のミス判定を行う（single以外）
       if (prevState.isTaikoMode && prevState.taikoNotes.length > 0) {
         const currentTime = bgmManager.getCurrentMusicTime();
         const stage = prevState.currentStage;
@@ -1110,15 +1096,26 @@ export const useFantasyGameEngine = ({
             isMissed: false
           }));
           
-          // ★ 追加: BGMをリセット
-          bgmManager.resetToStart();
-          
           devLog.debug('🔄 太鼓の達人：ループ処理（tick）');
+          
+          // 先頭と次のノーツ
+          const firstNote = resetNotes[0];
+          const secondNote = resetNotes.length > 1 ? resetNotes[1] : resetNotes[0];
+
+          // モンスターの表示コードもループ先頭に合わせて更新
+          const refreshedMonsters = prevState.activeMonsters.map(m => ({
+            ...m,
+            correctNotes: [],
+            gauge: 0,
+            chordTarget: firstNote?.chord || m.chordTarget,
+            nextChord: secondNote?.chord || firstNote?.chord || m.nextChord
+          }));
           
           return {
             ...prevState,
             currentNoteIndex: 0,
-            taikoNotes: resetNotes
+            taikoNotes: resetNotes,
+            activeMonsters: refreshedMonsters
           };
         }
         
@@ -1137,6 +1134,10 @@ export const useFantasyGameEngine = ({
           timeDiff += loopDuration;
         }
         
+        // カウントイン中はミス判定しない
+        if (currentTime < 0) {
+          return prevState;
+        }
         // ミス判定：+300ms以上経過した場合
         if (timeDiff > 0.3) {
           devLog.debug('💥 太鼓の達人：ミス判定', {
@@ -1181,8 +1182,7 @@ export const useFantasyGameEngine = ({
           };
         }
         
-        // 太鼓モードではゲージを更新しない
-        return prevState;
+              return prevState;
       }
       
       const incrementRate = 100 / (prevState.currentStage.enemyGaugeSeconds * 10); // 100ms間隔で更新

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -576,9 +576,18 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const currentTime = bgmManager.getCurrentMusicTime();
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
       
-      // カウントイン中は出題を表示しない
+      // カウントイン中はM1の1拍目のノーツだけ先行表示
       if (currentTime < 0) {
-        fantasyPixiInstance.updateTaikoNotes([]);
+        const notesToDisplay: Array<{id: string, chord: string, x: number}> = [];
+        const first = gameState.taikoNotes[0];
+        if (first) {
+          const timeUntilHit = -currentTime; // hitTime=0 までの残り秒
+          if (timeUntilHit <= lookAheadTime) {
+            const x = judgeLinePos.x + timeUntilHit * noteSpeed;
+            notesToDisplay.push({ id: first.id, chord: first.chord.displayName, x });
+          }
+        }
+        fantasyPixiInstance.updateTaikoNotes(notesToDisplay);
         animationId = requestAnimationFrame(updateTaikoNotes);
         return;
       }

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -563,7 +563,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     // ループ情報を事前計算
     const stage = gameState.currentStage!;
-    const loopDuration = stage.measureCount * (60 / stage.bpm) * stage.timeSignature;
+          const loopDuration = (stage.measureCount || 8) * (60 / (stage.bpm || 120)) * (stage.timeSignature || 4);
     
     const updateTaikoNotes = (timestamp: number) => {
       // フレームレート制御
@@ -575,6 +575,13 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       
       const currentTime = bgmManager.getCurrentMusicTime();
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
+      
+      // カウントイン中は出題を表示しない
+      if (currentTime < 0) {
+        fantasyPixiInstance.updateTaikoNotes([]);
+        animationId = requestAnimationFrame(updateTaikoNotes);
+        return;
+      }
       const lookAheadTime = 4; // 4秒先まで表示
       const noteSpeed = 400; // ピクセル/秒
       

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -575,6 +575,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       
       const currentTime = bgmManager.getCurrentMusicTime();
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
+      const lookAheadTime = 4; // 4秒先まで表示
+      const noteSpeed = 400; // ピクセル/秒
       
       // カウントイン中はM1の1拍目のノーツだけ先行表示
       if (currentTime < 0) {
@@ -591,8 +593,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         animationId = requestAnimationFrame(updateTaikoNotes);
         return;
       }
-      const lookAheadTime = 4; // 4秒先まで表示
-      const noteSpeed = 400; // ピクセル/秒
       
       // 表示するノーツを収集
       const notesToDisplay: Array<{id: string, chord: string, x: number}> = [];

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -122,12 +122,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         stage.bpm || 120,
         stage.timeSignature || 4,
         stage.measureCount ?? 8,
-        0,
+        stage.countInMeasures ?? 0,
         settings.bgmVolume ?? 0.7
       );
-      
-      // ★ 追加: 初期化時にBGMを確実に0秒からスタート
-      bgmManager.resetToStart();
     }
     return () => bgmManager.stop();
   }, [isReady, stage, settings.bgmVolume]);
@@ -584,8 +581,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       // 表示するノーツを収集
       const notesToDisplay: Array<{id: string, chord: string, x: number}> = [];
       
-      // 現在の時間をループ内の時間に正規化
-      const normalizedTime = currentTime % loopDuration;
+      // 現在の時間（カウントイン中は負値）をループ内0..Tへ正規化
+      const normalizedTime = ((currentTime % loopDuration) + loopDuration) % loopDuration;
       
       // 通常のノーツ
       gameState.taikoNotes.forEach((note, index) => {
@@ -799,7 +796,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       {/* ===== ヘッダー ===== */}
       <div className="relative z-30 p-1 text-white flex-shrink-0" style={{ minHeight: '40px' }}>
         <div className="absolute left-1/2 -translate-x-1/2 text-sm text-yellow-300 font-dotgothic16">
-          <>M {currentMeasure} - B {currentBeat}</>
+          <>{bgmManager.getIsCountIn() ? 'Measure /' : `Measure ${currentMeasure}`} - B {currentBeat}</>
         </div>
         <div className="flex justify-between items-center">
           {/* ステージ情報と敵の数 */}

--- a/src/components/fantasy/TaikoNoteSystem.ts
+++ b/src/components/fantasy/TaikoNoteSystem.ts
@@ -106,21 +106,21 @@ export function generateBasicProgressionNotes(
   const secPerBeat = 60 / bpm;
   const secPerMeasure = secPerBeat * timeSignature;
   
-  // M2から(measureCount-1)まで出題（M1と最終小節は休み）
-  for (let measure = 2; measure <= measureCount - 1; measure++) {
-    const chordIndex = (measure - 2) % chordProgression.length; // M2を0番目としてインデックス
+  // 本来仕様：Measure 1〜Measure Count の各小節の1拍目に出題
+  for (let measure = 1; measure <= measureCount; measure++) {
+    const chordIndex = (measure - 1) % chordProgression.length;
     const chordId = chordProgression[chordIndex];
     const chord = getChordDefinition(chordId);
     
     if (chord) {
-      // M1の時間を0として計算
+      // Measure 1 開始を0秒として計算（countInはBGM側でオフセット管理）
       const hitTime = (measure - 1) * secPerMeasure;
       
       notes.push({
         id: `note_${measure}_1`,
         chord,
         hitTime,
-        measure, // 表示用の小節番号
+        measure,
         beat: 1,
         isHit: false,
         isMissed: false
@@ -157,8 +157,8 @@ export function generateRandomProgressionNotes(
 
   let lastChordId = '';
 
-  // M2から(measureCount-1)まで出題（M1と最終小節は休み）
-  for (let measure = 2; measure <= measureCount - 1; measure++) {
+  // 本来仕様：Measure 1〜Measure Count の各小節の1拍目に出題
+  for (let measure = 1; measure <= measureCount; measure++) {
     // 直前と同じコードは避ける
     let nextId = chordPool[safeRandom()];
     if (chordPool.length > 1) {
@@ -209,19 +209,17 @@ export function parseChordProgressionData(
   const maxBar = Math.max(...progressionData.map(item => item.bar), 0);
   
   progressionData.forEach((item, index) => {
-    // M1と最終小節をスキップ
-    if (item.bar === 1 || item.bar === maxBar) return;
-    
+    // 本来仕様：Measure 1〜maxBar すべて許可
     const chord = getChordDefinition(item.chord);
     if (chord) {
-      // カウントイン時間を加算
+      // Measure 1 開始を0秒として計算
       const hitTime = (item.bar - 1) * secPerMeasure + (item.beats - 1) * secPerBeat;
       
       notes.push({
         id: `note_${item.bar}_${item.beats}_${index}`,
         chord,
         hitTime,
-        measure: item.bar, // 表示用の小節番号
+        measure: item.bar,
         beat: item.beats,
         isHit: false,
         isMissed: false

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -13,7 +13,8 @@ class BGMManager {
   private isPlaying = false
   private loopScheduled = false
   private nextLoopTime = 0
-  private loopTimeoutId: number | null = null // タイムアウトIDを保持
+  private loopTimeoutId: number | null = null // タイムアウトID
+  private loopCheckIntervalId: number | null = null // ループ監視Interval
 
   play(
     url: string,
@@ -41,7 +42,6 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    // ループ区間は「カウントイン直後（=Measure 1 の開始）」〜「Measure Count 演奏後」
     this.loopBegin = this.countInMeasures * secPerMeas
     this.loopEnd = (this.countInMeasures + measureCount) * secPerMeas
 
@@ -52,37 +52,47 @@ class BGMManager {
     this.audio.addEventListener('error', this.handleError)
     this.audio.addEventListener('ended', this.handleEnded)
     
-    // timeupdate イベントハンドラを保存（より精密なループ処理）
+    // timeupdate による事前スケジュール（補助）
     this.timeUpdateHandler = () => {
       if (!this.audio || !this.isPlaying) return
-      
       const currentTime = this.audio.currentTime
       const timeToEnd = this.loopEnd - currentTime
-      
-      // ループの事前スケジューリング（100ms前に準備）
-      if (timeToEnd < 0.1 && timeToEnd > 0 && !this.loopScheduled) {
+      if (timeToEnd < 0.08 && timeToEnd > 0 && !this.loopScheduled) {
         this.loopScheduled = true
         this.nextLoopTime = this.loopBegin
-        
-        // タイムアウトIDを保持
         this.loopTimeoutId = window.setTimeout(() => {
           if (this.audio && this.isPlaying) {
             this.audio.currentTime = this.nextLoopTime
-            console.log(`🔄 BGM Loop (scheduled): → ${this.nextLoopTime.toFixed(2)}s`)
           }
           this.loopScheduled = false
           this.loopTimeoutId = null
-        }, Math.max(0, timeToEnd * 1000 - 50)) // 50ms早めに実行
+        }, Math.max(0, timeToEnd * 1000 - 30))
       }
     }
-    
     this.audio.addEventListener('timeupdate', this.timeUpdateHandler)
-    
-    // 再生開始時刻を記録
-    this.startTime = performance.now()
-    this.isPlaying = true
+
+    // ループ監視Interval（最終防衛ライン）
+    this.loopCheckIntervalId = window.setInterval(() => {
+      if (!this.audio || !this.isPlaying) return
+      const now = this.audio.currentTime
+      // 少し早めに巻き戻す（デコーダの遅延考慮）
+      const epsilon = 0.02
+      if (now >= this.loopEnd - epsilon) {
+        try {
+          this.audio.currentTime = this.loopBegin
+          // 再生が止まっていたら再開
+          if (this.audio.paused) {
+            void this.audio.play().catch(() => {})
+          }
+        } catch (e) {
+          // noop
+        }
+      }
+    }, 25)
     
     // 再生開始
+    this.startTime = performance.now()
+    this.isPlaying = true
     const playPromise = this.audio.play()
     if (playPromise !== undefined) {
       playPromise
@@ -106,199 +116,121 @@ class BGMManager {
     this.isPlaying = false
     this.loopScheduled = false
     
-    // タイムアウトのクリア
     if (this.loopTimeoutId !== null) {
       clearTimeout(this.loopTimeoutId)
       this.loopTimeoutId = null
     }
+    if (this.loopCheckIntervalId !== null) {
+      clearInterval(this.loopCheckIntervalId)
+      this.loopCheckIntervalId = null
+    }
     
     if (this.audio) {
-      // イベントリスナーの削除
       if (this.timeUpdateHandler) {
         this.audio.removeEventListener('timeupdate', this.timeUpdateHandler)
         this.timeUpdateHandler = null
       }
-      
-      // その他のイベントリスナーも削除
       this.audio.removeEventListener('ended', this.handleEnded)
       this.audio.removeEventListener('error', this.handleError)
-      
-      // オーディオの停止と解放
       try {
         this.audio.pause()
         this.audio.currentTime = 0
-        this.audio.src = '' // srcをクリアしてメモリを解放
-        this.audio.load() // 明示的にリソースを解放
+        this.audio.src = ''
+        this.audio.load()
       } catch (e) {
         console.warn('Audio cleanup error:', e)
       }
-      
       this.audio = null
     }
     
     console.log('🔇 BGM停止・クリーンアップ完了')
   }
   
-  // エラーハンドリング
   private handleError = (e: Event) => {
     console.error('BGM playback error:', e)
     this.isPlaying = false
   }
   
-  // 終了ハンドリング
   private handleEnded = () => {
     if (this.loopEnd > 0) {
       this.audio!.currentTime = this.loopBegin
-      this.audio!.play().catch(console.error)
+      this.audio!.play().catch(() => {})
     }
   }
   
-  // タイミング管理用の新しいメソッド
-  
   /**
-   * 現在の音楽的時間を取得（秒単位）
-   * カウントイン終了時（Measure 1 開始）を0秒とする。
-   * カウントイン中は負の値を返す。
+   * 現在の音楽的時間（秒）。M1開始=0、カウントイン中は負。
    */
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
-    
-    const t = this.audio.currentTime - this.loopBegin
-    return t
+    return this.audio.currentTime - this.loopBegin
   }
   
-  /**
-   * 現在の小節番号を取得（1始まり）
-   * カウントイン中は0を返す（UI側で"/"表記）
-   */
+  /** 小節番号（1始まり）。カウントイン中は0 */
   getCurrentMeasure(): number {
     const musicTime = this.getCurrentMusicTime()
-    
     const secPerMeasure = (60 / this.bpm) * this.timeSignature
     if (musicTime < 0) return 0
-
     const measure = Math.floor(musicTime / secPerMeasure) + 1
-    
-    // ループを考慮（Measure 1..measureCount）
     return ((measure - 1) % this.measureCount) + 1
   }
   
-  /**
-   * 現在の拍番号を取得（1始まり）
-   */
+  /** 現在の拍（1始まり） */
   getCurrentBeat(): number {
     if (!this.isPlaying || !this.audio) return 1
-    
     const audioTime = this.audio.currentTime
     const secPerBeat = 60 / this.bpm
     const totalBeats = Math.floor(audioTime / secPerBeat)
-    const beatInMeasure = (totalBeats % this.timeSignature) + 1
-    return beatInMeasure
+    return (totalBeats % this.timeSignature) + 1
   }
   
-  /**
-   * 現在の小節内での拍位置を取得（0.0〜timeSignature）
-   * 例: 4/4拍子で2拍目の真ん中なら2.5
-   */
+  /** 小節内の拍位置（0..timeSignature） */
   getCurrentBeatPosition(): number {
     if (!this.isPlaying || !this.audio) return 0
-    
     const audioTime = this.audio.currentTime
     const secPerBeat = 60 / this.bpm
-    const beatPosition = (audioTime / secPerBeat) % this.timeSignature
-    return beatPosition
+    return (audioTime / secPerBeat) % this.timeSignature
   }
   
-  /**
-   * 指定した小節・拍の実時間（秒）を取得。
-   * Measure 1 の開始を this.loopBegin として、そこからのオフセットを返す。
-   * @param measure 小節番号（1始まり）
-   * @param beat 拍番号（1始まり、小数可）
-   */
+  /** 指定小節・拍の実時間（秒）。M1開始を基準 */
   getMusicTimeAt(measure: number, beat: number): number {
     const secPerBeat = 60 / this.bpm
     const secPerMeasure = secPerBeat * this.timeSignature
-    
-    // 指定小節までの時間 + 拍の時間（M1基準）にループ開始位置を加算
     return this.loopBegin + (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
   }
   
-  /**
-   * 次の拍タイミングまでの時間を取得（ミリ秒）
-   */
+  /** 次の拍までの残り時間（ms） */
   getTimeToNextBeat(): number {
     if (!this.isPlaying || !this.audio) return 0
-    
     const audioTime = this.audio.currentTime
     const secPerBeat = 60 / this.bpm
     const nextBeatTime = Math.ceil(audioTime / secPerBeat) * secPerBeat
     return (nextBeatTime - audioTime) * 1000
   }
   
-  /**
-   * 次のループまでの時間を取得（ミリ秒）
-   */
+  /** 次のループまでの残り時間（ms） */
   getTimeToLoop(): number {
     if (!this.isPlaying || !this.audio) return Infinity
-    
     const currentTime = this.audio.currentTime
     const timeToEnd = this.loopEnd - currentTime
-    
     return timeToEnd > 0 ? timeToEnd * 1000 : 0
   }
   
-  /**
-   * 音楽再生中かどうか
-   */
-  getIsPlaying(): boolean {
-    return this.isPlaying
-  }
-  
-  /**
-   * カウントイン中かどうか
-   */
-  getIsCountIn(): boolean {
-    if (!this.audio) return false
-    return this.audio.currentTime < this.loopBegin
-  }
-  
-  /**
-   * BPMを取得
-   */
-  getBPM(): number {
-    return this.bpm
-  }
-  
-  /**
-   * 拍子を取得
-   */
-  getTimeSignature(): number {
-    return this.timeSignature
-  }
-  
-  /**
-   * 総小節数（カウントイン除く）を取得
-   */
-  getMeasureCount(): number {
-    return this.measureCount
-  }
-  
-  /**
-   * カウントイン小節数を取得
-   */
-  getCountInMeasures(): number {
-    return this.countInMeasures
-  }
-  
-  /**
-   * BGMをMeasure 1の開始位置（ループ先頭）にリセット
-   * ゲームの小節ループと同期するために使用
-   */
+  getIsPlaying(): boolean { return this.isPlaying }
+  getBPM(): number { return this.bpm }
+  getTimeSignature(): number { return this.timeSignature }
+  getMeasureCount(): number { return this.measureCount }
+  getCountInMeasures(): number { return this.countInMeasures }
+  getIsCountIn(): boolean { return !!this.audio && this.audio.currentTime < this.loopBegin }
+
+  /** Measure 1 の開始へリセット */
   resetToStart() {
     if (!this.audio || !this.isPlaying) return
-    
     try {
       this.audio.currentTime = this.loopBegin
+      if (this.audio.paused) {
+        void this.audio.play().catch(() => {})
+      }
       console.log('🔄 BGMをMeasure 1の開始へリセット')
     } catch (error) {
       console.warn('BGMリセットエラー:', error)

--- a/src/utils/BGMManager.ts
+++ b/src/utils/BGMManager.ts
@@ -5,10 +5,11 @@ class BGMManager {
   private loopBegin = 0
   private loopEnd = 0
   private timeUpdateHandler: (() => void) | null = null
-  private startTime = 0  // BGM開始時刻（performance.now()）
+  private startTime = 0  // BGM開始時刻（performance.now）
   private bpm = 120
   private timeSignature = 4
   private measureCount = 8
+  private countInMeasures = 0
   private isPlaying = false
   private loopScheduled = false
   private nextLoopTime = 0
@@ -31,6 +32,7 @@ class BGMManager {
     this.bpm = bpm
     this.timeSignature = timeSig
     this.measureCount = measureCount
+    this.countInMeasures = Math.max(0, Math.floor(countIn || 0))
     
     this.audio = new Audio(url)
     this.audio.preload = 'auto'
@@ -39,10 +41,11 @@ class BGMManager {
     /* 計算: 1 拍=60/BPM 秒・1 小節=timeSig 拍 */
     const secPerBeat = 60 / bpm
     const secPerMeas = secPerBeat * timeSig
-    this.loopBegin = 0 // 0 秒からループ
-    this.loopEnd = measureCount * secPerMeas
+    // ループ区間は「カウントイン直後（=Measure 1 の開始）」〜「Measure Count 演奏後」
+    this.loopBegin = this.countInMeasures * secPerMeas
+    this.loopEnd = (this.countInMeasures + measureCount) * secPerMeas
 
-    // 初回再生は最初から（カウントインを含む）
+    // 初回再生は0秒から（カウントインを含む）
     this.audio.currentTime = 0
     
     // エラーハンドリング
@@ -84,7 +87,7 @@ class BGMManager {
     if (playPromise !== undefined) {
       playPromise
         .then(() => {
-          console.log('🎵 BGM再生開始:', { url, bpm, loopBegin: this.loopBegin, loopEnd: this.loopEnd })
+          console.log('🎵 BGM再生開始:', { url, bpm, loopBegin: this.loopBegin, loopEnd: this.loopEnd, countIn: this.countInMeasures })
         })
         .catch((error) => {
           console.warn('BGM playback failed:', error)
@@ -154,26 +157,29 @@ class BGMManager {
   
   /**
    * 現在の音楽的時間を取得（秒単位）
-   * カウントイン終了時を0秒とする
+   * カウントイン終了時（Measure 1 開始）を0秒とする。
+   * カウントイン中は負の値を返す。
    */
   getCurrentMusicTime(): number {
     if (!this.isPlaying || !this.audio) return 0
     
-    // オーディオの現在時間をそのまま返す（カウントインが無いため）
-    return this.audio.currentTime
+    const t = this.audio.currentTime - this.loopBegin
+    return t
   }
   
   /**
    * 現在の小節番号を取得（1始まり）
-   * カウントイン中は0を返す
+   * カウントイン中は0を返す（UI側で"/"表記）
    */
   getCurrentMeasure(): number {
     const musicTime = this.getCurrentMusicTime()
     
     const secPerMeasure = (60 / this.bpm) * this.timeSignature
+    if (musicTime < 0) return 0
+
     const measure = Math.floor(musicTime / secPerMeasure) + 1
     
-    // ループを考慮
+    // ループを考慮（Measure 1..measureCount）
     return ((measure - 1) % this.measureCount) + 1
   }
   
@@ -181,9 +187,9 @@ class BGMManager {
    * 現在の拍番号を取得（1始まり）
    */
   getCurrentBeat(): number {
-    if (!this.isPlaying) return 1
+    if (!this.isPlaying || !this.audio) return 1
     
-    const audioTime = this.audio?.currentTime || 0
+    const audioTime = this.audio.currentTime
     const secPerBeat = 60 / this.bpm
     const totalBeats = Math.floor(audioTime / secPerBeat)
     const beatInMeasure = (totalBeats % this.timeSignature) + 1
@@ -204,7 +210,8 @@ class BGMManager {
   }
   
   /**
-   * 指定した小節・拍の時刻を取得（秒単位）
+   * 指定した小節・拍の実時間（秒）を取得。
+   * Measure 1 の開始を this.loopBegin として、そこからのオフセットを返す。
    * @param measure 小節番号（1始まり）
    * @param beat 拍番号（1始まり、小数可）
    */
@@ -212,8 +219,8 @@ class BGMManager {
     const secPerBeat = 60 / this.bpm
     const secPerMeasure = secPerBeat * this.timeSignature
     
-    // 指定小節までの時間 + 拍の時間
-    return (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
+    // 指定小節までの時間 + 拍の時間（M1基準）にループ開始位置を加算
+    return this.loopBegin + (measure - 1) * secPerMeasure + (beat - 1) * secPerBeat
   }
   
   /**
@@ -248,6 +255,14 @@ class BGMManager {
   }
   
   /**
+   * カウントイン中かどうか
+   */
+  getIsCountIn(): boolean {
+    if (!this.audio) return false
+    return this.audio.currentTime < this.loopBegin
+  }
+  
+  /**
    * BPMを取得
    */
   getBPM(): number {
@@ -262,7 +277,7 @@ class BGMManager {
   }
   
   /**
-   * 総小節数を取得
+   * 総小節数（カウントイン除く）を取得
    */
   getMeasureCount(): number {
     return this.measureCount
@@ -272,28 +287,21 @@ class BGMManager {
    * カウントイン小節数を取得
    */
   getCountInMeasures(): number {
-    return 0 // カウントイン小節数は削除
+    return this.countInMeasures
   }
   
   /**
-   * カウントイン中かどうか（廃止のため常にfalse）
-   */
-  getIsCountIn(): boolean {
-    return false
-  }
-  
-  /**
-   * BGMを即座に開始地点（0秒）にリセット
+   * BGMをMeasure 1の開始位置（ループ先頭）にリセット
    * ゲームの小節ループと同期するために使用
    */
   resetToStart() {
-    if (!this.audio || !this.isPlaying) return;
+    if (!this.audio || !this.isPlaying) return
     
     try {
-      this.audio.currentTime = 0;
-      console.log('🔄 BGMを0秒にリセット');
+      this.audio.currentTime = this.loopBegin
+      console.log('🔄 BGMをMeasure 1の開始へリセット')
     } catch (error) {
-      console.warn('BGMリセットエラー:', error);
+      console.warn('BGMリセットエラー:', error)
     }
   }
 }


### PR DESCRIPTION
Restore fantasy mode BGM and question looping to original specification, fixing incorrect handling of count-in measures and loop boundaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-17a002f8-5933-44f3-9d36-71176ae1de64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17a002f8-5933-44f3-9d36-71176ae1de64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

