### PR TITLE
Adjust guide color for early hits in fantasy mode

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -971,7 +971,7 @@ export const useFantasyGameEngine = ({
             // コード進行モード：ループさせる
             const progression = prevState.currentStage?.chordProgression || [];
             const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-            nextChord = getProgressionChord(progression, nextIndex, displayOpts, prevState.currentStage?.showGuide);
+            nextChord = getProgressionChord(progression, nextIndex, displayOpts, !!prevState.currentStage?.showGuide);
           }
           
           return {
@@ -1104,7 +1104,7 @@ export const useFantasyGameEngine = ({
             // コード進行モード：ループさせる
             const progression = prevState.currentStage?.chordProgression || [];
             const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-            nextChord = getProgressionChord(progression, nextIndex, displayOpts, prevState.currentStage?.showGuide);
+            nextChord = getProgressionChord(progression, nextIndex, displayOpts, !!prevState.currentStage?.showGuide);
           }
           
           const nextState = {
@@ -1464,7 +1464,7 @@ export const useFantasyGameEngine = ({
               lastUsedChordId, // 直前のコードを避ける
               displayOpts,
               stageMonsterIds, // stageMonsterIdsを渡す
-              stage.showGuide
+              stateAfterAttack.currentStage?.showGuide ?? false
             );
             remainingMonsters.push(newMonster);
           }
@@ -1540,7 +1540,7 @@ export const useFantasyGameEngine = ({
       } else {
         const progression = prevState.currentStage?.chordProgression || [];
         const nextIndex = (prevState.currentQuestionIndex + 1) % progression.length;
-        nextChord = getProgressionChord(progression, nextIndex, displayOpts);
+        nextChord = getProgressionChord(progression, nextIndex, displayOpts, !!prevState.currentStage?.showGuide);
       }
 
       nextState = {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -736,11 +736,13 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // 問題が変わったタイミングでハイライトを確実にリセット
   useEffect(() => {
     if (!pixiRenderer) return;
+    // 太鼓モードでは、押下中のオレンジを維持するためリセットしない
+    if (gameState.isTaikoMode) return;
     // single: currentChordTarget が変わる / progression: currentNoteIndex が進む
     (pixiRenderer as any).clearActiveHighlights?.();
     // ガイドもいったん全消去 → 後続のガイド再設定で再点灯
     (pixiRenderer as any).clearAllHighlights?.();
-  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex]);
+  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex, gameState.isTaikoMode]);
 
   // ガイド用ハイライト更新（showGuideが有効かつ同時出現数=1のときのみ）
   useEffect(() => {
@@ -762,8 +764,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       setGuideMidi([]);
       return;
     }
-    // いったん全消去してから今回のガイドを設定（取り残し防止）
-    (pixiRenderer as any).clearAllHighlights?.();
+    // ガイドは差分適用で更新（太鼓モードでも押下中オレンジを保持）
+    if (!gameState.isTaikoMode) {
+      (pixiRenderer as any).clearAllHighlights?.();
+    }
     setGuideMidi(chord.notes as number[]);
   }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
   

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1685,19 +1685,13 @@ export class PIXINotesRendererInstance {
     if (active) {
       this.highlightedKeys.add(midiNote);
     } else {
-      // ガイドが存在する場合は解除しない
-      if (!this.guideHighlightedKeys.has(midiNote)) {
-        this.highlightedKeys.delete(midiNote);
-      }
+      // リリース時は常に演奏ハイライトを解除する（ガイドがあれば緑に戻る）
+      this.highlightedKeys.delete(midiNote);
     }
     
     const shouldHighlight = this.isKeyHighlighted(midiNote);
-    if (this.isBlackKey(midiNote)) {
-      this.redrawBlackKeyHighlight(keySprite, shouldHighlight, midiNote);
-      if (!shouldHighlight) keySprite.alpha = 1.0;
-    } else {
-      (keySprite as any).tint = shouldHighlight ? this.settings.colors.activeKey : 0xFFFFFF;
-    }
+    // ガイド/演奏の合算状態を元に見た目を一元適用
+    this.applyKeyHighlightVisual(midiNote, shouldHighlight);
   }
   
   /**


### PR DESCRIPTION
Updates Fantasy Taiko mode to revert early-pressed guide notes to green on key release and maintain orange highlights across problem changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-341bd424-e946-472a-8ced-325c6c5b4ac6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-341bd424-e946-472a-8ced-325c6c5b4ac6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

