### PR TITLE
Add red x mark for taiko mode misses

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -321,8 +321,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     console.log('🔥 handleEnemyAttack called with monsterId:', attackingMonsterId);
     devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
 
-    // Taikoモードのミス時は判定ラインへ赤い×を一瞬表示
-    if (isTaikoModeRef.current && fantasyPixiInstance) {
+    // progression系（order/random/timing）のTaikoミス時は判定ラインへ赤い×を一瞬表示
+    if (fantasyPixiInstance && stage.mode !== 'single') {
       const { x, y } = fantasyPixiInstance.getJudgeLinePosition();
       fantasyPixiInstance.createNoteHitEffect(x, y, false, 50);
     }

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -320,6 +320,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   const handleEnemyAttack = useCallback(async (attackingMonsterId?: string) => {
     console.log('🔥 handleEnemyAttack called with monsterId:', attackingMonsterId);
     devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
+
+    // Taikoモードのミス時は判定ラインへ赤い×を一瞬表示
+    if (isTaikoModeRef.current && fantasyPixiInstance) {
+      const { x, y } = fantasyPixiInstance.getJudgeLinePosition();
+      fantasyPixiInstance.createNoteHitEffect(x, y, false, 50);
+    }
     
     // 敵の攻撃音を再生（single クイズモードのみ）
     try {
@@ -341,7 +347,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     setHeartFlash(true);
     setTimeout(() => setHeartFlash(false), 150);
     
-  }, [stage.mode]);
+  }, [stage.mode, fantasyPixiInstance]);
   
   const handleGameCompleteCallback = useCallback((result: 'clear' | 'gameover', finalState: FantasyGameState) => {
     const text = result === 'clear' ? 'Stage Clear' : 'Game Over';


### PR DESCRIPTION
Display a temporary red 'X' mark at the judge line on Taiko mode misses for immediate visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dd75701-59e5-40bf-80b7-0add2aabe267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7dd75701-59e5-40bf-80b7-0add2aabe267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

