### PR TITLE
Stop enemy gauge in fantasy single ready phase

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -393,7 +393,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     onChordIncorrect: handleChordIncorrect,
     onGameComplete: handleGameCompleteCallback,
     onEnemyAttack: handleEnemyAttack,
-    displayOpts: { lang: 'en', simple: false } // コードネーム表示は常に英語、簡易表記OFF
+    displayOpts: { lang: 'en', simple: false }, // コードネーム表示は常に英語、簡易表記OFF
+    pauseEnemyGauge: isReady
   });
   
   // 現在の敵情報を取得

--- a/src/utils/chord-utils.ts
+++ b/src/utils/chord-utils.ts
@@ -124,8 +124,11 @@ export function getFantasyChordNotes(chordId: string, octave: number = 4): numbe
  * @returns { root: string, quality: ChordQuality } | null
  */
 export function parseChordName(chordName: string): { root: string; quality: ChordQuality } | null {
+  // スラッシュコード対応: 分母(ベース音)は無視して本体を解析
+  const base = chordName.split('/')[0];
+  
   // ルート音とサフィックスを分離（ダブルシャープ・ダブルフラットも対応）
-  const match = chordName.match(/^([A-G](?:#{1,2}|b{1,2}|x)?)(.*)$/);
+  const match = base.match(/^([A-G](?:#{1,2}|b{1,2}|x)?)(.*)$/);
   if (!match) return null;
   
   const [, root, suffix] = match;
@@ -181,6 +184,9 @@ export function resolveChord(
   const parsed = parseChordName(chordId);
   if (!parsed) return null;
 
+  // スラッシュコードのベースを表示名生成に利用（構成音は同じ）
+  const baseForDisplay = chordId.split('/')[0];
+
   // b) インターバル → 実音配列
   const notes = buildChordNotes(parsed.root, parsed.quality, octave);
 
@@ -189,7 +195,7 @@ export function resolveChord(
     root: parsed.root,
     quality: parsed.quality,
     notes,
-    displayName: displayOpts ? toDisplayChordName(chordId, displayOpts) : chordId
+    displayName: chordId.includes('/') ? chordId : (displayOpts ? toDisplayChordName(chordId, displayOpts) : chordId)
   };
 }
 


### PR DESCRIPTION
Pause enemy gauge during ready phase in fantasy single mode and enable slash chord parsing for display.

---
<a href="https://cursor.com/background-agent?bcId=bc-26ceb939-aefa-4d98-92d1-0fe91fa90582">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-26ceb939-aefa-4d98-92d1-0fe91fa90582">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

