### PR TITLE
Add fantasy BGM from Cloudflare R2

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import { LessonManager } from './LessonManager';
 import MissionManager from './MissionManager';
 import UserManager from './UserManager';
 import AnnouncementManager from './AnnouncementManager';
+import FantasyBgmManager from './FantasyBgmManager';
 
 /**
  * 管理画面ゲート – is_admin フラグを持つユーザーのみアクセス許可
@@ -54,14 +55,15 @@ const AdminDashboard: React.FC = () => {
       {/* デスクトップ: サイドバー */}
       <aside className="hidden md:flex w-60 bg-slate-800 border-r border-slate-700 p-4 space-y-4 flex-col">
         <h2 className="text-lg font-bold">Admin</h2>
-        <nav className="space-y-2 flex-1">
-          <SidebarLink hash="#admin-songs" label="曲管理" />
-          <SidebarLink hash="#admin-courses" label="コース管理" />
-          <SidebarLink hash="#admin-lessons" label="レッスン管理" />
-          <SidebarLink hash="#admin-challenges" label="ミッション管理" />
-          <SidebarLink hash="#admin-users" label="会員管理" />
-          <SidebarLink hash="#admin-announcements" label="お知らせ管理" />
-        </nav>
+                 <nav className="space-y-2 flex-1">
+           <SidebarLink hash="#admin-songs" label="曲管理" />
+           <SidebarLink hash="#admin-fantasy-bgm" label="ファンタジーBGM" />
+           <SidebarLink hash="#admin-courses" label="コース管理" />
+           <SidebarLink hash="#admin-lessons" label="レッスン管理" />
+           <SidebarLink hash="#admin-challenges" label="ミッション管理" />
+           <SidebarLink hash="#admin-users" label="会員管理" />
+           <SidebarLink hash="#admin-announcements" label="お知らせ管理" />
+         </nav>
         <button className="btn btn-sm btn-outline w-full" onClick={() => { window.location.href = '/main#dashboard'; }}>
           閉じる
         </button>
@@ -75,14 +77,15 @@ const AdminDashboard: React.FC = () => {
             閉じる
           </button>
         </div>
-        <nav className="flex space-x-2 overflow-x-auto">
-          <MobileTabLink hash="#admin-songs" label="曲管理" />
-          <MobileTabLink hash="#admin-courses" label="コース" />
-          <MobileTabLink hash="#admin-lessons" label="レッスン" />
-          <MobileTabLink hash="#admin-challenges" label="ミッション" />
-          <MobileTabLink hash="#admin-users" label="会員" />
-          <MobileTabLink hash="#admin-announcements" label="お知らせ" />
-        </nav>
+                 <nav className="flex space-x-2 overflow-x-auto">
+           <MobileTabLink hash="#admin-songs" label="曲管理" />
+           <MobileTabLink hash="#admin-fantasy-bgm" label="ファンタジーBGM" />
+           <MobileTabLink hash="#admin-courses" label="コース" />
+           <MobileTabLink hash="#admin-lessons" label="レッスン" />
+           <MobileTabLink hash="#admin-challenges" label="ミッション" />
+           <MobileTabLink hash="#admin-users" label="会員" />
+           <MobileTabLink hash="#admin-announcements" label="お知らせ" />
+         </nav>
       </div>
 
       {/* メインコンテンツ */}
@@ -130,12 +133,13 @@ const DashboardContent: React.FC = () => {
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);
 
-  if (currentHash.startsWith('#admin-songs')) return <SongManager />;
-  if (currentHash.startsWith('#admin-courses')) return <CourseManager />;
-  if (currentHash.startsWith('#admin-lessons')) return <LessonManager />;
-  if (currentHash.startsWith('#admin-challenges')) return <MissionManager />;
-  if (currentHash.startsWith('#admin-users')) return <UserManager />;
-  if (currentHash.startsWith('#admin-announcements')) return <AnnouncementManager />;
+     if (currentHash.startsWith('#admin-songs')) return <SongManager />;
+   if (currentHash.startsWith('#admin-fantasy-bgm')) return <FantasyBgmManager />;
+   if (currentHash.startsWith('#admin-courses')) return <CourseManager />;
+   if (currentHash.startsWith('#admin-lessons')) return <LessonManager />;
+   if (currentHash.startsWith('#admin-challenges')) return <MissionManager />;
+   if (currentHash.startsWith('#admin-users')) return <UserManager />;
+   if (currentHash.startsWith('#admin-announcements')) return <AnnouncementManager />;
   return (
     <div className="flex items-center justify-center h-full">
       <p className="text-gray-400 text-center px-4">

--- a/src/components/admin/FantasyBgmManager.tsx
+++ b/src/components/admin/FantasyBgmManager.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { addFantasyBgmAsset, fetchFantasyBgmAssets, deleteFantasyBgmAsset, FantasyBgmAsset } from '@/platform/supabaseFantasyBgm';
+import { useToast } from '@/stores/toastStore';
+
+interface BgmFormData {
+  name: string;
+  description?: string;
+  mp3File?: FileList;
+}
+
+const FantasyBgmManager: React.FC = () => {
+  const { register, handleSubmit, reset, watch } = useForm<BgmFormData>();
+  const [assets, setAssets] = useState<FantasyBgmAsset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const toast = useToast();
+
+  const watchedFile = watch('mp3File');
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const data = await fetchFantasyBgmAssets();
+      setAssets(data);
+    } catch (e) {
+      console.error(e);
+      toast.error('BGM一覧の読み込みに失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const onSubmit = async (values: BgmFormData) => {
+    const file = values.mp3File?.[0];
+    if (!file) {
+      toast.error('MP3ファイルは必須です');
+      return;
+    }
+    if (!values.name?.trim()) {
+      toast.error('名称は必須です');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      await addFantasyBgmAsset({ name: values.name.trim(), description: values.description }, file);
+      toast.success('BGMを追加しました');
+      reset();
+      await load();
+    } catch (e: any) {
+      console.error(e);
+      toast.error(e?.message || 'BGMの追加に失敗しました');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const copyToClipboard = async (text?: string | null) => {
+    if (!text) return;
+    await navigator.clipboard.writeText(text);
+    toast.success('URLをコピーしました');
+  };
+
+  const formatFileSize = (bytes?: number) => {
+    if (!bytes) return '';
+    const mb = bytes / 1024 / 1024;
+    return `${mb.toFixed(2)} MB`;
+  };
+
+  return (
+    <div>
+      <h3 className="text-xl font-bold mb-4">ファンタジーBGM管理</h3>
+
+      <form className="space-y-4 mb-8" onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <label className="block text-sm font-medium mb-1">名称 *</label>
+          <input className="input input-bordered w-full text-white" placeholder="例: ステージ1-1 BGM"
+                 {...register('name', { required: true })} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">説明</label>
+          <input className="input input-bordered w-full text-white" placeholder="任意説明"
+                 {...register('description')} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">MP3ファイル *</label>
+          <input type="file" accept=".mp3,audio/mpeg" className="file-input file-input-bordered w-full"
+                 {...register('mp3File', { required: true })} />
+          {watchedFile?.[0] && (
+            <p className="text-xs text-gray-400 mt-1">{watchedFile[0].name} ({formatFileSize(watchedFile[0].size)})</p>
+          )}
+        </div>
+        <button type="submit" className="btn btn-primary w-full" disabled={uploading}>
+          {uploading ? (
+            <>
+              <span className="loading loading-spinner loading-sm" /> アップロード中...
+            </>
+          ) : '追加'}
+        </button>
+      </form>
+
+      <div className="divider my-8" />
+
+      <h3 className="text-xl font-bold mb-4">BGM一覧</h3>
+      {loading ? (
+        <p className="text-gray-400">Loading...</p>
+      ) : (
+        <div className="bg-slate-800/50 rounded-lg overflow-hidden">
+          <ul className="divide-y divide-slate-700">
+            {assets.map(a => (
+              <li key={a.id} className="p-3 space-y-1 hover:bg-slate-700/50 transition-colors">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium truncate">{a.name}</p>
+                    {a.description && <p className="text-xs text-gray-400 truncate">{a.description}</p>}
+                    {a.mp3_url && (
+                      <div className="mt-1 flex items-center gap-2">
+                        <span className="text-xs bg-green-600/20 text-green-400 px-2 py-0.5 rounded">MP3</span>
+                        <button className="btn btn-xs" onClick={() => copyToClipboard(a.mp3_url)}>URLコピー</button>
+                        <a className="btn btn-xs btn-outline" href={a.mp3_url} target="_blank" rel="noreferrer">開く</a>
+                      </div>
+                    )}
+                  </div>
+                  <button className="btn btn-xs btn-error" onClick={async () => {
+                    if (!confirm(`「${a.name}」を削除しますか？`)) return;
+                    try {
+                      await deleteFantasyBgmAsset(a.id);
+                      toast.success('削除しました');
+                      await load();
+                    } catch (e: any) {
+                      console.error(e);
+                      toast.error('削除に失敗しました');
+                    }
+                  }}>削除</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400 mt-4">
+        取得したURLを `fantasy_stages.mp3_url` に手動で貼り付けてご利用ください。
+      </p>
+    </div>
+  );
+};
+
+export default FantasyBgmManager;

--- a/src/platform/r2Storage.ts
+++ b/src/platform/r2Storage.ts
@@ -176,3 +176,38 @@ export async function deleteDiaryImage(userId: string, diaryId: string): Promise
     }
   }
 }
+
+export async function uploadFantasyBgm(file: File, bgmId: string): Promise<string> {
+  checkFileSize(file, MAX_SONG_FILE_SIZE, 'BGMファイル');
+
+  const client = getR2Client();
+  const key = `fantasy-bgm/${bgmId}.mp3`;
+
+  const arrayBuffer = await file.arrayBuffer();
+
+  const command = new PutObjectCommand({
+    Bucket: BUCKET_NAME,
+    Key: key,
+    Body: new Uint8Array(arrayBuffer),
+    ContentType: 'audio/mpeg',
+    CacheControl: 'public, max-age=31536000',
+  });
+
+  await client.send(command);
+
+  return `${PUBLIC_URL}/${key}`;
+}
+
+export async function deleteFantasyBgm(bgmId: string): Promise<void> {
+  const client = getR2Client();
+  const key = `fantasy-bgm/${bgmId}.mp3`;
+  try {
+    const command = new DeleteObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: key,
+    });
+    await client.send(command);
+  } catch (error) {
+    console.log(`BGM ${key} の削除をスキップしました`);
+  }
+}

--- a/src/platform/supabaseFantasyBgm.ts
+++ b/src/platform/supabaseFantasyBgm.ts
@@ -1,0 +1,75 @@
+import { getSupabaseClient, clearSupabaseCache } from '@/platform/supabaseClient';
+import { uploadFantasyBgm, deleteFantasyBgm } from '@/platform/r2Storage';
+
+export interface FantasyBgmAsset {
+  id: string;
+  name: string;
+  description?: string | null;
+  mp3_url?: string | null;
+  r2_key?: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function fetchFantasyBgmAssets(): Promise<FantasyBgmAsset[]> {
+  const { data, error } = await getSupabaseClient()
+    .from('fantasy_bgm_assets')
+    .select('*')
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data || []) as FantasyBgmAsset[];
+}
+
+export async function addFantasyBgmAsset(params: { name: string; description?: string }, file: File): Promise<FantasyBgmAsset> {
+  const supabase = getSupabaseClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) throw new Error('ログインが必要です');
+
+  // 1) レコード作成（URLなし）
+  const insertPayload = {
+    name: params.name,
+    description: params.description || null,
+    created_by: auth.user.id,
+  } as const;
+  const { data: created, error: insertError } = await supabase
+    .from('fantasy_bgm_assets')
+    .insert(insertPayload)
+    .select('*')
+    .single();
+  if (insertError) throw insertError;
+
+  // 2) R2 にアップロード
+  const mp3Url = await uploadFantasyBgm(file, created.id);
+  const r2Key = `fantasy-bgm/${created.id}.mp3`;
+
+  // 3) URL を更新
+  const { data: updated, error: updateError } = await supabase
+    .from('fantasy_bgm_assets')
+    .update({ mp3_url: mp3Url, r2_key: r2Key })
+    .eq('id', created.id)
+    .select('*')
+    .single();
+  if (updateError) throw updateError;
+
+  clearSupabaseCache();
+  return updated as FantasyBgmAsset;
+}
+
+export async function deleteFantasyBgmAsset(id: string): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) throw new Error('ログインが必要です');
+
+  // 先にR2から削除
+  await deleteFantasyBgm(id);
+
+  // レコード削除
+  const { error } = await supabase
+    .from('fantasy_bgm_assets')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+
+  clearSupabaseCache();
+}

--- a/supabase/migrations/20250808000100_create_fantasy_bgm_assets.sql
+++ b/supabase/migrations/20250808000100_create_fantasy_bgm_assets.sql
@@ -1,0 +1,50 @@
+-- ファンタジーBGMアセットテーブルの作成とRLS設定
+
+-- テーブル作成
+CREATE TABLE IF NOT EXISTS public.fantasy_bgm_assets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  mp3_url text,
+  r2_key text,
+  created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.fantasy_bgm_assets IS 'ファンタジーモード用のBGMファイル管理テーブル (Cloudflare R2に保存されたMP3のURLを管理)';
+COMMENT ON COLUMN public.fantasy_bgm_assets.name IS '管理用表示名';
+COMMENT ON COLUMN public.fantasy_bgm_assets.mp3_url IS '公開MP3 URL (R2 CDN)';
+COMMENT ON COLUMN public.fantasy_bgm_assets.r2_key IS 'R2オブジェクトキー（削除用）';
+
+-- 更新トリガー
+DROP TRIGGER IF EXISTS fantasy_bgm_assets_updated_at_trigger ON public.fantasy_bgm_assets;
+CREATE TRIGGER fantasy_bgm_assets_updated_at_trigger
+  BEFORE UPDATE ON public.fantasy_bgm_assets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_set_timestamp();
+
+-- RLS 有効化
+ALTER TABLE public.fantasy_bgm_assets ENABLE ROW LEVEL SECURITY;
+
+-- ポリシー: 全員読み取り可
+DROP POLICY IF EXISTS fantasy_bgm_assets_read_policy ON public.fantasy_bgm_assets;
+CREATE POLICY fantasy_bgm_assets_read_policy ON public.fantasy_bgm_assets
+  FOR SELECT USING (true);
+
+-- ポリシー: 管理者のみ書き込み可（INSERT/UPDATE/DELETE）
+DROP POLICY IF EXISTS fantasy_bgm_assets_write_policy ON public.fantasy_bgm_assets;
+CREATE POLICY fantasy_bgm_assets_write_policy ON public.fantasy_bgm_assets
+  FOR ALL USING (
+    auth.uid() IN (
+      SELECT id FROM public.profiles WHERE is_admin = true
+    )
+  );
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS fantasy_bgm_assets_created_at_idx ON public.fantasy_bgm_assets(created_at DESC);
+
+-- 権限
+GRANT ALL ON TABLE public.fantasy_bgm_assets TO anon;
+GRANT ALL ON TABLE public.fantasy_bgm_assets TO authenticated;
+GRANT ALL ON TABLE public.fantasy_bgm_assets TO service_role;


### PR DESCRIPTION
Add admin UI and backend for managing fantasy mode BGM assets from Cloudflare R2.

This enables non-hardcoded BGM management by providing URLs for manual input into `fantasy_stages.mp3_url`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6484e8fe-20ab-48f9-9565-c468c1e65038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6484e8fe-20ab-48f9-9565-c468c1e65038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

