### PR TITLE
Show keyboard highlights in fantasy mode

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -439,24 +439,25 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const whiteKeyWidth = screenWidth / totalWhiteKeys;
       const dynamicNoteWidth = Math.max(whiteKeyWidth - 2, 16); // 最小16px
       
-      renderer.updateSettings({
-        noteNameStyle: 'abc',
-        simpleDisplayMode: true, // シンプル表示モードを有効
-        pianoHeight: 120, // ファンタジーモード用に大幅に縮小
-        noteHeight: 16, // 音符の高さも縮小
-        noteWidth: dynamicNoteWidth,
-        transpose: 0,
-        transposingInstrument: 'concert_pitch',
-        practiceGuide: stage.showGuide ? 'key' : 'off', // ガイド表示設定に基づく
-        showHitLine: false, // ヒットラインを非表示
-        viewportHeight: 120, // pianoHeightと同じ値に設定してノーツ下降部分を完全に非表示
-        timingAdjustment: 0,
-        effects: {
-          glow: true,
-          particles: false,
-          trails: false
-        }
-      });
+              const shouldEnableGuide = stage.showGuide && (stage.simultaneousMonsterCount === 1);
+        renderer.updateSettings({
+          noteNameStyle: 'abc',
+          simpleDisplayMode: true, // シンプル表示モードを有効
+          pianoHeight: 120, // ファンタジーモード用に大幅に縮小
+          noteHeight: 16, // 音符の高さも縮小
+          noteWidth: dynamicNoteWidth,
+          transpose: 0,
+          transposingInstrument: 'concert_pitch',
+          practiceGuide: shouldEnableGuide ? 'key' : 'off', // ガイド表示: show_guide && 同時出現数1 のときのみ
+          showHitLine: false, // ヒットラインを非表示
+          viewportHeight: 120, // pianoHeightと同じ値に設定してノーツ下降部分を完全に非表示
+          timingAdjustment: 0,
+          effects: {
+            glow: true,
+            particles: false,
+            trails: false
+          }
+        });
       
       // キーボードのクリックイベントを接続
       devLog.debug('🎹 Setting key callbacks for Fantasy mode...');
@@ -484,12 +485,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         if (midiControllerRef.current) {
           midiControllerRef.current.setKeyHighlightCallback((note: number, active: boolean) => {
             renderer.highlightKey(note, active);
-            // アクティブ(ノートオン)時に即時エフェクトを発火
             if (active) {
               renderer.triggerKeyPressEffect(note);
             }
           });
-          
           devLog.debug('✅ ファンタジーモードMIDIController ↔ PIXIレンダラー連携完了');
         }
       
@@ -708,12 +707,13 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // 設定変更時にPIXIレンダラーを更新（鍵盤ハイライトは無効化）
   useEffect(() => {
     if (pixiRenderer) {
+      const shouldEnableGuide = stage.showGuide && (stage.simultaneousMonsterCount === 1);
       pixiRenderer.updateSettings({
-        practiceGuide: 'off' // 常にOFFにして鍵盤ハイライトを無効化
+        practiceGuide: shouldEnableGuide ? 'key' : 'off'
       });
-      devLog.debug('🎮 PIXIレンダラー設定更新: 鍵盤ハイライト無効化');
+      devLog.debug(`🎮 PIXIレンダラー設定更新: practiceGuide=${shouldEnableGuide ? 'key' : 'off'}`);
     }
-  }, [pixiRenderer]);
+  }, [pixiRenderer, stage.showGuide, stage.simultaneousMonsterCount]);
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）
   const renderHearts = useCallback((hp: number, maxHp: number, isPlayer: boolean = true) => {

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1437,14 +1437,7 @@ export class PIXINotesRendererInstance {
       // pointerイベントがタッチとマウスの両方を処理するため、touchイベントは不要
       // （touchイベントとpointerイベントの両方が発火して2重になるのを防ぐ）
       
-      // ホバー効果を追加
-      key.on('pointerover', () => {
-        key.tint = 0xF3F4F6; // light gray hover
-      });
-      
-      key.on('pointerout', () => {
-        key.tint = 0xFFFFFF; // white
-      });
+      // ホバー効果を削除（ファンタジーモード等でのハイライトと競合を回避）
     }
     
     return key;
@@ -1538,20 +1531,7 @@ export class PIXINotesRendererInstance {
       // pointerイベントがタッチとマウスの両方を処理するため、touchイベントは不要
       // （touchイベントとpointerイベントの両方が発火して2重になるのを防ぐ）
       
-      // ホバー効果を追加（黒鍵専用、tintではなく軽微な視覚効果のみ）
-      key.on('pointerover', () => {
-        // 黒鍵のホバー効果は微妙にして、ハイライト状態を阻害しない
-        if (!this.isKeyHighlighted(midiNote)) {
-          key.alpha = 0.8; // 少し透明にしてホバー感を演出
-        }
-      });
-      
-      key.on('pointerout', () => {
-        // ハイライト状態でない場合のみリセット
-        if (!this.isKeyHighlighted(midiNote)) {
-          key.alpha = 1.0; // 通常状態に戻す
-        }
-      });
+      // ホバー効果を削除（黒鍵も含む）
     }
     
     return key;


### PR DESCRIPTION
Conditionally enable keyboard highlighting in Fantasy mode and remove piano key hover animations to prevent highlight conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfe15f93-f91d-4980-a312-1a73abc46dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bfe15f93-f91d-4980-a312-1a73abc46dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

