### PR TITLE
Display codename above taiko notes

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1943,20 +1943,25 @@ export class FantasyPIXIInstance {
     
     // ノーツの円を作成
     const noteCircle = new PIXI.Graphics();
+    const NOTE_RADIUS = 35;
     noteCircle.lineStyle(3, 0xFFFFFF, 1);
     noteCircle.beginFill(0xFF6B6B, 0.8);
-    noteCircle.drawCircle(0, 0, 35);
+    noteCircle.drawCircle(0, 0, NOTE_RADIUS);
     noteCircle.endFill();
     
-    // コード名のテキスト
+    // コード名のテキスト（ノーツの上に表示）
     const chordText = new PIXI.Text(chordName, {
       fontFamily: 'Arial',
-      fontSize: 24,
+      fontSize: 18,
       fontWeight: 'bold',
       fill: 0xFFFFFF,
-      align: 'center'
+      stroke: 0x000000,
+      strokeThickness: 4,
+      align: 'center',
+      wordWrap: false,
     });
     chordText.anchor.set(0.5);
+    chordText.y = -(NOTE_RADIUS + 10); // ノーツの上に配置
     
     noteContainer.addChild(noteCircle);
     noteContainer.addChild(chordText);


### PR DESCRIPTION
Repositioned codename labels above notes in Fantasy mode Taiko UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-239e66fc-7d06-49ab-b71b-50d36912a8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-239e66fc-7d06-49ab-b71b-50d36912a8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

