### PR TITLE
Prevent hit notes from reappearing in loop preview

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -662,8 +662,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 現在ループ基準の時間差
         const timeUntilHit = note.hitTime - normalizedTime;
 
-        // 判定ライン通過後も一定時間は左に流し続ける（-0.5秒）
-        const lowerBound = -0.5;
+        // 判定ライン通過後の残し時間を少し短めに（-0.25秒）
+        const lowerBound = -0.25;
 
         // 表示範囲内のノーツ（現在ループのみ）
         if (timeUntilHit >= lowerBound && timeUntilHit <= lookAheadTime) {
@@ -693,6 +693,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           
           // 直前に消化した最後のノーツはプレビューで復活させない
           if (i === lastCompletedIndex) continue;
+
+          // ヒット済みフラグが立っているノーツはプレビュー表示しない（直前復活防止）
+          if (note.isHit) continue;
           
           // すでに通常ノーツに含まれている場合はプレビュー重複を避ける
           if (displayedBaseIds.has(note.id)) continue;


### PR DESCRIPTION
Fixes a bug where recently hit notes briefly reappear in the next loop's preview by adding an `isHit` guard and adjusts note display duration after passing the judge line.

---
<a href="https://cursor.com/background-agent?bcId=bc-07bab28b-5403-4d1b-9502-491c3590de2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07bab28b-5403-4d1b-9502-491c3590de2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

