### PR TITLE
Fix orange highlight clearing in single mode

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -752,13 +752,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // 問題が変わったタイミングでハイライトを確実にリセット
   useEffect(() => {
     if (!pixiRenderer) return;
-    // 太鼓モードでは、押下中のオレンジを維持するためリセットしない
-    if (gameState.isTaikoMode) return;
-    // single: currentChordTarget が変わる / progression: currentNoteIndex が進む
-    (pixiRenderer as any).clearActiveHighlights?.();
-    // ガイドもいったん全消去 → 後続のガイド再設定で再点灯
-    (pixiRenderer as any).clearAllHighlights?.();
-  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex, gameState.isTaikoMode]);
+    // progression/single 共通：押下中のオレンジは保持。ガイドのみクリア。
+    (pixiRenderer as any).setGuideHighlightsByMidiNotes?.([]);
+  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex]);
 
   // ガイド用ハイライト更新（showGuideが有効かつ同時出現数=1のときのみ）
   useEffect(() => {
@@ -768,22 +764,17 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       (pixiRenderer as any).setGuideHighlightsByMidiNotes?.(midiNotes);
     };
     if (!canGuide) {
-      // ガイドOFF時は確実に全消去
-      (pixiRenderer as any).clearAllHighlights?.();
+      // ガイドだけ消す（演奏中オレンジは維持）
       setGuideMidi([]);
       return;
     }
     const targetMonster = gameState.activeMonsters?.[0];
     const chord = targetMonster?.chordTarget || gameState.currentChordTarget;
     if (!chord) {
-      (pixiRenderer as any).clearAllHighlights?.();
       setGuideMidi([]);
       return;
     }
-    // ガイドは差分適用で更新（太鼓モードでも押下中オレンジを保持）
-    if (!gameState.isTaikoMode) {
-      (pixiRenderer as any).clearAllHighlights?.();
-    }
+    // 差分適用のみ（オレンジは残る）
     setGuideMidi(chord.notes as number[]);
   }, [pixiRenderer, stage.showGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
   


### PR DESCRIPTION
Ensure performance highlights (orange) persist until Note Off in single mode by only updating guide highlights (green).

Previously, `clearAllHighlights()` was called during guide updates in single mode, which prematurely cleared performance highlights (orange) and caused a flicker. This change modifies the effects to only update or clear guide highlights, aligning single mode behavior with progression mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-e13451aa-5432-4cef-80b1-362d511c7dc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e13451aa-5432-4cef-80b1-362d511c7dc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

