### PR TITLE
Add taiko note hit effects and disappearance

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -555,6 +555,11 @@ export const useFantasyGameEngine = ({
       // SP更新
       const newSp = isSpecialAttack ? 0 : Math.min(prevState.playerSp + 1, 5);
       
+      // 現在ヒットしたノーツにフラグを立てる
+      const updatedTaikoNotes = prevState.taikoNotes.map((n, i) =>
+        i === prevState.currentNoteIndex ? { ...n, isHit: true } : n
+      );
+      
       // モンスター更新
       const updatedMonsters = prevState.activeMonsters.map(m => {
         if (m.id === currentMonster.id) {
@@ -607,7 +612,8 @@ export const useFantasyGameEngine = ({
             playerSp: newSp,
             enemiesDefeated: newEnemiesDefeated,
             correctAnswers: prevState.correctAnswers + 1,
-            currentNoteIndex: nextNoteIndex
+            currentNoteIndex: nextNoteIndex,
+            taikoNotes: updatedTaikoNotes
           };
           onGameComplete('clear', finalState);
           return finalState;
@@ -618,8 +624,8 @@ export const useFantasyGameEngine = ({
           activeMonsters: remainingMonsters,
           monsterQueue: newMonsterQueue,
           playerSp: newSp,
-                      currentNoteIndex: nextNoteIndex,
-            taikoNotes: prevState.taikoNotes,
+          currentNoteIndex: nextNoteIndex,
+          taikoNotes: updatedTaikoNotes,
           correctAnswers: prevState.correctAnswers + 1,
           score: prevState.score + 100 * actualDamage,
           enemiesDefeated: newEnemiesDefeated
@@ -631,7 +637,7 @@ export const useFantasyGameEngine = ({
         activeMonsters: updatedMonsters,
         playerSp: newSp,
         currentNoteIndex: nextNoteIndex,
-        taikoNotes: prevState.taikoNotes,
+        taikoNotes: updatedTaikoNotes,
         correctAnswers: prevState.correctAnswers + 1,
         score: prevState.score + 100 * actualDamage
       };

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -616,8 +616,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 2週目以降は全てのノーツを表示対象とする
         const loopCount = Math.floor(currentTime / loopDuration);
         
-        // 1週目のみ、処理済みのノーツをスキップ（直前にヒットしたノーツも含めて非表示）
-        if (loopCount === 0 && index < gameState.currentNoteIndex) return;
+        // 処理済みのノーツをスキップ（直前にヒットしたノーツも含めて非表示）
+        if (index < gameState.currentNoteIndex) return;
+        
+        // ヒット済みノーツは現在ループでは表示しない（次ループのプレビューには表示される）
+        if (note.isHit) return;
         
         // ループを考慮した時間差計算
         let timeUntilHit = note.hitTime - normalizedTime;
@@ -648,6 +651,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
+          // 次ループのプレビュー用には表示（idに _loop を付与）
           notesToDisplay.push({
             id: `${note.id}_loop`,
             chord: note.chord.displayName,

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -247,6 +247,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // PIXI.js レンダラー
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
   const [fantasyPixiInstance, setFantasyPixiInstance] = useState<FantasyPIXIInstance | null>(null);
+  const isTaikoModeRef = useRef(false);
   const gameAreaRef = useRef<HTMLDivElement>(null);
   const [gameAreaSize, setGameAreaSize] = useState({ width: 1000, height: 120 }); // ファンタジーモード用に高さを大幅に縮小
   
@@ -271,6 +272,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     
     if (fantasyPixiInstance) {
       fantasyPixiInstance.triggerAttackSuccessOnMonster(monsterId, chord.displayName, isSpecial, damageDealt, defeated);
+      // 太鼓progressionモード時は判定ライン上に小さなヒットエフェクトを表示
+      if (isTaikoModeRef.current) {
+        const pos = fantasyPixiInstance.getJudgeLinePosition();
+        fantasyPixiInstance.createNoteHitEffect(pos.x, pos.y, true);
+      }
     }
 
     // ルート音を再生（非同期対応）
@@ -484,6 +490,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     setFantasyPixiInstance(instance);
     // 初期状態の太鼓モードを設定
     instance.updateTaikoMode(gameState.isTaikoMode);
+    isTaikoModeRef.current = gameState.isTaikoMode;
   }, [gameState.isTaikoMode]);
   
   // 魔法名表示ハンドラー
@@ -550,6 +557,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   useEffect(() => {
     if (fantasyPixiInstance) {
       fantasyPixiInstance.updateTaikoMode(gameState.isTaikoMode);
+      isTaikoModeRef.current = gameState.isTaikoMode;
     }
   }, [fantasyPixiInstance, gameState.isTaikoMode]);
   
@@ -608,8 +616,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 2週目以降は全てのノーツを表示対象とする
         const loopCount = Math.floor(currentTime / loopDuration);
         
-        // 1週目のみ、処理済みのノーツをスキップ
-        if (loopCount === 0 && index < gameState.currentNoteIndex - 1) return;
+        // 1週目のみ、処理済みのノーツをスキップ（直前にヒットしたノーツも含めて非表示）
+        if (loopCount === 0 && index < gameState.currentNoteIndex) return;
         
         // ループを考慮した時間差計算
         let timeUntilHit = note.hitTime - normalizedTime;


### PR DESCRIPTION
Adds note disappearance and a small hit effect upon successful Taiko note hits in Fantasy progression mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2c96072-1834-4272-ac2e-82a325497fd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2c96072-1834-4272-ac2e-82a325497fd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

