### PR TITLE
Add fantasy mode stage 1 demo

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import FantasyDemoSection from './fantasy/FantasyDemoSection';
 
 const LandingPage: React.FC = () => {
   const { user, isGuest, loading, enterGuestMode } = useAuthStore();
@@ -99,9 +100,14 @@ const LandingPage: React.FC = () => {
               </Link>
             </div>
           </div>
-        </section>
+                </section>
 
-        {/* Story Section */}
+        {/* Fantasy Mode Demo Section (1-1) */}
+        <section id="fantasy-demo" className="py-16 bg-gradient-to-b from-slate-900 to-slate-950 border-t border-purple-500/20">
+          <FantasyDemoSection />
+        </section>
+ 
+         {/* Story Section */}
         <section id="story" className="py-20 story-gradient">
           <div className="container mx-auto px-6">
             <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-center mb-16 section-title">

--- a/src/components/fantasy/FantasyDemoSection.tsx
+++ b/src/components/fantasy/FantasyDemoSection.tsx
@@ -1,0 +1,84 @@
+import React, { lazy, Suspense, useMemo, useState, useCallback } from 'react';
+import type { FantasyStage as EngineFantasyStage } from './FantasyGameEngine';
+
+const FantasyGameScreen = lazy(() => import('./FantasyGameScreen'));
+
+const FantasyDemoSection: React.FC = () => {
+  const [loadDemo, setLoadDemo] = useState(false);
+
+  const stage = useMemo<EngineFantasyStage>(() => ({
+    id: 'demo-1-1',
+    stageNumber: '1-1',
+    name: 'はじまりの森',
+    description: '基本的なメジャーコードに挑戦！',
+    maxHp: 5,
+    enemyGaugeSeconds: 6,
+    enemyCount: 1,
+    enemyHp: 5,
+    minDamage: 1,
+    maxDamage: 1,
+    mode: 'single',
+    allowedChords: ['C', 'F', 'G', 'Am'],
+    showSheetMusic: false,
+    showGuide: true,
+    monsterIcon: 'dragon',
+    bgmUrl: '/demo-1.mp3',
+    simultaneousMonsterCount: 1,
+    bpm: 120,
+    measureCount: 8,
+    countInMeasures: 0,
+    timeSignature: 4,
+    playRootOnCorrect: true,
+  }), []);
+
+  const handleBack = useCallback(() => {
+    setLoadDemo(false);
+  }, []);
+
+  return (
+    <div className="container mx-auto px-6">
+      <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-center mb-8 section-title flex items-center justify-center gap-4">
+        <img src="/stage_icons/1.png" alt="ファンタジーモード デモ" className="w-16 h-16" />
+        ファンタジーモード デモ (1-1)
+      </h2>
+      <p className="text-center text-purple-200 mb-6">MIDIキーボード、タッチ、またはクリックでプレイできます。</p>
+
+      {!loadDemo && (
+        <div className="max-w-5xl mx-auto">
+          <div className="relative rounded-2xl overflow-hidden border border-purple-500/30 bg-slate-900/60 p-6 flex flex-col items-center">
+            <div className="w-full h-48 sm:h-56 md:h-64 flex items-center justify-center text-gray-400 bg-slate-800/40 rounded-lg mb-6">
+              デモプレビュー
+            </div>
+            <button
+              onClick={() => setLoadDemo(true)}
+              className="px-6 py-3 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 transition text-sm font-bold"
+            >
+              デモを読み込む
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loadDemo && (
+        <div className="relative max-w-6xl mx-auto rounded-2xl overflow-hidden border border-purple-500/30 bg-slate-900/60 p-2">
+          <Suspense
+            fallback={
+              <div className="w-full h-[520px] flex items-center justify-center text-gray-400">読み込み中...</div>
+            }
+          >
+            <div className="w-full min-h-[520px]">
+              <FantasyGameScreen
+                stage={stage}
+                autoStart={false}
+                onGameComplete={() => { /* no-op for demo */ }}
+                onBackToStageSelect={handleBack}
+              />
+            </div>
+          </Suspense>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FantasyDemoSection;


### PR DESCRIPTION
Adds a lazy-loaded Fantasy Mode Stage 1-1 demo section to the landing page.

This demo allows users to play Fantasy Mode 1-1 directly from the LP using MIDI, touch, or click. It is lazy-loaded to ensure the initial page load speed is not impacted, with the game content only loading when the user clicks "Load Demo".

---
<a href="https://cursor.com/background-agent?bcId=bc-5290612e-0fb5-4c26-9f3d-21f68da727eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5290612e-0fb5-4c26-9f3d-21f68da727eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

