### PR TITLE
Prevent standard_global users from accessing song selection

### DIFF
--- a/src/LegacyApp.tsx
+++ b/src/LegacyApp.tsx
@@ -206,6 +206,7 @@ const App: React.FC = () => {
   
   // ハッシュをベース部分だけで判定するための処理
   const baseHash = hash.split('?')[0];
+  const isStandardGlobal = profile?.rank === 'standard_global';
   
   switch (baseHash) {
     case '#dashboard':
@@ -225,6 +226,7 @@ const App: React.FC = () => {
       MainContent = <LevelRanking />;
       break;
     case '#missions':
+    case '#mission':
       MainContent = <MissionPage />;
       break;
     case '#mission-ranking':
@@ -254,10 +256,10 @@ const App: React.FC = () => {
     case '#performance':
     case '#play-lesson':
     case '#play-mission':
-      MainContent = <GameScreen />;
+      MainContent = isStandardGlobal ? <Dashboard /> : <GameScreen />;
       break;
     default:
-      MainContent = <GameScreen />;
+      MainContent = isStandardGlobal ? <Dashboard /> : <GameScreen />;
       break;
   }
 

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -48,6 +48,14 @@ const GameScreen: React.FC = () => {
       const requiresDays = params.get('requiresDays') === 'true';
       const dailyCount = parseInt(params.get('dailyCount') || '1');
       
+      // 権限制御: Standard(Global)はレッスン/曲プレイ不可
+      if (useAuthStore.getState().profile?.rank === 'standard_global') {
+        console.warn('Standard(Global)は#play-lesson非対応のためダッシュボードへ');
+        setIsLoadingLessonSong(false);
+        window.location.hash = '#dashboard';
+        return;
+      }
+      
       if (songId) {
         try {
           // 曲データを取得（レッスン曲は通常曲も使用できるため、すべての曲から検索）
@@ -218,6 +226,14 @@ const GameScreen: React.FC = () => {
     const handleMissionPlay = async (hash: string) => {
       console.log('🎵 ミッション曲読み込み開始');
       setIsLoadingLessonSong(true);
+      
+      // 権限制御: Standard(Global)はミッションプレイ不可
+      if (useAuthStore.getState().profile?.rank === 'standard_global') {
+        console.warn('Standard(Global)は#play-mission非対応のためミッション一覧→ダッシュボードへ');
+        setIsLoadingLessonSong(false);
+        window.location.hash = '#dashboard';
+        return;
+      }
       
       // '#play-mission?...' から '?' 以降をパース
       const [, query] = hash.split('?');
@@ -435,7 +451,13 @@ const GameScreen: React.FC = () => {
     });
     
     // レッスン曲・ミッション曲読み込み中は曲選択画面へのリダイレクトをスキップ
+    const isStandardGlobal = useAuthStore.getState().profile?.rank === 'standard_global';
     if (!currentSong && currentTab !== 'songs' && !isPlayLessonHash && !isLoadingLessonSong) {
+      if (isStandardGlobal) {
+        // 権限制御: standard_global は曲選択タブへ飛ばさない
+        console.log('🔧 Auto-redirect suppressed for Standard(Global)');
+        return;
+      }
       console.log('🔧 Auto-redirecting to songs tab');
       gameActions.setCurrentTab('songs');
     } else if (isPlayLessonHash || isLoadingLessonSong) {


### PR DESCRIPTION
Prevent `standard_global` plan users from accessing song/lesson/mission play screens and redirect them to the dashboard.

`standard_global` users were inadvertently redirected to the song selection screen when attempting to access routes like `#mission` or other play-related paths, as the system's default behavior led them to `GameScreen`, which then forced a song selection. This change ensures they are instead directed to the dashboard, aligning with the plan's restrictions.

---
<a href="https://cursor.com/background-agent?bcId=bc-443b91e6-6d99-4021-a802-ebdd58c60fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-443b91e6-6d99-4021-a802-ebdd58c60fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

