### PR TITLE
Fix fantasy progression note and effect bugs

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -951,8 +951,8 @@ export const useFantasyGameEngine = ({
     // 怒り状態のトグル（IDがわかる場合）
     if (attackingMonsterId) {
       const { setEnrage } = useEnemyStore.getState();
-      setEnrage(attackingMonsterId, true);
-      setTimeout(() => setEnrage(attackingMonsterId!, false), 500);
+      // 自動解除に任せる（重複しない）
+      setEnrage(attackingMonsterId, true, 1200);
     }
     
     setGameState(prevState => {
@@ -960,8 +960,7 @@ export const useFantasyGameEngine = ({
       if (!attackingMonsterId && prevState.activeMonsters?.length) {
         const { setEnrage } = useEnemyStore.getState();
         const fallbackId = prevState.activeMonsters[0].id;
-        setEnrage(fallbackId, true);
-        setTimeout(() => setEnrage(fallbackId, false), 500);
+        setEnrage(fallbackId, true, 1200);
       }
 
       const newHp = Math.max(0, prevState.playerHp - 1); // 確実に1減らす
@@ -1224,8 +1223,7 @@ export const useFantasyGameEngine = ({
         
         // 怒り状態をストアに通知
         const { setEnrage } = useEnemyStore.getState();
-        setEnrage(attackingMonster.id, true);
-        setTimeout(() => setEnrage(attackingMonster.id, false), 500); // 0.5秒後にOFF
+        setEnrage(attackingMonster.id, true, 1200); // 自動解除（重複無し）
         
         // 攻撃したモンスターのゲージをリセット
         const resetMonsters = updatedMonsters.map(m => 

--- a/src/stores/enemyStore.ts
+++ b/src/stores/enemyStore.ts
@@ -3,14 +3,40 @@ import { create } from 'zustand';
 type EnemyStore = {
   /** 現在 "怒り中" のモンスター ID → true */
   enraged: Record<string, boolean>;
-  /** 怒りフラグを立てる / 消す */
-  setEnrage: (id: string, value: boolean) => void;
+  /** 個別の怒り終了タイマーを管理（重複防止） */
+  timers: Record<string, number | undefined>;
+  /** 怒りフラグを立てる / 消す（自動解除付） */
+  setEnrage: (id: string, value: boolean, durationMs?: number) => void;
 };
 
-export const useEnemyStore = create<EnemyStore>(set => ({
+export const useEnemyStore = create<EnemyStore>((set, get) => ({
   enraged: {},
-  setEnrage: (id, value) =>
+  timers: {},
+  setEnrage: (id, value, durationMs = 800) => {
+    // 既存タイマーがあればクリア
+    const timers = { ...get().timers };
+    if (timers[id] !== undefined) {
+      clearTimeout(timers[id]);
+      delete timers[id];
+    }
+
     set(state => ({
       enraged: { ...state.enraged, [id]: value }
-    }))
+    }));
+
+    if (value) {
+      const timeoutId = window.setTimeout(() => {
+        // タイマー満了で怒り解除（重複防止）
+        const current = get().enraged[id];
+        if (current) {
+          set(state => ({ enraged: { ...state.enraged, [id]: false } }));
+        }
+        // 後始末
+        const t = { ...get().timers };
+        if (t[id] !== undefined) delete t[id];
+        set({ timers: t });
+      }, durationMs);
+      set({ timers: { ...get().timers, [id]: timeoutId } });
+    }
+  }
 }));


### PR DESCRIPTION
Fixes note disappearance and refactors anger effects in Fantasy Progression mode to improve visual feedback and prevent effect conflicts.

The previous anger effect (monster icon scaling) could conflict or fail to display during rapid misses. This PR replaces it with floating anger marks, similar to damage text, and implements robust state management to prevent overlapping or persistent anger states. It also resolves an unnatural visual where missed notes instantly vanished at the judgment line.

---
<a href="https://cursor.com/background-agent?bcId=bc-177e3eee-2750-4a74-bf32-7c214fbf1874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-177e3eee-2750-4a74-bf32-7c214fbf1874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

