### PR TITLE
Add diary navigation to daily feed page

### DIFF
--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -59,7 +59,7 @@ const DiaryPage: React.FC = () => {
         const id = urlParams.get('id');
         setUserId(id);
         setOpen(!!id);
-      } else if (hash === '#diary') {
+      } else if (hash === '#diary' || hash.startsWith('#diary?')) {
         setOpen(true);
         setUserId(null);
       } else {


### PR DESCRIPTION
Implement date navigation and display on the Daily Feed page to allow viewing diaries for specific dates.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fcc7476-984a-4f83-a41f-b7460ed8e72e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fcc7476-984a-4f83-a41f-b7460ed8e72e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

