### PR TITLE
Adjust enemy hp ui for more container height

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1085,11 +1085,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                             </div>
                           </div>
                         );
-                      })()}
-                      </div>
-                    </div>
-                    );
-                  })}
+                                             })()}
+                     </div>
+                     );
+                   })}
               </div>
             ) : null}
             

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1012,16 +1012,24 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
 
                             if (!stage.showGuide && !isCorrect) {
                               return (
-                                <span key={index} className={`mx-0.5 opacity-0 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'}`}>
+                                <span
+                                  key={index}
+                                  className={`mx-0.5 opacity-0 ${monsterCount > 5 ? '' : 'text-xs'}`}
+                                  style={monsterCount > 5 ? { fontSize: '10px' } : undefined}
+                                >
                                   ?
                                 </span>
                               );
                             }
                             return (
-                              <span key={index} className={`mx-0.5 ${monsterCount > 5 ? 'text-[10px]' : 'text-xs'} ${isCorrect ? 'text-green-400 font-bold' : 'text-gray-300'}`}>
-                                {displayNoteName}
-                                {isCorrect && '✓'}
-                              </span>
+                                                              <span
+                                  key={index}
+                                  className={`mx-0.5 ${monsterCount > 5 ? '' : 'text-xs'} ${isCorrect ? 'text-green-400 font-bold' : 'text-gray-300'}`}
+                                  style={monsterCount > 5 ? { fontSize: '10px' } : undefined}
+                                >
+                                  {displayNoteName}
+                                  {isCorrect && '✓'}
+                                </span>
                             );
                           })}
                           </div>

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1057,14 +1057,27 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       )}
                       
                       {/* HPゲージ */}
-                      <div className="w-full h-3 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative">
-                        <div
-                          className="h-full bg-gradient-to-r from-red-500 to-red-700 transition-all duration-300"
-                          style={{ width: `${(monster.currentHp / monster.maxHp) * 100}%` }}
-                        />
-                        <div className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-white">
-                          {monster.currentHp}/{monster.maxHp}
-                        </div>
+                      {(() => {
+                        const isLandscape = window.innerWidth > window.innerHeight;
+                        // 横画面のモバイルではUI圧縮中だが、バーは従来より大きめに
+                        const gaugeHeightClass = (isMobile && isLandscape)
+                          ? (monsterCount > 5 ? 'h-4' : 'h-5')
+                          : (monsterCount > 5 ? 'h-5' : 'h-6');
+                        const textSizeClass = (isMobile && isLandscape)
+                          ? (monsterCount > 5 ? 'text-[12px]' : 'text-xs')
+                          : (monsterCount > 5 ? 'text-xs' : 'text-sm');
+                        return (
+                          <div className={cn("w-full bg-gray-700 rounded-full overflow-hidden relative border-2 border-gray-600", gaugeHeightClass)}>
+                            <div
+                              className="h-full bg-gradient-to-r from-red-500 to-red-700 transition-all duration-300"
+                              style={{ width: `${(monster.currentHp / monster.maxHp) * 100}%` }}
+                            />
+                            <div className={cn("absolute inset-0 flex items-center justify-center font-bold text-white drop-shadow", textSizeClass)}>
+                              {monster.currentHp}/{monster.maxHp}
+                            </div>
+                          </div>
+                        );
+                      })()}
                       </div>
                     </div>
                     );

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1064,8 +1064,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                           ? (monsterCount > 5 ? 'h-4' : 'h-5')
                           : (monsterCount > 5 ? 'h-5' : 'h-6');
                         const textSizeClass = (isMobile && isLandscape)
-                          ? (monsterCount > 5 ? 'text-[12px]' : 'text-xs')
-                          : (monsterCount > 5 ? 'text-xs' : 'text-sm');
+                          ? (monsterCount > 5 ? 'text-xs' : 'text-sm')
+                          : (monsterCount > 5 ? 'text-sm' : 'text-base');
                         return (
                           <div className={cn("w-full bg-gray-700 rounded-full overflow-hidden relative border-2 border-gray-600", gaugeHeightClass)}>
                             <div

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -499,7 +499,7 @@ export class FantasyPIXIInstance {
         alpha: 1.0,
         visible: true,
         tint: 0xFFFFFF,
-        scale: this.calcSpriteScale(this.monsterSprite.texture, this.app.screen.width, 200, 1) // 動的スケール計算
+        scale: this.calcSpriteScale(this.monsterSprite.texture, this.app.screen.width, this.app.screen.height, 1) // 動的スケール計算
       };
       
       // ゲーム状態をリセット
@@ -546,7 +546,7 @@ export class FantasyPIXIInstance {
         alpha: 1.0,
         visible: true,
         tint: 0xFFFFFF,
-        scale: this.calcSpriteScale(texture, this.app.screen.width, 200, 1) // 動的スケール計算
+        scale: this.calcSpriteScale(texture, this.app.screen.width, this.app.screen.height, 1) // 動的スケール計算
       };
       
       // スプライトの属性を更新
@@ -595,8 +595,8 @@ export class FantasyPIXIInstance {
         
         const visualState: MonsterVisualState = {
           x: this.getPositionX(i, sortedMonsters.length),
-          y: 100, // Y座標を100pxに固定（200px高さの中央）
-          scale: this.calcSpriteScale(sprite.texture, this.app.screen.width, 200, sortedMonsters.length),
+          y: this.app.screen.height / 2, // コンテナ高さの中央
+          scale: this.calcSpriteScale(sprite.texture, this.app.screen.width, this.app.screen.height, sortedMonsters.length),
           rotation: 0,
           tint: 0xFFFFFF,
           alpha: 1.0,
@@ -723,7 +723,7 @@ export class FantasyPIXIInstance {
             const targetScale = this.calcSpriteScale(
               loadedTexture,
               this.app.screen.width,
-              200,
+              this.app.screen.height,
               this.monsterSprites.size || 1
             );
 
@@ -755,7 +755,7 @@ export class FantasyPIXIInstance {
       // ▼▼▼ 修正箇所 ▼▼▼
       // 実際のモンスター表示エリアのサイズに基づいてサイズを決定
       const CONTAINER_WIDTH = this.app.screen.width;
-      const CONTAINER_HEIGHT = 200; // FantasyGameScreen.tsxで定義されている固定高さ
+      const CONTAINER_HEIGHT = this.app.screen.height; // 実コンテナ高さに追従
 
       // モバイル判定
       const isMobile = CONTAINER_WIDTH < 768;
@@ -1646,7 +1646,7 @@ export class FantasyPIXIInstance {
         
         if (enragedTable[id]) {
           // ---- 怒り演出 ----
-          const baseScale = this.calcSpriteScale(sprite.texture, this.app.screen.width, 200, this.monsterSprites.size);
+          const baseScale = this.calcSpriteScale(sprite.texture, this.app.screen.width, this.app.screen.height, this.monsterSprites.size);
           visualState.scale = baseScale * 1.25; // 巨大化（25%増し）
           sprite.tint = 0xFFCCCC;
           
@@ -1694,7 +1694,7 @@ export class FantasyPIXIInstance {
           
         } else {
           // ---- 通常状態 ----
-          const baseScale = this.calcSpriteScale(sprite.texture, this.app.screen.width, 200, this.monsterSprites.size);
+          const baseScale = this.calcSpriteScale(sprite.texture, this.app.screen.width, this.app.screen.height, this.monsterSprites.size);
           visualState.scale = baseScale;
           sprite.tint = gameState.isHit ? gameState.hitColor : 0xFFFFFF;
           
@@ -1894,13 +1894,13 @@ export class FantasyPIXIInstance {
       for (let i = 0; i < sortedEntries.length; i++) {
         const [id, monsterData] = sortedEntries[i];
         monsterData.visualState.x = this.getPositionX(i, sortedEntries.length);
-        monsterData.visualState.y = 100; // Y座標を100pxに固定（200px高さの中央）
+        monsterData.visualState.y = this.app.screen.height / 2; // コンテナ高さの中央
         // ▼▼▼ 修正箇所 ▼▼▼
         // 動的スケール計算を使用
         const dynamicScale = this.calcSpriteScale(
           monsterData.sprite.texture,
           width,
-          200, // FantasyGameScreen.tsxで定義されている固定高さ
+          this.app.screen.height, // 実コンテナ高さ
           sortedEntries.length
         );
         


### PR DESCRIPTION
Adjusts PIXI container height and UI area for fantasy mode on landscape mobile.

To provide more visual space for game elements by increasing the PIXI container height and reducing UI overlay on landscape mobile screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-08429544-4f1f-4017-9fe1-634171fdf97f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08429544-4f1f-4017-9fe1-634171fdf97f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

