### PR TITLE
Adjust piano scroll position to center c4

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -280,32 +280,60 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
   const pianoScrollRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
+  const centerPianoC4 = useCallback(() => {
     const container = pianoScrollRef.current;
     if (!container) return;
 
-    const centerC4 = () => {
-      const contentWidth = container.scrollWidth;
-      const viewportWidth = container.clientWidth;
-      if (!contentWidth || !viewportWidth) return;
-      if (contentWidth <= viewportWidth) return;
-      const TOTAL_WHITE_KEYS = 52;
-      const C4_WHITE_INDEX = 23; // A0=0 ... C4=23
-      const whiteKeyWidth = contentWidth / TOTAL_WHITE_KEYS;
-      const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
-      const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
-      container.scrollLeft = desiredScroll;
-    };
+    const contentWidth = container.scrollWidth;
+    const viewportWidth = container.clientWidth;
+    if (!contentWidth || !viewportWidth) return;
+    if (contentWidth <= viewportWidth) return;
 
-    const raf = requestAnimationFrame(centerC4);
-    const handleResize = () => requestAnimationFrame(centerC4);
+    const TOTAL_WHITE_KEYS = 52;
+    const C4_WHITE_INDEX = 23; // A0=0 ... C4=23
+    const whiteKeyWidth = contentWidth / TOTAL_WHITE_KEYS;
+    const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
+    const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
+
+    try {
+      container.scrollTo({ left: desiredScroll, behavior: 'auto' });
+    } catch {}
+    container.scrollLeft = desiredScroll;
+  }, []);
+
+  useEffect(() => {
+    // Run after initial mount/layout
+    const raf = requestAnimationFrame(centerPianoC4);
+    const handleResize = () => requestAnimationFrame(centerPianoC4);
     window.addEventListener('resize', handleResize);
+    const handleOrientation = () => requestAnimationFrame(centerPianoC4);
+    window.addEventListener('orientationchange', handleOrientation);
+
+    const el = pianoScrollRef.current;
+    let ro: ResizeObserver | null = null;
+    if (el && 'ResizeObserver' in window) {
+      ro = new ResizeObserver(() => {
+        // When content or container size changes, re-center
+        requestAnimationFrame(centerPianoC4);
+      });
+      ro.observe(el);
+    }
+
+    // Fallback recenter after slight delay (mobile Safari layout pass)
+    const t1 = setTimeout(centerPianoC4, 120);
+    const t2 = setTimeout(centerPianoC4, 300);
+    const t3 = setTimeout(centerPianoC4, 500);
 
     return () => {
       cancelAnimationFrame(raf);
       window.removeEventListener('resize', handleResize);
+      window.removeEventListener('orientationchange', handleOrientation);
+      if (ro) ro.disconnect();
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
     };
-  }, [pianoScrollRef]);
+  }, [centerPianoC4]);
   const [fantasyPixiInstance, setFantasyPixiInstance] = useState<FantasyPIXIInstance | null>(null);
   const isTaikoModeRef = useRef(false);
   const gameAreaRef = useRef<HTMLDivElement>(null);
@@ -513,6 +541,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           particles: false,
           trails: false
         }
+      });
+
+      // レイアウト反映後にC4を中央へ
+      requestAnimationFrame(() => {
+        // iOS Safari 対策で二重に呼ぶ
+        requestAnimationFrame(centerPianoC4);
       });
       
       // キーボードのクリックイベントを接続
@@ -1237,18 +1271,25 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           if (needsScroll) {
             // スクロールが必要な場合
             return (
-              <div 
-                className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
-                style={{ 
-                  WebkitOverflowScrolling: 'touch',
-                  scrollSnapType: 'x proximity',
-                  scrollBehavior: 'smooth',
-                  width: '100%',
-                  touchAction: 'pan-x', // 横スクロールのみを許可
-                  overscrollBehavior: 'contain' // スクロールの境界を制限
-                }}
-                ref={pianoScrollRef}
-              >
+                             <div 
+                 className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
+                 style={{ 
+                   WebkitOverflowScrolling: 'touch',
+                   scrollSnapType: 'x proximity',
+                   scrollBehavior: 'smooth',
+                   width: '100%',
+                   touchAction: 'pan-x', // 横スクロールのみを許可
+                   overscrollBehavior: 'contain' // スクロールの境界を制限
+                 }}
+                 ref={(el) => {
+                   pianoScrollRef.current = el;
+                   if (el) {
+                     requestAnimationFrame(() => {
+                       requestAnimationFrame(centerPianoC4);
+                     });
+                   }
+                 }}
+               >
                 <PIXINotesRenderer
                   activeNotes={[]}
                   width={pixiWidth}

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1275,8 +1275,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                  className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
                  style={{ 
                    WebkitOverflowScrolling: 'touch',
-                   scrollSnapType: 'x proximity',
-                   scrollBehavior: 'smooth',
+                   scrollSnapType: 'none',
+                   scrollBehavior: 'auto',
                    width: '100%',
                    touchAction: 'pan-x', // 横スクロールのみを許可
                    overscrollBehavior: 'contain' // スクロールの境界を制限

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -278,6 +278,34 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   // PIXI.js レンダラー
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
+  const pianoScrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = pianoScrollRef.current;
+    if (!container) return;
+
+    const centerC4 = () => {
+      const contentWidth = container.scrollWidth;
+      const viewportWidth = container.clientWidth;
+      if (!contentWidth || !viewportWidth) return;
+      if (contentWidth <= viewportWidth) return;
+      const TOTAL_WHITE_KEYS = 52;
+      const C4_WHITE_INDEX = 23; // A0=0 ... C4=23
+      const whiteKeyWidth = contentWidth / TOTAL_WHITE_KEYS;
+      const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
+      const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
+      container.scrollLeft = desiredScroll;
+    };
+
+    const raf = requestAnimationFrame(centerC4);
+    const handleResize = () => requestAnimationFrame(centerC4);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [pianoScrollRef]);
   const [fantasyPixiInstance, setFantasyPixiInstance] = useState<FantasyPIXIInstance | null>(null);
   const isTaikoModeRef = useRef(false);
   const gameAreaRef = useRef<HTMLDivElement>(null);
@@ -1219,6 +1247,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                   touchAction: 'pan-x', // 横スクロールのみを許可
                   overscrollBehavior: 'contain' // スクロールの境界を制限
                 }}
+                ref={pianoScrollRef}
               >
                 <PIXINotesRenderer
                   activeNotes={[]}

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -1053,8 +1053,8 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
               className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x pixi-mobile-scroll custom-game-scrollbar" 
               style={{ 
                 WebkitOverflowScrolling: 'touch',
-                scrollSnapType: 'x proximity',
-                scrollBehavior: 'smooth'
+                scrollSnapType: 'none',
+                scrollBehavior: 'auto'
               }}
               ref={pianoScrollRef}
             >

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -53,6 +53,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
   const gameAreaRef = useRef<HTMLDivElement>(null);
   const [gameAreaSize, setGameAreaSize] = useState({ width: 800, height: 600 });
+  const pianoScrollRef = useRef<HTMLDivElement | null>(null);
   
   // 音声再生用の要素
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -948,6 +949,33 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     return () => window.removeEventListener('keydown', handleKeyPress);
   }, [handleKeyPress]);
   
+  // ===== 初期スクロール位置: C4を中央に =====
+  useEffect(() => {
+    const container = pianoScrollRef.current;
+    if (!container) return;
+
+    const centerC4 = () => {
+      const contentWidth = container.scrollWidth;
+      const viewportWidth = container.clientWidth;
+      if (!contentWidth || !viewportWidth) return;
+      if (contentWidth <= viewportWidth) return;
+      const TOTAL_WHITE_KEYS = 52;
+      const C4_WHITE_INDEX = 23; // A0=0 ... C4=23
+      const whiteKeyWidth = contentWidth / TOTAL_WHITE_KEYS;
+      const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
+      const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
+      container.scrollLeft = desiredScroll;
+    };
+
+    const raf = requestAnimationFrame(centerC4);
+    const handleResize = () => requestAnimationFrame(centerC4);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   if (!currentSong) {
     return (
       <div className={cn(
@@ -1028,6 +1056,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
                 scrollSnapType: 'x proximity',
                 scrollBehavior: 'smooth'
               }}
+              ref={pianoScrollRef}
             >
               <div style={{ 
                 width: idealWidth, 


### PR DESCRIPTION
Center C4 on the piano keyboard's initial scroll position in Fantasy and Game modes to improve usability on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-7be82652-94b1-4df0-8df1-9a209cead204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7be82652-94b1-4df0-8df1-9a209cead204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

