### PR TITLE
Improve highlight and guide rendering logic

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -733,15 +733,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     devLog.debug('🎮 PIXIレンダラー設定更新:', { practiceGuide: canGuide ? 'key' : 'off', showGuide: stage.showGuide, simCount: gameState.simultaneousMonsterCount, mode: stage.mode });
   }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, stage.mode]);
 
-  // 問題が変わったタイミングでハイライトを確実にリセット
-  useEffect(() => {
-    if (!pixiRenderer) return;
-    // single: currentChordTarget が変わる / progression: currentNoteIndex が進む
-    (pixiRenderer as any).clearActiveHighlights?.();
-    // ガイドもいったん全消去 → 後続のガイド再設定で再点灯
-    (pixiRenderer as any).clearAllHighlights?.();
-  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex]);
-
   // ガイド用ハイライト更新（showGuideが有効かつ同時出現数=1のときのみ）
   useEffect(() => {
     if (!pixiRenderer) return;
@@ -749,22 +740,16 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     const setGuideMidi = (midiNotes: number[]) => {
       (pixiRenderer as any).setGuideHighlightsByMidiNotes?.(midiNotes);
     };
+
     if (!canGuide) {
-      // ガイドOFF時は確実に全消去
-      (pixiRenderer as any).clearAllHighlights?.();
+      // ガイドだけを外す（演奏中ハイライトは残す）
       setGuideMidi([]);
       return;
     }
+
     const targetMonster = gameState.activeMonsters?.[0];
     const chord = targetMonster?.chordTarget || gameState.currentChordTarget;
-    if (!chord) {
-      (pixiRenderer as any).clearAllHighlights?.();
-      setGuideMidi([]);
-      return;
-    }
-    // いったん全消去してから今回のガイドを設定（取り残し防止）
-    (pixiRenderer as any).clearAllHighlights?.();
-    setGuideMidi(chord.notes as number[]);
+    setGuideMidi(chord ? (chord.notes as number[]) : []);
   }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
   
   // HPハート表示（プレイヤーと敵の両方を赤色のハートで表示）

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1681,23 +1681,17 @@ export class PIXINotesRendererInstance {
       log.warn(`⚠️ Key sprite not found for note: ${midiNote}`);
       return;
     }
-    
+
     if (active) {
       this.highlightedKeys.add(midiNote);
     } else {
-      // ガイドが存在する場合は解除しない
-      if (!this.guideHighlightedKeys.has(midiNote)) {
-        this.highlightedKeys.delete(midiNote);
-      }
+      // ノートオフ時は演奏ハイライトを確実に解除（ガイドは別管理で残す）
+      this.highlightedKeys.delete(midiNote);
     }
-    
+
     const shouldHighlight = this.isKeyHighlighted(midiNote);
-    if (this.isBlackKey(midiNote)) {
-      this.redrawBlackKeyHighlight(keySprite, shouldHighlight, midiNote);
-      if (!shouldHighlight) keySprite.alpha = 1.0;
-    } else {
-      (keySprite as any).tint = shouldHighlight ? this.settings.colors.activeKey : 0xFFFFFF;
-    }
+    // 見た目は統一関数で適用（ガイド/演奏の合算状態に基づく色分け）
+    this.applyKeyHighlightVisual(midiNote, shouldHighlight);
   }
   
   /**


### PR DESCRIPTION
Persist keyboard highlights for pressed keys and ensure guide highlights correctly reappear by removing aggressive highlight resets.

The previous implementation aggressively cleared all keyboard highlights (both active/pressed and guide) on problem changes and when updating guide highlights. This led to incorrect visual feedback where pressed keys would lose their highlight prematurely, and guide keys would not correctly revert to green after being pressed and released. This PR modifies the highlight logic to maintain active highlights and update guide highlights differentially, resolving these visual inconsistencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bfb6fb5-9c75-494c-ba16-47be016834d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bfb6fb5-9c75-494c-ba16-47be016834d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

