### PR TITLE
Fix reappearing notes in fantasy progression mode

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -625,6 +625,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
       const lookAheadTime = 4; // 4秒先まで表示
       const noteSpeed = 400; // ピクセル/秒
+      const PREVIEW_MIN_DELAY = 0.6; // 次ループの先頭は 0.6 秒はプレビューしない（復活防止）
       
       // カウントイン中は複数ノーツを先行表示
       if (currentTime < 0) {
@@ -702,6 +703,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           
           const virtualHitTime = note.hitTime + loopDuration; // 次ループのヒット時刻
           const timeUntilHit = virtualHitTime - normalizedTime;
+          // ループ直後のプレビューは一定時間抑制
+          if (timeUntilHit < PREVIEW_MIN_DELAY) continue;
           if (timeUntilHit > lookAheadTime) break;
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
           notesToDisplay.push({

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -696,6 +696,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           
           // すでに通常ノーツに含まれている場合はプレビュー重複を避ける
           if (displayedBaseIds.has(note.id)) continue;
+
+          // 既に当ループでヒット済みのノーツは次ループの先行表示に含めない（復活防止）
+          if (note.isHit) continue;
           
           const virtualHitTime = note.hitTime + loopDuration; // 次ループのヒット時刻
           const timeUntilHit = virtualHitTime - normalizedTime;


### PR DESCRIPTION
Prevent already hit notes from reappearing in the next loop's preview in Fantasy mode to fix a visual bug.

Notes that were hit and disappeared would reappear after passing the judgment line when the music looped in progression timing mode. This change ensures that notes marked as `isHit` are not included in the preview for the subsequent loop, resolving this "resurrection" issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-e43b6df9-bb57-4518-93e2-cfb61adb6617">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e43b6df9-bb57-4518-93e2-cfb61adb6617">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

