### PR TITLE
Fix fantasy progression note and effect bugs

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -1234,6 +1234,10 @@ export const useFantasyGameEngine = ({
         // 怒り状態をストアに通知
         const { setEnrage } = useEnemyStore.getState();
         setEnrage(attackingMonster.id, true);
+        try {
+          // 視覚は直ちに100msだけ怒りを保証（取りこぼし防止）
+          (window as any).__fantasy_pixi__?.triggerEnrageBurst?.(attackingMonster.id, 100);
+        } catch {}
         setTimeout(() => setEnrage(attackingMonster.id, false), 100); // 0.1秒後にOFF
         
         // 攻撃したモンスターのゲージをリセット

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -1234,7 +1234,7 @@ export const useFantasyGameEngine = ({
         // 怒り状態をストアに通知
         const { setEnrage } = useEnemyStore.getState();
         setEnrage(attackingMonster.id, true);
-        setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
+        setTimeout(() => setEnrage(attackingMonster.id, false), 100); // 0.1秒後にOFF
         
         // 攻撃したモンスターのゲージをリセット
         const resetMonsters = updatedMonsters.map(m => 

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -1165,16 +1165,25 @@ export const useFantasyGameEngine = ({
             currentTime: currentTime.toFixed(3),
             hitTime: currentNote.hitTime.toFixed(3)
           });
-          
+
+          // ▼ 判定ライン上にミスエフェクト（短時間）
+          try {
+            // FantasyPIXIRenderer 経由で失敗エフェクトを表示
+            (window as any).__fantasy_pixi__?.createNoteHitEffect?.(
+              (window as any).__fantasy_pixi__?.getJudgeLinePosition?.().x,
+              (window as any).__fantasy_pixi__?.getJudgeLinePosition?.().y,
+              false
+            );
+          } catch {}
+
           // 敵の攻撃を発動（先頭モンスターを指定）
           const attackerId = prevState.activeMonsters?.[0]?.id;
           setTimeout(() => handleEnemyAttack(attackerId), 0);
-          
-          // 次のノーツへ進む
-          const nextIndex = currentNoteIndex + 1;
-          
-          // 次のノーツの情報を取得（ループ対応）
-          let nextNote, nextNextNote;
+
+          // 次のノーツに進める
+          let nextIndex = (currentNoteIndex + 1) % prevState.taikoNotes.length;
+          let nextNote: TaikoNote | undefined;
+          let nextNextNote: TaikoNote | undefined;
           if (nextIndex < prevState.taikoNotes.length) {
             nextNote = prevState.taikoNotes[nextIndex];
             nextNextNote = (nextIndex + 1 < prevState.taikoNotes.length) 
@@ -1195,8 +1204,8 @@ export const useFantasyGameEngine = ({
               ...m,
               correctNotes: [],
               gauge: 0,
-              chordTarget: nextNote.chord,
-              nextChord: nextNextNote.chord
+              chordTarget: nextNote?.chord || m.chordTarget,
+              nextChord: nextNextNote?.chord || nextNote?.chord || m.nextChord
             }))
           };
         }

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2251,6 +2251,11 @@ export class FantasyPIXIInstance {
   private isSpriteInvalid = (s: PIXI.DisplayObject | null | undefined) =>
     !s || (s as any).destroyed || !(s as any).transform;
 
+  // 怒りを短時間だけ強制表示（即時反映＆即終了）
+  public triggerEnrageBurst(monsterId: string, durationMs: number = 100): void {
+    const now = Date.now();
+    this.enrageHoldUntil.set(monsterId, now + Math.max(0, durationMs));
+  }
 
 }
 

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1597,11 +1597,11 @@ export class FantasyPIXIInstance {
     icon.y = -monsterData.sprite.height * 0.45;
     monsterData.sprite.addChild(icon);
 
-    // 1 秒後に自動削除（ずっと残すなら setTimeout を外す）
+    // 0.5 秒後に自動削除（過密時の視認性改善）
     setTimeout(() => {
       if (!icon.destroyed && icon.parent) icon.parent.removeChild(icon);
       icon.destroy();
-    }, 1000);
+    }, 500);
 
     (monsterData as any).attackIcon = icon; // 再利用できるよう保持
   }
@@ -2069,20 +2069,24 @@ export class FantasyPIXIInstance {
     
     this.effectContainer.addChild(effectGraphics);
     
-    // フェードアウトアニメーション
-    const fadeOut = () => {
-      effectGraphics.alpha -= 0.05;
-      effectGraphics.scale.x += 0.05;
-      effectGraphics.scale.y += 0.05;
-      
-      if (effectGraphics.alpha <= 0) {
-        effectGraphics.destroy();
+    // 140msで確実に終了する時間制御フェード
+    const start = performance.now();
+    const duration = 140;
+    const startScaleX = effectGraphics.scale.x;
+    const startScaleY = effectGraphics.scale.y;
+    const animate = (t: number) => {
+      const elapsed = t - start;
+      const p = Math.min(1, elapsed / duration);
+      effectGraphics.alpha = 1 - p;
+      const s = 1 + p * 0.25;
+      effectGraphics.scale.set(startScaleX * s, startScaleY * s);
+      if (p < 1) {
+        requestAnimationFrame(animate);
       } else {
-        requestAnimationFrame(fadeOut);
+        if (!effectGraphics.destroyed) effectGraphics.destroy();
       }
     };
-    
-    requestAnimationFrame(fadeOut);
+    requestAnimationFrame(animate);
   }
   
   // 判定ラインの位置を取得

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1597,11 +1597,11 @@ export class FantasyPIXIInstance {
     icon.y = -monsterData.sprite.height * 0.45;
     monsterData.sprite.addChild(icon);
 
-    // 0.5 秒後に自動削除（過密時の視認性改善）
+    // 0.1 秒後に自動削除（過密時の視認性改善）
     setTimeout(() => {
       if (!icon.destroyed && icon.parent) icon.parent.removeChild(icon);
       icon.destroy();
-    }, 500);
+    }, 100);
 
     (monsterData as any).attackIcon = icon; // 再利用できるよう保持
   }
@@ -1686,7 +1686,7 @@ export class FantasyPIXIInstance {
           sprite.scale.set(visualState.scale * pulse);
           
           // 攻撃直後のモンスター赤フラッシュ
-          if (monsterData.lastAttackTime && Date.now() - monsterData.lastAttackTime < 150) {
+          if (monsterData.lastAttackTime && Date.now() - monsterData.lastAttackTime < 100) {
             sprite.tint = 0xFF4444; // 真紅
           }
           


### PR DESCRIPTION
Fixes note disappearance and improves miss effect visibility in Fantasy Mode Progression by adjusting note visibility and refining effect display logic.

Previously, notes would vanish prematurely at the judgment line upon a miss, particularly for the first note. Additionally, rapid note sequences caused miss effects to fail to display due to conflicts or excessive display duration. This PR ensures notes remain visible briefly after a miss and that miss effects are consistently triggered and displayed for a shorter, clearer duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ff345d7-bc85-491d-941c-aed9a4c5a78a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ff345d7-bc85-491d-941c-aed9a4c5a78a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

