### PR TITLE
Fix loop note color brightness issue

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -649,6 +649,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         const maxLoopPreview = 6;
         for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
+          // すでに処理済み（currentNoteIndex より前）のノーツは次ループの直前プレビューに出さない
+          if (i < gameState.currentNoteIndex) continue;
+          // 直前にヒット済みのノーツは、直後のプレビューに出さない
+          if (note.isHit) continue;
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -639,7 +639,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
             chord: note.chord.displayName,
             x
           });
-          baseIdsPresent.add(note.id);
+          // 現在ループに表示したベースIDとして登録
+          // ただし、ヒット直後に消えた最後ノーツはベースID登録しないことで、
+          // 次ループ側のプレビューを許可して "復活" を実現する
+          if (!note.isHit) {
+            baseIdsPresent.add(note.id);
+          }
         }
       });
       
@@ -649,10 +654,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         const maxLoopPreview = 6;
         for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
-          // すでに処理済み（currentNoteIndex より前）のノーツは次ループの直前プレビューに出さない
-          if (i < gameState.currentNoteIndex) continue;
-          // 直前にヒット済みのノーツは、直後のプレビューに出さない
-          if (note.isHit) continue;
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -652,11 +652,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const timeToLoop = loopDuration - normalizedTime;
       if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
         const maxLoopPreview = 6;
+        const minPreviewLeadTime = 1.2;
         for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;
+          // ループ直後0.4秒未満のものは、直前ループの残像と紛らわしいので抑制
+          if (timeUntilHit < minPreviewLeadTime) continue;
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
           // 次ループのプレビューは、同じベースIDが既に通常ノーツで表示されている場合は重ね表示しない
           if (!baseIdsPresent.has(note.id)) {


### PR DESCRIPTION
Deduplicate next-loop preview notes to prevent perceived brightness increase.

Previously, notes near the loop boundary could be rendered twice (once as a 'normal' note and once as a 'next-loop preview' note) if they shared the same base ID, causing them to appear brighter due to overlapping sprites.

---
<a href="https://cursor.com/background-agent?bcId=bc-043b0eed-9316-42d2-b4db-7a56ad347819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-043b0eed-9316-42d2-b4db-7a56ad347819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

