### PR TITLE
Fix fantasy mode bugs and UI issues

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -473,10 +473,10 @@ export class FantasyPIXIInstance {
     try {
       devLog.debug('👾 モンスタースプライト作成開始:', { icon });
       
-      // 既存のテクスチャをクリア
-      if (this.monsterSprite.texture && this.monsterSprite.texture !== PIXI.Texture.EMPTY) {
-        this.monsterSprite.texture.destroy(true);
-      }
+      // 既存のテクスチャの destroy はしない（共有資源のため）
+      // if (this.monsterSprite.texture && this.monsterSprite.texture !== PIXI.Texture.EMPTY) {
+      //   this.monsterSprite.texture.destroy(true);
+      // }
       
       // ★★★ createMonsterSpriteForId を画像ベースに修正 ★★★
       const sprite = await this.createMonsterSpriteForId('default', icon);
@@ -2149,8 +2149,8 @@ export class FantasyPIXIInstance {
           }
         }
         
-        // Destroy the app
-        this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+        // Destroy the app (keep textures to avoid null uvs)
+        this.app.destroy(true, { children: true, texture: false, baseTexture: false });
       } catch (error) {
         devLog.debug('⚠️ PIXI破棄エラー:', error);
       }


### PR DESCRIPTION
Fixes multiple Fantasy mode issues, including a PIXI retry crash, BGM auto-start, enemy SFX, enemy count display, and UI overlap.

The `uvsFloat32` error on retry was due to PIXI textures and base textures being prematurely destroyed when the renderer was torn down or sprites were updated. By preventing the destruction of these shared resources, the issue is resolved, allowing icons and notes to render correctly on subsequent game attempts.

---
<a href="https://cursor.com/background-agent?bcId=bc-e035fce7-eba4-480d-906e-c6b62ec3d82f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e035fce7-eba4-480d-906e-c6b62ec3d82f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

