### PR TITLE
Adjust dashboard and account for free plan

### DIFF
--- a/src/LegacyApp.tsx
+++ b/src/LegacyApp.tsx
@@ -37,6 +37,7 @@ const App: React.FC = () => {
   
   // 認証ストアの状態
   const { profile, loading:authLoading, isGuest, user } = useAuthStore();
+  const isFree = profile?.rank === 'free';
   
   // hash monitor
   const [hash, setHash] = useState(window.location.hash);
@@ -115,10 +116,23 @@ const App: React.FC = () => {
   }, []);
   
   useEffect(() => {
-    if (isGuest && window.location.hash !== '#dashboard') {
-      window.location.hash = '#dashboard';
+    const baseHash = window.location.hash.split('?')[0];
+    if (isGuest) {
+      if (baseHash !== '#dashboard' && baseHash !== '#account') {
+        window.location.hash = '#dashboard';
+      }
     }
   }, [isGuest]);
+
+  // フリープランはダッシュボード/アカウントのみ
+  useEffect(() => {
+    const baseHash = window.location.hash.split('?')[0];
+    if (isFree) {
+      if (baseHash !== '#dashboard' && baseHash !== '#account') {
+        window.location.hash = '#dashboard';
+      }
+    }
+  }, [isFree]);
   
   // 他画面遷移時にヘッダー非表示状態を自動解除
   useEffect(() => {
@@ -183,7 +197,7 @@ const App: React.FC = () => {
     );
   }
 
-  if (hash === '#mypage') {
+  if (hash === '#mypage' && !isFree) {
     return (
       <>
         <MypagePage />
@@ -192,7 +206,7 @@ const App: React.FC = () => {
     );
   }
 
-  if (hash.startsWith('#diary-detail')) {
+  if (hash.startsWith('#diary-detail') && !isFree) {
     return (
       <>
         <DiaryDetailPage />
@@ -214,29 +228,29 @@ const App: React.FC = () => {
       break;
     case '#diary':
     case '#diary-user':
-      MainContent = <DiaryPage />;
+      MainContent = isFree ? <Dashboard /> : <DiaryPage />;
       break;
     case '#lessons':
-      MainContent = <LessonPage />;
+      MainContent = isFree ? <Dashboard /> : <LessonPage />;
       break;
     case '#lesson-detail':
-      MainContent = <LessonDetailPage />;
+      MainContent = isFree ? <Dashboard /> : <LessonDetailPage />;
       break;
     case '#ranking':
-      MainContent = <LevelRanking />;
+      MainContent = isFree ? <Dashboard /> : <LevelRanking />;
       break;
     case '#missions':
     case '#mission':
-      MainContent = <MissionPage />;
+      MainContent = isFree ? <Dashboard /> : <MissionPage />;
       break;
     case '#mission-ranking':
-      MainContent = <MissionRanking />;
+      MainContent = isFree ? <Dashboard /> : <MissionRanking />;
       break;
     case '#information':
-      MainContent = <InformationPage />;
+      MainContent = isFree ? <Dashboard /> : <InformationPage />;
       break;
     case '#pricing':
-      MainContent = <PricingTable />;
+      MainContent = isFree ? <Dashboard /> : <PricingTable />;
       break;
     case '#admin-songs':
     case '#admin-fantasy-bgm':
@@ -246,20 +260,20 @@ const App: React.FC = () => {
     case '#admin-users':
     case '#admin-announcements':
     case '#admin-courses':
-      MainContent = <AdminDashboard />;
+      MainContent = isFree ? <Dashboard /> : <AdminDashboard />;
       break;
     case '#fantasy':
-      MainContent = <FantasyMain />;
+      MainContent = isFree ? <Dashboard /> : <FantasyMain />;
       break;
     case '#songs':
     case '#practice':
     case '#performance':
     case '#play-lesson':
     case '#play-mission':
-      MainContent = isStandardGlobal ? <Dashboard /> : <GameScreen />;
+      MainContent = isStandardGlobal || isFree ? <Dashboard /> : <GameScreen />;
       break;
     default:
-      MainContent = isStandardGlobal ? <Dashboard /> : <GameScreen />;
+      MainContent = isStandardGlobal || isFree ? <Dashboard /> : <GameScreen />;
       break;
   }
 

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
 } from 'react-icons/fa';
 import { Mission } from '@/platform/supabaseMissions';
 import GameHeader from '@/components/ui/GameHeader';
+import OpenBetaPlanSwitcher from '@/components/subscription/OpenBetaPlanSwitcher';
 import { xpToNextLevel, currentLevelXP } from '@/utils/xpCalculator';
 import { calcLevel } from '@/platform/supabaseXp';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
@@ -197,6 +198,20 @@ const Dashboard: React.FC = () => {
 
   if (!open) return null;
 
+  // フリープランの場合はプラン変更UIのみ表示
+  if (profile?.rank === 'free') {
+    return (
+      <div className="w-full h-full flex flex-col bg-gradient-game text-white">
+        <GameHeader />
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <div className="max-w-2xl mx-auto space-y-6">
+            <OpenBetaPlanSwitcher />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div 
       className="w-full h-full flex flex-col bg-gradient-game text-white"
@@ -205,6 +220,8 @@ const Dashboard: React.FC = () => {
       {/* ダッシュボードコンテンツ */}
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="max-w-6xl mx-auto space-y-6">
+          {/* オープンベータ: プラン変更 UI */}
+          <OpenBetaPlanSwitcher />
           {/* ユーザー情報カード */}
           {profile && (
             <div className="bg-slate-800 rounded-lg p-6 border border-slate-700">

--- a/src/components/subscription/OpenBetaPlanSwitcher.tsx
+++ b/src/components/subscription/OpenBetaPlanSwitcher.tsx
@@ -1,0 +1,97 @@
+import React, { useMemo, useState } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import { getSupabaseClient } from '@/platform/supabaseClient';
+import { useToast } from '@/stores/toastStore';
+
+// オープンベータ用の簡易プラン変更UI
+// 注意: Stripe を介さず Supabase の profiles.rank を直接更新します
+const OpenBetaPlanSwitcher: React.FC = () => {
+  const { profile } = useAuthStore();
+  const toast = useToast();
+  const [updating, setUpdating] = useState(false);
+  const [selected, setSelected] = useState<string>(profile?.rank || 'free');
+
+  const availablePlans = useMemo(() => {
+    const isJapan = (profile?.country || '').toUpperCase() === 'JP' || (profile?.country || '').toLowerCase() === 'japan';
+    if (isJapan) {
+      return [
+        { value: 'free', label: 'フリー' },
+        { value: 'standard', label: 'スタンダード' },
+        { value: 'premium', label: 'プレミアム' },
+        { value: 'platinum', label: 'プラチナ' },
+      ];
+    }
+    return [
+      { value: 'free', label: 'フリー' },
+      { value: 'standard_global', label: 'スタンダード（グローバル）' },
+    ];
+  }, [profile?.country]);
+
+  const applyPlan = async () => {
+    if (!profile?.id) return;
+    if (!availablePlans.some(p => p.value === selected)) {
+      toast.error('選択したプランは利用できません');
+      return;
+    }
+
+    setUpdating(true);
+    try {
+      const supabase = getSupabaseClient();
+      const { error } = await supabase
+        .from('profiles')
+        .update({ rank: selected })
+        .eq('id', profile.id);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      await useAuthStore.getState().fetchProfile();
+      toast.success('プランを更新しました');
+    } catch (e: any) {
+      toast.error(`プランの更新に失敗しました: ${e?.message || e}`);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <div className="bg-slate-800 rounded-lg border border-slate-700 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold text-white">オープンベータ: プラン変更</h3>
+        {profile?.rank && (
+          <span className="text-xs px-2 py-1 rounded-full bg-slate-700 text-gray-300">
+            現在: {profile.rank}
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="openbeta-plan" className="text-sm text-gray-300">プランを選択</label>
+        <select
+          id="openbeta-plan"
+          className="w-full p-2 rounded bg-slate-700 text-sm"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          disabled={updating}
+        >
+          {availablePlans.map(plan => (
+            <option key={plan.value} value={plan.value}>{plan.label}</option>
+          ))}
+        </select>
+        <button
+          className="btn btn-sm btn-primary mt-2"
+          onClick={applyPlan}
+          disabled={updating || !selected}
+        >
+          {updating ? '更新中…' : 'このプランに変更'}
+        </button>
+        <p className="text-xs text-gray-400 mt-2">
+          本UIはオープンベータ用です。決済なしで一時的にプランを切り替えます。
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default OpenBetaPlanSwitcher;

--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -14,6 +14,7 @@ const GameHeader: React.FC = () => {
   const gameActions = useGameActions();
   const { isGuest, profile } = useAuthStore();
   const isStandardGlobal = profile?.rank === 'standard_global';
+  const isFree = profile?.rank === 'free';
 
   return (
     <header className="flex-shrink-0 bg-game-surface border-b border-gray-700 px-3 py-1 z-[60]">
@@ -31,7 +32,7 @@ const GameHeader: React.FC = () => {
           </button>
 
           {/* 曲選択タブ */}
-          {!isStandardGlobal && (
+          {!isStandardGlobal && !isFree && (
             <HashButton
               hash="#songs"
               onClick={() => {
@@ -43,12 +44,12 @@ const GameHeader: React.FC = () => {
             </HashButton>
           )}
 
-          {!isStandardGlobal && <HashButton hash="#lessons" disabled={isGuest}>レッスン</HashButton>}
-          <HashButton hash="#fantasy">ファンタジー</HashButton>
-          <HashButton hash="#ranking" disabled={isGuest}>ランキング</HashButton>
-          {!isStandardGlobal && <HashButton hash="#missions" disabled={isGuest}>ミッション</HashButton>}
-          {!isStandardGlobal && <HashButton hash="#diary" disabled={isGuest}>日記</HashButton>}
-          <HashButton hash="#information" disabled={isGuest}>お知らせ</HashButton>
+          {!isStandardGlobal && !isFree && <HashButton hash="#lessons" disabled={isGuest}>レッスン</HashButton>}
+          {!isFree && <HashButton hash="#fantasy">ファンタジー</HashButton>}
+          {!isFree && <HashButton hash="#ranking" disabled={isGuest}>ランキング</HashButton>}
+          {!isStandardGlobal && !isFree && <HashButton hash="#missions" disabled={isGuest}>ミッション</HashButton>}
+          {!isStandardGlobal && !isFree && <HashButton hash="#diary" disabled={isGuest}>日記</HashButton>}
+          {!isFree && <HashButton hash="#information" disabled={isGuest}>お知らせ</HashButton>}
         </div>
 
         {/* 右側のコントロール */}


### PR DESCRIPTION
Restrict free plan user access to dashboard and account, and integrate the open beta plan switcher into the dashboard for all plans.

---
<a href="https://cursor.com/background-agent?bcId=bc-8891efa1-b8e2-42ac-8864-351ef4f48bbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8891efa1-b8e2-42ac-8864-351ef4f48bbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

