### PR TITLE
Fix fantasy mode xp display on results

### DIFF
--- a/src/utils/xpCalculator.ts
+++ b/src/utils/xpCalculator.ts
@@ -124,8 +124,8 @@ export function calculateXPDetailed(params: XPCalcParams): XPDetailed {
 
 // 次レベル到達に必要な XP
 export function xpToNextLevel(currentLevel: number): number {
-  if (currentLevel <= 10) return 2000;
-  if (currentLevel <= 50) return 50000;
+  if (currentLevel < 10) return 2000;
+  if (currentLevel < 50) return 50000;
   return 100000;
 }
 

--- a/supabase/migrations/20250808094500_fix_xp_next_level_boundary.sql
+++ b/supabase/migrations/20250808094500_fix_xp_next_level_boundary.sql
@@ -1,0 +1,16 @@
+-- Fix XP next level boundary conditions to match app logic
+-- 1-9: 2,000 XP per level
+-- 10-49: 50,000 XP per level
+-- 50+: 100,000 XP per level
+
+CREATE OR REPLACE FUNCTION public.xp_to_next_level(current_level integer) RETURNS integer
+    LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN current_level < 10 THEN 2000
+    WHEN current_level < 50 THEN 50000
+    ELSE 100000
+  END;
+$$;
+
+COMMENT ON FUNCTION public.xp_to_next_level(current_level integer) IS 'Returns XP required for next level: 1-9=2000, 10-49=50000, 50+=100000.';


### PR DESCRIPTION
Corrects XP calculation boundary for next level in fantasy mode and database.

The `xpToNextLevel` function in `src/utils/xpCalculator.ts` and the `public.xp_to_next_level` DB function had an off-by-one error, causing level 10 players to incorrectly show 2,000 XP needed for the next level instead of 50,000. This PR changes the boundary condition from `<=` to `<` to fix this display issue in fantasy mode and ensure consistency with the intended XP progression.

---
<a href="https://cursor.com/background-agent?bcId=bc-05972c62-f8c6-4516-8689-bf3e83179d40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05972c62-f8c6-4516-8689-bf3e83179d40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

