### PR TITLE
Fix white key highlight reversion

### DIFF
--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -704,7 +704,10 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
         // 一定時間後にハイライトを解除
         setTimeout(() => {
           if (pixiRenderer) {
-            pixiRenderer.highlightKey(pitch, false);
+            // 押下中でない場合のみ自動解除（押下中は離すまでオレンジ維持）
+            if (!pixiRenderer.isKeyPressed(pitch)) {
+              pixiRenderer.highlightKey(pitch, false);
+            }
           }
         }, 150); // 150ms後にハイライト解除（マウスクリックと同じ長さ）
       }

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1681,23 +1681,17 @@ export class PIXINotesRendererInstance {
       log.warn(`⚠️ Key sprite not found for note: ${midiNote}`);
       return;
     }
-    
+
     if (active) {
       this.highlightedKeys.add(midiNote);
     } else {
-      // ガイドが存在する場合は解除しない
-      if (!this.guideHighlightedKeys.has(midiNote)) {
-        this.highlightedKeys.delete(midiNote);
-      }
+      // 演奏ハイライトからは外す（ガイドは別Setで保持）
+      this.highlightedKeys.delete(midiNote);
     }
-    
-    const shouldHighlight = this.isKeyHighlighted(midiNote);
-    if (this.isBlackKey(midiNote)) {
-      this.redrawBlackKeyHighlight(keySprite, shouldHighlight, midiNote);
-      if (!shouldHighlight) keySprite.alpha = 1.0;
-    } else {
-      (keySprite as any).tint = shouldHighlight ? this.settings.colors.activeKey : 0xFFFFFF;
-    }
+
+    // ガイド or 演奏の合算状態をもとに見た目を適用
+    const unionHighlighted = this.isKeyHighlighted(midiNote);
+    this.applyKeyHighlightVisual(midiNote, unionHighlighted);
   }
   
   /**

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -3190,6 +3190,13 @@ export class PIXINotesRendererInstance {
     }
     this.highlightedKeys.clear();
   }
+
+  /**
+   * 現在そのキーが押下中（演奏ハイライト中）かどうか
+   */
+  public isKeyPressed(midiNote: number): boolean {
+    return this.highlightedKeys.has(midiNote);
+  }
 }
 
 // ===== React コンポーネント =====


### PR DESCRIPTION
Refactor `highlightKey` to delegate visual updates to `applyKeyHighlightVisual` to ensure piano keys correctly revert to guide green on release.

Previously, `highlightKey` would always tint white keys with the `activeKey` color if `shouldHighlight` was true, preventing them from reverting to the guide color (green) upon release. By delegating the visual application to `applyKeyHighlightVisual`, the combined state of guide and active highlights is correctly rendered, allowing keys to return to guide green when no longer actively pressed.

---
<a href="https://cursor.com/background-agent?bcId=bc-3540bdeb-cfb2-4273-a09d-8c86bccc1681">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3540bdeb-cfb2-4273-a09d-8c86bccc1681">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

