### PR TITLE
Fix fantasy root sound playback logic

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -192,19 +192,17 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
             devLog.debug('🎵 ファンタジーモード初期音量設定: 80%');
             
             // FantasySoundManagerの初期化
-            import('@/utils/FantasySoundManager').then(({ FantasySoundManager }) => {
-              FantasySoundManager.init(
-                settings.soundEffectVolume ?? 0.8,
-                settings.rootSoundVolume ?? 0.5,
-                false
-              ).then(() => {
+            import('@/utils/FantasySoundManager')
+              .then(async (mod) => {
+                const FSM = (mod as any).FantasySoundManager ?? mod.default;
+                await FSM?.init(
+                  settings.soundEffectVolume ?? 0.8,
+                  settings.rootSoundVolume ?? 0.5,
+                  false
+                );
                 devLog.debug('🔊 ファンタジーモード効果音初期化完了');
-              }).catch(error => {
-                console.error('Failed to initialize FantasySoundManager:', error);
-              });
-            }).catch(error => {
-              console.error('Failed to import FantasySoundManager:', error);
-            });
+              })
+              .catch(err => console.error('Failed to import/init FantasySoundManager:', err));
           }).catch(error => {
             console.error('Audio system initialization failed:', error);
           });
@@ -266,8 +264,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     let cancelled = false;
     const apply = async () => {
       try {
-        const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-        FantasySoundManager.enableRootSound(stage?.playRootOnCorrect === true);
+        const mod = await import('@/utils/FantasySoundManager');
+        const FSM = (mod as any).FantasySoundManager ?? mod.default;
+        FSM?.enableRootSound(stage?.playRootOnCorrect === true);
         if (stage?.playRootOnCorrect === true) {
           // 初回有効化直後に鳴らない問題の回避: 少し待機
           await new Promise(r => setTimeout(r, 50));
@@ -318,8 +317,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     const allowRootSound = stage?.playRootOnCorrect === true;
     if (allowRootSound) {
       try {
-        const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-        await FantasySoundManager.playRootNote(chord.root);
+        const mod = await import('@/utils/FantasySoundManager');
+        const FSM = (mod as any).FantasySoundManager ?? mod.default;
+        await FSM?.playRootNote(chord.root);
       } catch (error) {
         console.error('Failed to play root note:', error);
       }
@@ -341,12 +341,13 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     devLog.debug('💥 敵の攻撃!', { attackingMonsterId });
     
     // 敵の攻撃音を再生（single クイズモードのみ）
-    try {
-      if (stage.mode === 'single') {
-        const { FantasySoundManager } = await import('@/utils/FantasySoundManager');
-        FantasySoundManager.playEnemyAttack();
-      }
-    } catch (error) {
+          try {
+        if (stage.mode === 'single') {
+          const mod = await import('@/utils/FantasySoundManager');
+          const FSM = (mod as any).FantasySoundManager ?? mod.default;
+          FSM?.playEnemyAttack();
+        }
+      } catch (error) {
       console.error('Failed to play enemy attack sound:', error);
     }
     
@@ -1297,11 +1298,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
             devLog.debug(`🔊 ファンタジーモードの効果音音量を更新: ${settings.soundEffectVolume}`);
             
             // FantasySoundManagerの音量も即座に更新
-            import('@/utils/FantasySoundManager').then(({ FantasySoundManager }) => {
-              FantasySoundManager.setVolume(settings.soundEffectVolume);
-            }).catch(error => {
-              console.error('Failed to update FantasySoundManager volume:', error);
-            });
+            import('@/utils/FantasySoundManager')
+              .then((mod) => {
+                const FSM = (mod as any).FantasySoundManager ?? mod.default;
+                FSM?.setVolume(settings.soundEffectVolume);
+              })
+              .catch(error => {
+                console.error('Failed to update FantasySoundManager volume:', error);
+              });
           }
         }}
         // gameStoreの値を渡す

--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -114,7 +114,10 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           showGuide: stage.show_guide || false,
           // 追加: 拍間隔（存在すれば）
           noteIntervalBeats: (stage as any).note_interval_beats,
-          showSheetMusic: false
+          showSheetMusic: false,
+          // 追加: 正解時にルート音を鳴らす
+          playRootOnCorrect: (stage as any).play_root_on_correct ?? true,
+          bpm: (stage as any).bpm || 120,
         }));
         
         setStages(convertedStages);
@@ -204,7 +207,9 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         bpm: (stage as any).bpm || 120,
         measureCount: (stage as any).measure_count,
         countInMeasures: (stage as any).count_in_measures,
-        timeSignature: (stage as any).time_signature
+        timeSignature: (stage as any).time_signature,
+        // 追加: 正解時にルート音を鳴らす
+        playRootOnCorrect: (stage as any).play_root_on_correct ?? true,
       }));
       
       const convertedProgress: FantasyUserProgress = {


### PR DESCRIPTION
Fixes root note not playing from stage select by mapping `play_root_on_correct` and making `FantasySoundManager` dynamic imports robust.

Previously, the `play_root_on_correct` flag was not correctly propagated from the backend to the frontend when a stage was initiated from the stage selection screen, causing the root note to not play. Furthermore, mixed named and default exports for `FantasySoundManager` in dynamic imports could result in the sound manager being `undefined`, preventing sound initialization and playback. This PR ensures the flag is passed and imports are handled correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-d88c7412-bee8-46e4-9183-1de919fc9734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d88c7412-bee8-46e4-9183-1de919fc9734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

