### PR TITLE
Fix preview note behavior for loop transitions

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -623,7 +623,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       
       const currentTime = bgmManager.getCurrentMusicTime();
       const judgeLinePos = fantasyPixiInstance.getJudgeLinePosition();
-      const lookAheadTime = 4; // 4秒先まで表示
+      // プレビューノーツは2小節分だけ先読み
+      const secPerBeat = 60 / (stage.bpm || 120);
+      const secPerMeasure = secPerBeat * (stage.timeSignature || 4);
+      const lookAheadTime = secPerMeasure * 2;
       const noteSpeed = 400; // ピクセル/秒
       
       // カウントイン中は複数ノーツを先行表示


### PR DESCRIPTION
Change preview note lookahead to 2 measures to prevent deleted notes from reappearing after a loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-7871bd87-b81e-4c8c-941f-714a274fb232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7871bd87-b81e-4c8c-941f-714a274fb232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

