### PR TITLE
Fix game mode bugs and visual glitches

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -647,7 +647,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const timeToLoop = loopDuration - normalizedTime;
       if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
         const maxLoopPreview = 6;
-        for (let i = 0; i < gameState.taikoNotes.length; i++) {
+        // 直前に処理済みのノーツ（currentNoteIndex より前）はプレビューしない
+        for (let i = gameState.currentNoteIndex; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -653,6 +653,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
+          // 既に同等のX位置に通常ノーツがある場合はプレビューを追加しない（重なりで明るく見えるのを防止）
+          const isDuplicateX = notesToDisplay.some(n => Math.abs(n.x - x) < 1.5);
+          if (isDuplicateX) continue;
           // 次ループのプレビュー用には表示（idに _loop を付与）
           notesToDisplay.push({
             id: `${note.id}_loop`,

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -646,24 +646,19 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       // ループ対応：最後に近づいたら最初から複数ノーツを仮想的に追加
       const timeToLoop = loopDuration - normalizedTime;
       if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
-        const maxLoopPreview = 6;
-        // 直前に処理済みのノーツ（currentNoteIndex より前）はプレビューしない
-        for (let i = gameState.currentNoteIndex; i < gameState.taikoNotes.length; i++) {
+        // 次ループの全ノーツをプレビュー対象にする（上限なし、lookAheadTimeで制限）
+        for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
-          // 既に同等のX位置に通常ノーツがある場合はプレビューを追加しない（重なりで明るく見えるのを防止）
-          const isDuplicateX = notesToDisplay.some(n => Math.abs(n.x - x) < 1.5);
-          if (isDuplicateX) continue;
           // 次ループのプレビュー用には表示（idに _loop を付与）
           notesToDisplay.push({
             id: `${note.id}_loop`,
             chord: note.chord.displayName,
             x
           });
-          if (i + 1 >= maxLoopPreview) break;
         }
       }
       

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -304,12 +304,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     console.log('🔥 handleEnemyAttack called with monsterId:', attackingMonsterId);
     devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
     
-    // 敵の攻撃音を再生
-    try {
-      const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-      FantasySoundManager.playEnemyAttack();
-    } catch (error) {
-      console.error('Failed to play enemy attack sound:', error);
+    // 敵の攻撃音を再生（single クイズモードのみ）
+    if (stage.mode === 'single') {
+      try {
+        const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
+        FantasySoundManager.playEnemyAttack();
+      } catch (error) {
+        console.error('Failed to play enemy attack sound:', error);
+      }
     }
     
     // confetti削除 - 何もしない
@@ -322,7 +324,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     setHeartFlash(true);
     setTimeout(() => setHeartFlash(false), 150);
     
-  }, []);
+  }, [stage.mode]);
   
   const handleGameCompleteCallback = useCallback((result: 'clear' | 'gameover', finalState: FantasyGameState) => {
     const text = result === 'clear' ? 'Stage Clear' : 'Game Over';

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1936,19 +1936,19 @@ export class FantasyPIXIInstance {
   createTaikoNote(noteId: string, chordName: string, x: number): PIXI.Container {
     const noteContainer = new PIXI.Container();
     
-    // ノーツの円を作成
+    // ノーツの円を作成（デフォルト暗めに）
     const noteCircle = new PIXI.Graphics();
-    noteCircle.lineStyle(3, 0xFFFFFF, 1);
-    noteCircle.beginFill(0xFF6B6B, 0.8);
+    noteCircle.lineStyle(2, 0xAAAAAA, 0.8);
+    noteCircle.beginFill(0x444444, 0.8);
     noteCircle.drawCircle(0, 0, 35);
     noteCircle.endFill();
     
     // コード名のテキスト
     const chordText = new PIXI.Text(chordName, {
       fontFamily: 'Arial',
-      fontSize: 24,
+      fontSize: 22,
       fontWeight: 'bold',
-      fill: 0xFFFFFF,
+      fill: 0xDDDDDD,
       align: 'center'
     });
     chordText.anchor.set(0.5);
@@ -1958,8 +1958,8 @@ export class FantasyPIXIInstance {
     noteContainer.x = x;
     noteContainer.y = this.app.screen.height / 2;
     
-    // 半透明にする
-    noteContainer.alpha = 0.85;
+    // 半透明だがより暗く（明るくならない）
+    noteContainer.alpha = 0.6;
     
     return noteContainer;
   }
@@ -2071,7 +2071,9 @@ export class FantasyPIXIInstance {
     this.monsterSprites.forEach(data => {
       if (data.outline) data.outline.destroy();
       if (data.angerMark) data.angerMark.destroy();
-      data.sprite.destroy();
+      if (data.sprite && !data.sprite.destroyed) {
+        data.sprite.destroy({ children: true });
+      }
     });
     this.monsterSprites.clear();
     
@@ -2111,46 +2113,38 @@ export class FantasyPIXIInstance {
     }
     
     // ▼▼▼ 追加 ▼▼▼
-    // バンドルされたアセットをアンロード
+    // バンドルされたアセットをアンロード（テクスチャはPIXI側の参照に任せる）
     PIXI.Assets.unloadBundle('monsterTextures').catch(e => devLog.debug("monsterTextures unload error", e));
     PIXI.Assets.unloadBundle('magicTextures').catch(e => devLog.debug("magicTextures unload error", e));
     // ▲▲▲ ここまで ▲▲▲
     
-    // テクスチャクリーンアップ
+    // テクスチャクリーンアップ（参照だけクリア）
     try {
       this.imageTextures.forEach((texture: PIXI.Texture) => {
-        try {
-          if (texture && typeof texture.destroy === 'function' && !texture.destroyed) {
-            texture.destroy(true);
-          }
-        } catch (error) {
-          devLog.debug('⚠️ 画像テクスチャ削除エラー:', error);
-        }
+        // ここでは destroy(true) は呼ばず、参照のみ破棄する
       });
       this.imageTextures.clear();
     } catch (error) {
       devLog.debug('⚠️ テクスチャクリーンアップエラー:', error);
     }
     
-    // PIXIアプリケーションの破棄
+    // PIXIアプリケーションの破棄（テクスチャは破棄しない）
     if (this.app) {
       try {
-        // ステージから全ての子要素を削除（PIXIの内部エラーを防ぐため）
         if (this.app.stage) {
-          // Remove all event listeners first to prevent null reference errors
           this.app.stage.removeAllListeners?.();
-          
-          // Remove all children safely
           while (this.app.stage.children.length > 0) {
             const child = this.app.stage.children[0];
             if (child) {
               this.app.stage.removeChild(child);
+              if (typeof (child as any).destroy === 'function') {
+                (child as any).destroy({ children: true });
+              }
             }
           }
         }
-        
-        // Destroy the app
-        this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+        // Destroy the app without nuking textures/baseTextures to avoid null uvsFloat32
+        this.app.destroy(true, { children: true });
       } catch (error) {
         devLog.debug('⚠️ PIXI破棄エラー:', error);
       }
@@ -2191,13 +2185,15 @@ export class FantasyPIXIInstance {
       });
 
       // 親コンポーネント通知の直前で片付け
-      this.monsterSprite.visible = false;
-      // 二度アクセスしない様に null‑out
-      (this.monsterSprite as any) = null;
-      (this.monsterGameState as any) = null;
+      if (this.monsterSprite) {
+        this.monsterSprite.visible = false;
+        // 破棄は行わず、参照は保持したまま
+      }
+      // 二度アクセスしない様に null‑out はしない
+      // (this.monsterSprite as any) = null;
+      // (this.monsterGameState as any) = null;
       
       // 親コンポーネントに通知
-      // isDestroyedフラグをチェックして、インスタンス破棄後のコールバック呼び出しを防ぐ
       if (!this.isDestroyed) {
         this.onDefeated?.();
       } 

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1936,42 +1936,30 @@ export class FantasyPIXIInstance {
   createTaikoNote(noteId: string, chordName: string, x: number): PIXI.Container {
     const noteContainer = new PIXI.Container();
     
-    const isPreview = noteId.endsWith('_loop');
-    
-    // ノーツの円を作成
+    // ノーツの円を作成（全て同じ明るい赤）
     const noteCircle = new PIXI.Graphics();
-    if (isPreview) {
-      // 次ループプレビュー: 輪郭線のみ（中塗り無し）
-      noteCircle.lineStyle(2, 0xFF6B6B, 1);
-      noteCircle.drawCircle(0, 0, 35);
-    } else {
-      // 通常ノーツ: 赤塗り＋白フチ
-      noteCircle.lineStyle(3, 0xFFFFFF, 1);
-      noteCircle.beginFill(0xFF6B6B, 0.8);
-      noteCircle.drawCircle(0, 0, 35);
-      noteCircle.endFill();
-    }
+    noteCircle.lineStyle(3, 0xFFFFFF, 1);
+    noteCircle.beginFill(0xFF6B6B, 0.85);
+    noteCircle.drawCircle(0, 0, 35);
+    noteCircle.endFill();
     
-    // コード名のテキスト
+    // コード名のテキスト（全て同じ見た目）
     const chordText = new PIXI.Text(chordName, {
       fontFamily: 'Arial',
       fontSize: 22,
       fontWeight: 'bold',
-      fill: isPreview ? 0xFF6B6B : 0xFFFFFF,
+      fill: 0xFFFFFF,
       align: 'center'
     });
     chordText.anchor.set(0.5);
-    if (isPreview) {
-      chordText.alpha = 0.6; // プレビューはやや薄く
-    }
     
     noteContainer.addChild(noteCircle);
     noteContainer.addChild(chordText);
     noteContainer.x = x;
     noteContainer.y = this.app.screen.height / 2;
     
-    // 半透明（暗すぎない程度に固定）
-    noteContainer.alpha = 0.6;
+    // 全ノーツで同一の不透明度
+    noteContainer.alpha = 0.85;
     
     return noteContainer;
   }

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1936,22 +1936,34 @@ export class FantasyPIXIInstance {
   createTaikoNote(noteId: string, chordName: string, x: number): PIXI.Container {
     const noteContainer = new PIXI.Container();
     
-    // ノーツの円を作成（赤）
+    const isPreview = noteId.endsWith('_loop');
+    
+    // ノーツの円を作成
     const noteCircle = new PIXI.Graphics();
-    noteCircle.lineStyle(3, 0xFFFFFF, 1);
-    noteCircle.beginFill(0xFF6B6B, 0.8);
-    noteCircle.drawCircle(0, 0, 35);
-    noteCircle.endFill();
+    if (isPreview) {
+      // 次ループプレビュー: 輪郭線のみ（中塗り無し）
+      noteCircle.lineStyle(2, 0xFF6B6B, 1);
+      noteCircle.drawCircle(0, 0, 35);
+    } else {
+      // 通常ノーツ: 赤塗り＋白フチ
+      noteCircle.lineStyle(3, 0xFFFFFF, 1);
+      noteCircle.beginFill(0xFF6B6B, 0.8);
+      noteCircle.drawCircle(0, 0, 35);
+      noteCircle.endFill();
+    }
     
     // コード名のテキスト
     const chordText = new PIXI.Text(chordName, {
       fontFamily: 'Arial',
       fontSize: 22,
       fontWeight: 'bold',
-      fill: 0xFFFFFF,
+      fill: isPreview ? 0xFF6B6B : 0xFFFFFF,
       align: 'center'
     });
     chordText.anchor.set(0.5);
+    if (isPreview) {
+      chordText.alpha = 0.6; // プレビューはやや薄く
+    }
     
     noteContainer.addChild(noteCircle);
     noteContainer.addChild(chordText);

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1936,10 +1936,10 @@ export class FantasyPIXIInstance {
   createTaikoNote(noteId: string, chordName: string, x: number): PIXI.Container {
     const noteContainer = new PIXI.Container();
     
-    // ノーツの円を作成（デフォルト暗めに）
+    // ノーツの円を作成（赤）
     const noteCircle = new PIXI.Graphics();
-    noteCircle.lineStyle(2, 0xAAAAAA, 0.8);
-    noteCircle.beginFill(0x444444, 0.8);
+    noteCircle.lineStyle(3, 0xFFFFFF, 1);
+    noteCircle.beginFill(0xFF6B6B, 0.8);
     noteCircle.drawCircle(0, 0, 35);
     noteCircle.endFill();
     
@@ -1948,7 +1948,7 @@ export class FantasyPIXIInstance {
       fontFamily: 'Arial',
       fontSize: 22,
       fontWeight: 'bold',
-      fill: 0xDDDDDD,
+      fill: 0xFFFFFF,
       align: 'center'
     });
     chordText.anchor.set(0.5);
@@ -1958,7 +1958,7 @@ export class FantasyPIXIInstance {
     noteContainer.x = x;
     noteContainer.y = this.app.screen.height / 2;
     
-    // 半透明だがより暗く（明るくならない）
+    // 半透明（暗すぎない程度に固定）
     noteContainer.alpha = 0.6;
     
     return noteContainer;


### PR DESCRIPTION
Fixes enemy SFX playback, Taiko note appearance, and a PixiJS texture error on retry.

The PixiJS "uvsFloat32" error on retry was caused by overly aggressive texture destruction, leading to null references when the game attempted to re-render elements. The fix involves a more gentle cleanup of PIXI resources, specifically preventing the destruction of base textures and ensuring sprites are properly managed without nulling out references, allowing for smoother retries without visual glitches.

---
<a href="https://cursor.com/background-agent?bcId=bc-40831abe-7c6f-4182-a852-25b241fcd976">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40831abe-7c6f-4182-a852-25b241fcd976">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

