### PR TITLE
Handle fantasy mode chord definitions

### DIFF
--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -159,8 +159,8 @@ const getChordDefinition = (spec: ChordSpec, displayOpts?: DisplayOpts, useVoici
   let midiNotes: number[];
   let noteNamesForDisplay: string[];
 
-  if (useVoicing && (maybeInversion != null || maybeOctave != null)) {
-    // ボイシング適用（最低音から積む）
+  if (useVoicing) {
+    // ガイド表示時: 未指定なら inversion=0, octave=4 を既定値として使用
     const baseNames = resolved.notes; // 例: ['A','C','E']
     const N = baseNames.length;
     const inv = Math.max(0, Math.min(N - 1, (maybeInversion ?? 0)));

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -317,7 +317,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       try {
         const mod = await import('@/utils/FantasySoundManager');
         const FSM = (mod as any).FantasySoundManager ?? mod.default;
-        await FSM?.playRootNote(chord.root);
+        // スラッシュコード対応: 分母があればそれをルートとして鳴らす
+        const id = chord.id || chord.displayName || chord.root;
+        let bassToPlay = chord.root;
+        if (typeof id === 'string' && id.includes('/')) {
+          const parts = id.split('/');
+          if (parts[1]) bassToPlay = parts[1];
+        }
+        await FSM?.playRootNote(bassToPlay);
       } catch (error) {
         console.error('Failed to play root note:', error);
       }

--- a/src/utils/chord-utils.ts
+++ b/src/utils/chord-utils.ts
@@ -177,15 +177,24 @@ export function resolveChord(
   displayOpts?: DisplayOpts
 ): { id: string; root: string; quality: ChordQuality; notes: string[]; displayName: string } | null {
   
-  // a) まずエイリアスを考慮してパース
-  const parsed = parseChordName(chordId);
+  // a) スラッシュコード対応: 分子/分母に分割（例: C/E, F/G）
+  let numerator = chordId;
+  if (chordId.includes('/')) {
+    const parts = chordId.split('/');
+    if (parts[0]) {
+      numerator = parts[0];
+    }
+  }
+
+  // b) まずエイリアスを考慮してパース（分子のみ）
+  const parsed = parseChordName(numerator);
   if (!parsed) return null;
 
-  // b) インターバル → 実音配列
+  // c) インターバル → 実音配列（分子から生成。分母はボイシングや判定には使わない）
   const notes = buildChordNotes(parsed.root, parsed.quality, octave);
 
   return {
-    id: chordId,
+    id: chordId, // 表示や後段処理のため、元のID（スラッシュ含む）を保持
     root: parsed.root,
     quality: parsed.quality,
     notes,


### PR DESCRIPTION
Implement default inversion/octave for fantasy mode chords and add support for slash chords, including using the bass note for correct note playback.

These changes enhance fantasy mode's chord definition and playback logic as requested by the user. Unspecified inversions and octaves now default to 0/4 for consistent guide voicing, and slash chords are parsed, using the numerator for chord tones and the denominator for the root note when playing correct answers.

---
<a href="https://cursor.com/background-agent?bcId=bc-61abf5f5-a40b-40e7-8a3b-8c03b430b029">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61abf5f5-a40b-40e7-8a3b-8c03b430b029">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

