### PR TITLE
Fix keyboard scrolling to allow free movement

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -279,10 +279,19 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   // PIXI.js レンダラー
   const [pixiRenderer, setPixiRenderer] = useState<PIXINotesRendererInstance | null>(null);
   const pianoScrollRef = useRef<HTMLDivElement | null>(null);
+  const hasUserScrolledRef = useRef(false);
+  const isProgrammaticScrollRef = useRef(false);
+  const handlePianoScroll = useCallback(() => {
+    if (!isProgrammaticScrollRef.current) {
+      hasUserScrolledRef.current = true;
+    }
+  }, []);
 
   const centerPianoC4 = useCallback(() => {
     const container = pianoScrollRef.current;
     if (!container) return;
+
+    if (hasUserScrolledRef.current) return;
 
     const contentWidth = container.scrollWidth;
     const viewportWidth = container.clientWidth;
@@ -295,10 +304,14 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
     const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
 
+    isProgrammaticScrollRef.current = true;
     try {
       container.scrollTo({ left: desiredScroll, behavior: 'auto' });
     } catch {}
     container.scrollLeft = desiredScroll;
+    requestAnimationFrame(() => {
+      isProgrammaticScrollRef.current = false;
+    });
   }, []);
 
   useEffect(() => {
@@ -1281,6 +1294,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                    touchAction: 'pan-x', // 横スクロールのみを許可
                    overscrollBehavior: 'contain' // スクロールの境界を制限
                  }}
+                 onScroll={handlePianoScroll}
                  ref={(el) => {
                    pianoScrollRef.current = el;
                    if (el) {

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -54,6 +54,13 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
   const gameAreaRef = useRef<HTMLDivElement>(null);
   const [gameAreaSize, setGameAreaSize] = useState({ width: 800, height: 600 });
   const pianoScrollRef = useRef<HTMLDivElement | null>(null);
+  const hasUserScrolledRef = useRef(false);
+  const isProgrammaticScrollRef = useRef(false);
+  const handlePianoScroll = useCallback(() => {
+    if (!isProgrammaticScrollRef.current) {
+      hasUserScrolledRef.current = true;
+    }
+  }, []);
   
   // 音声再生用の要素
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -955,6 +962,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     if (!container) return;
 
     const centerC4 = () => {
+      if (hasUserScrolledRef.current) return;
       const contentWidth = container.scrollWidth;
       const viewportWidth = container.clientWidth;
       if (!contentWidth || !viewportWidth) return;
@@ -964,7 +972,11 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       const whiteKeyWidth = contentWidth / TOTAL_WHITE_KEYS;
       const c4CenterX = (C4_WHITE_INDEX + 0.5) * whiteKeyWidth;
       const desiredScroll = Math.max(0, Math.min(contentWidth - viewportWidth, c4CenterX - viewportWidth / 2));
+      isProgrammaticScrollRef.current = true;
       container.scrollLeft = desiredScroll;
+      requestAnimationFrame(() => {
+        isProgrammaticScrollRef.current = false;
+      });
     };
 
     const raf = requestAnimationFrame(centerC4);
@@ -1056,6 +1068,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
                 scrollSnapType: 'none',
                 scrollBehavior: 'auto'
               }}
+              onScroll={handlePianoScroll}
               ref={pianoScrollRef}
             >
               <div style={{ 


### PR DESCRIPTION
Allow free horizontal scrolling of the piano keyboard after initial centering in Game and Fantasy modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-61a5f30b-ede4-440e-887b-0b1adce92a30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61a5f30b-ede4-440e-887b-0b1adce92a30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

