### PR TITLE
Hide open beta plan change for guest play

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -206,7 +206,7 @@ const Dashboard: React.FC = () => {
   if (!open) return null;
 
   // フリープランの場合はプラン変更UIのみ表示
-  if (profile?.rank === 'free') {
+  if (profile?.rank === 'free' && !isGuest) {
     return (
       <div className="w-full h-full flex flex-col bg-gradient-game text-white">
         <GameHeader />
@@ -228,7 +228,7 @@ const Dashboard: React.FC = () => {
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="max-w-6xl mx-auto space-y-6">
           {/* オープンベータ: プラン変更 UI */}
-          <OpenBetaPlanSwitcher />
+          {!isGuest && <OpenBetaPlanSwitcher />}
           {/* ユーザー情報カード */}
           {profile && (
             <div className="bg-slate-800 rounded-lg p-6 border border-slate-700">

--- a/src/components/subscription/OpenBetaPlanSwitcher.tsx
+++ b/src/components/subscription/OpenBetaPlanSwitcher.tsx
@@ -6,7 +6,7 @@ import { useToast } from '@/stores/toastStore';
 // オープンベータ用の簡易プラン変更UI
 // 注意: Stripe を介さず Supabase の profiles.rank を直接更新します
 const OpenBetaPlanSwitcher: React.FC = () => {
-  const { profile } = useAuthStore();
+  const { profile, isGuest } = useAuthStore();
   const toast = useToast();
   const [updating, setUpdating] = useState(false);
   const [selected, setSelected] = useState<string>(profile?.rank || 'free');

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -92,7 +92,14 @@ export const useAuthStore = create<AuthState & AuthActions>()(
         state.session = session ?? null;
         state.user = session?.user ?? null;
         state.loading = false;
-        state.isGuest = false;
+        try {
+          const storedGuestId = typeof localStorage !== 'undefined' ? localStorage.getItem('guest_id') : null;
+          state.isGuest = !session?.user && !!storedGuestId;
+          state.guestId = !session?.user && storedGuestId ? storedGuestId : null;
+        } catch {
+          state.isGuest = false;
+          state.guestId = null;
+        }
       });
 
       // セッションがある場合はプロフィールも取得


### PR DESCRIPTION
Hide open beta plan switcher for guest users and persist guest sessions across reloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-25d17743-81cd-44f4-85b6-d7c80f7103d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25d17743-81cd-44f4-85b6-d7c80f7103d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

