### PR TITLE
Investigate null error in fantasy mode progression

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -570,6 +570,11 @@ export const useFantasyGameEngine = ({
         return m;
       });
       
+      // ★ 完了ノーツを isHit=true に更新（表示から除外）
+      const updatedTaikoNotes = prevState.taikoNotes.map((n, i) =>
+        i === prevState.currentNoteIndex ? { ...n, isHit: true } : n
+      );
+      
       // 敵を倒した場合、新しいモンスターを補充
       if (isDefeated) {
         const remainingMonsters = updatedMonsters.filter(m => m.id !== currentMonster.id);
@@ -618,8 +623,8 @@ export const useFantasyGameEngine = ({
           activeMonsters: remainingMonsters,
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
-                      currentNoteIndex: nextNoteIndex,
-            taikoNotes: prevState.taikoNotes,
+          currentNoteIndex: nextNoteIndex,
+          taikoNotes: updatedTaikoNotes,
           correctAnswers: prevState.correctAnswers + 1,
           score: prevState.score + 100 * actualDamage,
           enemiesDefeated: newEnemiesDefeated
@@ -631,7 +636,7 @@ export const useFantasyGameEngine = ({
         activeMonsters: updatedMonsters,
         playerSp: newSp,
         currentNoteIndex: nextNoteIndex,
-        taikoNotes: prevState.taikoNotes,
+        taikoNotes: updatedTaikoNotes,
         correctAnswers: prevState.correctAnswers + 1,
         score: prevState.score + 100 * actualDamage
       };

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -473,9 +473,11 @@ export class FantasyPIXIInstance {
     try {
       devLog.debug('👾 モンスタースプライト作成開始:', { icon });
       
-      // 既存のテクスチャをクリア
+      // 既存のテクスチャをクリア（共有ベーステクスチャは破棄しない）
       if (this.monsterSprite.texture && this.monsterSprite.texture !== PIXI.Texture.EMPTY) {
-        this.monsterSprite.texture.destroy(true);
+        if (!this.monsterSprite.texture.destroyed) {
+          this.monsterSprite.texture.destroy(false);
+        }
       }
       
       // ★★★ createMonsterSpriteForId を画像ベースに修正 ★★★
@@ -710,17 +712,17 @@ export class FantasyPIXIInstance {
         
         // 非同期で本物のテクスチャをロードして差し替える
         loadMonsterTexture(icon).then(loadedTexture => {
-          if (!placeholder.destroyed) {
+          if (!placeholder.destroyed && loadedTexture && !(loadedTexture as any).destroyed && (loadedTexture as any).valid) {
             placeholder.texture = loadedTexture;
             placeholder.tint = 0xFFFFFF;
             
             // αを滑らかに 0→1 にする
-            const targetScale = this.calcSpriteScale(
-              loadedTexture,
-              this.app.screen.width,
-              200,
-              this.monsterSprites.size || 1
-            );
+                         const targetScale = this.calcSpriteScale(
+               loadedTexture,
+               this.app?.screen?.width ?? 0,
+               200,
+               this.monsterSprites.size || 1
+             );
 
             placeholder.scale.set(targetScale);
 
@@ -2121,7 +2123,8 @@ export class FantasyPIXIInstance {
       this.imageTextures.forEach((texture: PIXI.Texture) => {
         try {
           if (texture && typeof texture.destroy === 'function' && !texture.destroyed) {
-            texture.destroy(true);
+            // BaseTexture を共有している可能性があるためテクスチャのみ破棄
+            texture.destroy(false);
           }
         } catch (error) {
           devLog.debug('⚠️ 画像テクスチャ削除エラー:', error);

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -845,11 +845,13 @@ export class PIXINotesRendererInstance {
       graphics.beginFill(0x000000, 0);
       graphics.drawRect(-width / 2, -height / 2, width, height);
       graphics.endFill();
+      graphics.alpha = 0;
       return;
     }
 
     // より美しいグラデーション効果を再現（平らなノーツ対応）
     if (state === 'visible') {
+      graphics.alpha = 1; // デフォルトで明るく
       if (isBlackKey) {
         // 黒鍵ノーツ（紫系のグラデーション）- 平らなノーツ用に調整
         const steps = Math.max(2, Math.min(4, Math.floor(height / 2))); // 高さに応じて段数を調整
@@ -2292,6 +2294,8 @@ export class PIXINotesRendererInstance {
         noteSprite.sprite.texture = isBlackNote
           ? this.noteTextures.blackVisible
           : this.noteTextures.whiteVisible;
+        // 明るさ維持のため、visible 状態の初期αをやや高くする
+        noteSprite.sprite.alpha = 1;
       }
     }
     


### PR DESCRIPTION
Fixes PIXI texture destruction to prevent `uvsFloat32` errors and ensures consistent note brightness and visibility after hits.

The `uvsFloat32` error was caused by `PIXI.Texture.destroy(true)` which also destroyed the shared `BaseTexture`, leading to null references on subsequent texture reloads (e.g., on retry). This is fixed by using `destroy(false)` to only destroy the `Texture` itself, along with added validity checks. Note brightness is now explicitly set to 1 for visible notes and 0 for hit graphics to prevent flickering and ensure consistent appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-125b6e70-7111-44c2-ac81-1646afeb2d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-125b6e70-7111-44c2-ac81-1646afeb2d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

