### PR TITLE
Fix one-time password input screen navigation

### DIFF
--- a/src/LegacyApp.tsx
+++ b/src/LegacyApp.tsx
@@ -167,7 +167,7 @@ const App: React.FC = () => {
   if (!user && !isGuest || forceLogin) {
     return (
       <>
-        <AuthLanding />
+        <AuthLanding mode="login" />
         <ToastContainer />
       </>
     );

--- a/src/components/auth/AuthGate.tsx
+++ b/src/components/auth/AuthGate.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import AuthLanding from '@/components/auth/AuthLanding';
 import { cn } from '@/utils/cn';
+import { useState } from 'react';
 
 interface AuthGateProps {
   children: React.ReactNode;

--- a/src/components/auth/AuthLanding.tsx
+++ b/src/components/auth/AuthLanding.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { useToast, handleApiError } from '@/stores/toastStore';
+import { useNavigate } from 'react-router-dom';
 
 interface AuthLandingProps {
   mode: 'signup' | 'login';
@@ -12,6 +13,7 @@ const AuthLanding: React.FC<AuthLandingProps> = ({ mode }) => {
   const [email, setEmail] = useState('');
   const [otpSent, setOtpSent] = useState(false);
   const [signupDisabled, setSignupDisabled] = useState(false);
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,7 +56,7 @@ const AuthLanding: React.FC<AuthLandingProps> = ({ mode }) => {
       email,
       mode
     });
-    window.location.href = `/login/verify-otp?${params.toString()}`;
+    navigate(`/login/verify-otp?${params.toString()}`, { replace: true });
     return null;
   }
 


### PR DESCRIPTION
Fixes navigation to the OTP input screen after requesting a one-time password from the login page when accessing protected routes while logged out.

Previously, after requesting a one-time password from the login screen displayed for protected routes (e.g., `/main#dashboard`), the application failed to redirect to the OTP input page. This was due to the navigation using `window.location.href` instead of `react-router`'s `navigate`, and the `AuthLanding` component not receiving the necessary `mode="login"` prop when rendered in the `LegacyApp` context. A missing `useState` import in `AuthGate.tsx` was also added to resolve a type error.

---
<a href="https://cursor.com/background-agent?bcId=bc-002499f7-1734-4d74-b6f0-49cb5cd31766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-002499f7-1734-4d74-b6f0-49cb5cd31766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

