### PR TITLE
Update piano highlight for fantasy mode guide

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -21,6 +21,7 @@ import {
   parseSimpleProgressionText
 } from './TaikoNoteSystem';
 import { bgmManager } from '@/utils/BGMManager';
+import { buildChordMidiNotes } from '@/utils/chord-utils';
 
 // ===== 型定義 =====
 
@@ -142,11 +143,8 @@ const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDe
     return null;
   }
 
-  // notesをMIDIノート番号に変換
-  const midiNotes = resolved.notes.map(noteName => {
-    const noteObj = parseNote(noteName + '4'); // オクターブ4を付加
-    return noteObj && typeof noteObj.midi === 'number' ? noteObj.midi : 60; // デフォルトでC4
-  });
+  // ルートを下にした基本形のまま（指定オクターブ基準）でMIDIノートを生成
+  const midiNotes = buildChordMidiNotes(resolved.root, resolved.quality, 4);
 
   return {
     id: chordId,
@@ -157,9 +155,6 @@ const getChordDefinition = (chordId: string, displayOpts?: DisplayOpts): ChordDe
     root: resolved.root
   };
 };
-
-// parseNoteをインポート
-import { note as parseNote } from 'tonal';
 
 // ===== 敵リスト定義 =====
 

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -717,21 +717,21 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   useEffect(() => {
     if (!pixiRenderer) return;
     const canGuide = stage.showGuide && gameState.simultaneousMonsterCount === 1;
-    const setGuide = (pcs: number[]) => {
-      (pixiRenderer as any).setGuideHighlightsByPitchClasses?.(pcs);
+    const setGuideMidi = (midiNotes: number[]) => {
+      (pixiRenderer as any).setGuideHighlightsByMidiNotes?.(midiNotes);
     };
     if (!canGuide) {
-      setGuide([]);
+      setGuideMidi([]);
       return;
     }
     const targetMonster = gameState.activeMonsters?.[0];
     const chord = targetMonster?.chordTarget || gameState.currentChordTarget;
     if (!chord) {
-      setGuide([]);
+      setGuideMidi([]);
       return;
     }
-    const pcs = Array.from(new Set(chord.notes.map((n: number) => ((n % 12) + 12) % 12)));
-    setGuide(pcs);
+    // 出題オクターブでのMIDIノートをそのまま渡す
+    setGuideMidi(chord.notes as number[]);
   }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -705,15 +705,34 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     };
   }, [gameState.isTaikoMode, gameState.taikoNotes, gameState.currentNoteIndex, fantasyPixiInstance, gameState.currentStage]);
   
-  // 設定変更時にPIXIレンダラーを更新（鍵盤ハイライトは無効化）
+  // 設定変更時にPIXIレンダラーを更新（鍵盤ハイライトは条件付きで有効）
   useEffect(() => {
-    if (pixiRenderer) {
-      pixiRenderer.updateSettings({
-        practiceGuide: 'off' // 常にOFFにして鍵盤ハイライトを無効化
-      });
-      devLog.debug('🎮 PIXIレンダラー設定更新: 鍵盤ハイライト無効化');
+    if (!pixiRenderer) return;
+    const canGuide = stage.showGuide && gameState.simultaneousMonsterCount === 1;
+    pixiRenderer.updateSettings({ practiceGuide: canGuide ? 'key' : 'off' });
+    devLog.debug('🎮 PIXIレンダラー設定更新:', { practiceGuide: canGuide ? 'key' : 'off', showGuide: stage.showGuide, simCount: gameState.simultaneousMonsterCount, mode: stage.mode });
+  }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, stage.mode]);
+  
+  // ガイド用ハイライト更新（showGuideが有効かつ同時出現数=1のときのみ）
+  useEffect(() => {
+    if (!pixiRenderer) return;
+    const canGuide = stage.showGuide && gameState.simultaneousMonsterCount === 1;
+    const setGuide = (pcs: number[]) => {
+      (pixiRenderer as any).setGuideHighlightsByPitchClasses?.(pcs);
+    };
+    if (!canGuide) {
+      setGuide([]);
+      return;
     }
-  }, [pixiRenderer]);
+    const targetMonster = gameState.activeMonsters?.[0];
+    const chord = targetMonster?.chordTarget || gameState.currentChordTarget;
+    if (!chord) {
+      setGuide([]);
+      return;
+    }
+    const pcs = Array.from(new Set(chord.notes.map((n: number) => ((n % 12) + 12) % 12)));
+    setGuide(pcs);
+  }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）
   const renderHearts = useCallback((hp: number, maxHp: number, isPlayer: boolean = true) => {

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -3123,6 +3123,31 @@ export class PIXINotesRendererInstance {
       });
     }
   }
+
+  // 出題オクターブのみのガイド表示用：MIDI番号で直接指定
+  public setGuideHighlightsByMidiNotes(midiNotes: number[]): void {
+    const clamped = new Set<number>();
+    for (const n of midiNotes) {
+      const midi = Math.round(n);
+      if (midi >= 21 && midi <= 108) clamped.add(midi);
+    }
+
+    // なくなるガイドを消す（演奏ハイライトが無ければ可視も解除）
+    for (const midi of Array.from(this.guideHighlightedKeys)) {
+      if (!clamped.has(midi)) {
+        this.guideHighlightedKeys.delete(midi);
+        if (!this.highlightedKeys.has(midi)) this.applyKeyHighlightVisual(midi, false);
+      }
+    }
+
+    // 新しく必要なガイドを付与
+    for (const midi of clamped) {
+      if (!this.guideHighlightedKeys.has(midi)) {
+        this.guideHighlightedKeys.add(midi);
+        this.applyKeyHighlightVisual(midi, true);
+      }
+    }
+  }
 }
 
 // ===== React コンポーネント =====

--- a/src/utils/chord-utils.ts
+++ b/src/utils/chord-utils.ts
@@ -47,16 +47,26 @@ export function buildChordNotes(root: string, quality: ChordQuality, octave: num
  * @returns MIDIノート番号配列
  */
 export function buildChordMidiNotes(root: string, quality: ChordQuality, octave: number = 4): number[] {
-  const notes = buildChordNotes(root, quality, octave);
-  
-  return notes.map(noteName => {
-    const note = parseNote(noteName);
-    if (!note || typeof note.midi !== 'number') {
-      console.warn(`⚠️ MIDI変換失敗: ${noteName}`);
-      return 60; // デフォルトでC4
+  const intervals = CHORD_TEMPLATES[quality];
+  if (!intervals) {
+    console.warn(`⚠️ 未定義のコードクオリティ: ${quality}`);
+    return [];
+  }
+
+  const rootWithOctave = `${root}${octave}`;
+  const midiNotes: number[] = [];
+  for (const interval of intervals) {
+    const n = transpose(rootWithOctave, interval);
+    if (!n) {
+      console.warn(`⚠️ 移調失敗: ${rootWithOctave} + ${interval}`);
+      continue;
     }
-    return note.midi;
-  });
+    const parsed = parseNote(n);
+    if (parsed && typeof parsed.midi === 'number') {
+      midiNotes.push(parsed.midi);
+    }
+  }
+  return midiNotes;
 }
 
 /**


### PR DESCRIPTION
Implement conditional keyboard guide highlights in Fantasy mode and remove hover effects to ensure guide stability.

Previously, keyboard highlights for guidance were not persistent and could be cleared by user input or mouse hovers, diminishing their utility. This PR introduces a dedicated guide highlight system that displays only when `show_guide` is true and `simultaneousMonsterCount` is 1, remains stable against user interaction, and dynamically updates with chord changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-78a55d4c-f71f-45f1-a3a4-777f6ccde017">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78a55d4c-f71f-45f1-a3a4-777f6ccde017">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

