### PR TITLE
Fix taiko note flashing in fantasy mode

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -636,12 +636,22 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         }
       });
       
+      // すでに通常ノーツで表示予定のベースID集合（プレビューと重複させない）
+      const displayedBaseIds = new Set(notesToDisplay.map(n => n.id));
+      
       // ループ対応：最後に近づいたら最初から複数ノーツを仮想的に追加（次ループのプレビュー）
       const timeToLoop = loopDuration - normalizedTime;
       if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
         const maxLoopPreview = 6;
         for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
+          
+          // 現在ループでヒット済みのノーツは、次ループのプレビューでも直前復活させない
+          if (note.isHit) continue;
+          
+          // すでに通常ノーツに含まれている場合はプレビュー重複を避ける
+          if (displayedBaseIds.has(note.id)) continue;
+          
           const virtualHitTime = note.hitTime + loopDuration; // 次ループのヒット時刻
           const timeUntilHit = virtualHitTime - normalizedTime;
           if (timeUntilHit > lookAheadTime) break;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -639,6 +639,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       // すでに通常ノーツで表示予定のベースID集合（プレビューと重複させない）
       const displayedBaseIds = new Set(notesToDisplay.map(n => n.id));
       
+      // 直前に消化したノーツのインデックス（復活させない）
+      const lastCompletedIndex = gameState.taikoNotes.length > 0
+        ? (gameState.currentNoteIndex - 1 + gameState.taikoNotes.length) % gameState.taikoNotes.length
+        : -1;
+      
       // ループ対応：最後に近づいたら最初から複数ノーツを仮想的に追加（次ループのプレビュー）
       const timeToLoop = loopDuration - normalizedTime;
       if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
@@ -646,8 +651,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         for (let i = 0; i < gameState.taikoNotes.length; i++) {
           const note = gameState.taikoNotes[i];
           
-          // 現在ループでヒット済みのノーツは、次ループのプレビューでも直前復活させない
-          if (note.isHit) continue;
+          // 直前に消化した最後のノーツはプレビューで復活させない
+          if (i === lastCompletedIndex) continue;
           
           // すでに通常ノーツに含まれている場合はプレビュー重複を避ける
           if (displayedBaseIds.has(note.id)) continue;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -642,24 +642,24 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       });
       
       // ループ対応：最後に近づいたら最初から複数ノーツを仮想的に追加
-      const timeToLoop = loopDuration - normalizedTime;
-      if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
-        const maxLoopPreview = 6;
-        for (let i = 0; i < gameState.taikoNotes.length; i++) {
-          const note = gameState.taikoNotes[i];
-          const virtualHitTime = note.hitTime + loopDuration;
-          const timeUntilHit = virtualHitTime - normalizedTime;
-          if (timeUntilHit > lookAheadTime) break;
-          const x = judgeLinePos.x + timeUntilHit * noteSpeed;
-          // 次ループのプレビュー用には表示（idに _loop を付与）
-          notesToDisplay.push({
-            id: `${note.id}_loop`,
-            chord: note.chord.displayName,
-            x
-          });
-          if (i + 1 >= maxLoopPreview) break;
-        }
-      }
+      // const timeToLoop = loopDuration - normalizedTime;
+      // if (timeToLoop < lookAheadTime && gameState.taikoNotes.length > 0) {
+      //   const maxLoopPreview = 6;
+      //   for (let i = 0; i < gameState.taikoNotes.length; i++) {
+      //     const note = gameState.taikoNotes[i];
+      //     const virtualHitTime = note.hitTime + loopDuration;
+      //     const timeUntilHit = virtualHitTime - normalizedTime;
+      //     if (timeUntilHit > lookAheadTime) break;
+      //     const x = judgeLinePos.x + timeUntilHit * noteSpeed;
+      //     // 次ループのプレビュー用には表示（idに _loop を付与）
+      //     notesToDisplay.push({
+      //       id: `${note.id}_loop`,
+      //       chord: note.chord.displayName,
+      //       x
+      //     });
+      //     if (i + 1 >= maxLoopPreview) break;
+      //   }
+      // }
       
       // PIXIレンダラーに更新を送信
       fantasyPixiInstance.updateTaikoNotes(notesToDisplay);

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -625,8 +625,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 現在ループ基準の時間差
         const timeUntilHit = note.hitTime - normalizedTime;
         
+        // ループリセット直後（currentNoteIndex===0）は負の許容をやめ、直前ノーツの復活を防ぐ
+        const lowerBound = gameState.currentNoteIndex === 0 ? 0 : -0.5;
+        
         // 表示範囲内のノーツ（現在ループのみ）
-        if (timeUntilHit >= -0.5 && timeUntilHit <= lookAheadTime) {
+        if (timeUntilHit >= lowerBound && timeUntilHit <= lookAheadTime) {
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
           notesToDisplay.push({
             id: note.id,


### PR DESCRIPTION
Fix Taiko notes briefly brightening in Fantasy progression mode's second loop by removing redundant loop preview rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-7575ad4a-026d-4b07-ae7e-9e99c36c9d2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7575ad4a-026d-4b07-ae7e-9e99c36c9d2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

