### PR TITLE
Add fantasy mode stage 1 demo to landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+const LPFantasyDemo = React.lazy(() => import('./fantasy/LPFantasyDemo'));
 
 const LandingPage: React.FC = () => {
   const { user, isGuest, loading, enterGuestMode } = useAuthStore();
@@ -100,6 +101,11 @@ const LandingPage: React.FC = () => {
             </div>
           </div>
         </section>
+
+        {/* Fantasy Mode Demo Section (after hero) */}
+        <React.Suspense fallback={<div className="py-12 text-center text-gray-400">デモを読み込み中...</div>}>
+          <LPFantasyDemo />
+        </React.Suspense>
 
         {/* Story Section */}
         <section id="story" className="py-20 story-gradient">

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -26,6 +26,7 @@ interface FantasyGameScreenProps {
   noteNameLang?: DisplayOpts['lang'];     // 音名表示言語
   simpleNoteName?: boolean;                // 簡易表記
   lessonMode?: boolean;                    // レッスンモード
+  fitAllKeys?: boolean;                    // ★ 追加: 全鍵盤を幅内に収める（LPデモ用）
 }
 
 // 不要な定数とインターフェースを削除（PIXI側で処理）
@@ -37,7 +38,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   onBackToStageSelect,
   noteNameLang = 'en',
   simpleNoteName = false,
-  lessonMode = false
+  lessonMode = false,
+  fitAllKeys = false
 }) => {
   // useGameStoreの使用を削除（ファンタジーモードでは不要）
   
@@ -993,7 +995,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   return (
     <div className={cn(
-      "h-screen bg-black text-white relative overflow-hidden select-none flex flex-col fantasy-game-screen"
+      `${fitAllKeys ? 'h-full' : 'h-screen'} bg-black text-white relative overflow-hidden select-none flex flex-col fantasy-game-screen`
     )}>
       {/* ===== ヘッダー ===== */}
       <div className="relative z-30 p-1 text-white flex-shrink-0" style={{ minHeight: '40px' }}>
@@ -1270,7 +1272,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           let pixiWidth: number;
           let needsScroll: boolean;
           
-          if (gameAreaWidth >= adjustedThreshold) {
+          if (fitAllKeys) {
+            // 全鍵盤を現在の幅にフィット（横スクロール無し）
+            pixiWidth = gameAreaWidth;
+            needsScroll = false;
+          } else if (gameAreaWidth >= adjustedThreshold) {
             // PC等、画面が十分広い → 88鍵全表示（スクロール不要）
             pixiWidth = gameAreaWidth;
             needsScroll = false;
@@ -1284,26 +1290,26 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           if (needsScroll) {
             // スクロールが必要な場合
             return (
-                             <div 
-                 className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
-                 style={{ 
-                   WebkitOverflowScrolling: 'touch',
-                   scrollSnapType: 'none',
-                   scrollBehavior: 'auto',
-                   width: '100%',
-                   touchAction: 'pan-x', // 横スクロールのみを許可
-                   overscrollBehavior: 'contain' // スクロールの境界を制限
-                 }}
-                 onScroll={handlePianoScroll}
-                 ref={(el) => {
-                   pianoScrollRef.current = el;
-                   if (el) {
-                     requestAnimationFrame(() => {
-                       requestAnimationFrame(centerPianoC4);
-                     });
-                   }
-                 }}
-               >
+              <div 
+                className="absolute inset-0 overflow-x-auto overflow-y-hidden touch-pan-x custom-game-scrollbar" 
+                style={{ 
+                  WebkitOverflowScrolling: 'touch',
+                  scrollSnapType: 'none',
+                  scrollBehavior: 'auto',
+                  width: '100%',
+                  touchAction: 'pan-x', // 横スクロールのみを許可
+                  overscrollBehavior: 'contain' // スクロールの境界を制限
+                }}
+                onScroll={handlePianoScroll}
+                ref={(el) => {
+                  pianoScrollRef.current = el;
+                  if (el) {
+                    requestAnimationFrame(() => {
+                      requestAnimationFrame(centerPianoC4);
+                    });
+                  }
+                }}
+              >
                 <PIXINotesRenderer
                   activeNotes={[]}
                   width={pixiWidth}

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState, Suspense } from 'react';
+
+const LPFantasyDemo: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [stage, setStage] = useState<any | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Lazy import FantasyGameScreen only when modal opens
+  const FantasyGameScreen = useMemo(() => React.lazy(() => import('./FantasyGameScreen')), []);
+
+  // Fetch 1-1 stage from DB when opening
+  const loadStage = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { fetchFantasyStageByNumber } = await import('@/platform/supabaseFantasyStages');
+      const dbStage = await fetchFantasyStageByNumber('1-1');
+      if (!dbStage) {
+        throw new Error('ステージ 1-1 が見つかりませんでした');
+      }
+      // Map DB shape to FantasyGameScreen expected stage shape
+      const mapped = {
+        id: dbStage.id,
+        stageNumber: dbStage.stage_number,
+        name: dbStage.name,
+        description: dbStage.description,
+        maxHp: dbStage.max_hp,
+        enemyGaugeSeconds: dbStage.enemy_gauge_seconds,
+        enemyCount: dbStage.enemy_count,
+        enemyHp: dbStage.enemy_hp,
+        minDamage: dbStage.min_damage,
+        maxDamage: dbStage.max_damage,
+        mode: (dbStage as any).mode,
+        allowedChords: (dbStage as any).allowed_chords,
+        chordProgression: (dbStage as any).chord_progression,
+        chordProgressionData: (dbStage as any).chord_progression_data,
+        showSheetMusic: false,
+        showGuide: dbStage.show_guide,
+        simultaneousMonsterCount: dbStage.simultaneous_monster_count || 1,
+        monsterIcon: 'dragon',
+        bpm: (dbStage as any).bpm || 120,
+        bgmUrl: dbStage.bgm_url || (dbStage as any).mp3_url || '/demo-1.mp3',
+        measureCount: (dbStage as any).measure_count,
+        countInMeasures: (dbStage as any).count_in_measures,
+        timeSignature: (dbStage as any).time_signature,
+        noteIntervalBeats: (dbStage as any).note_interval_beats,
+        playRootOnCorrect: (dbStage as any).play_root_on_correct ?? true
+      } as const;
+      setStage(mapped);
+    } catch (e: any) {
+      console.error(e);
+      setError(e?.message || 'ステージ取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const openDemo = useCallback(async () => {
+    if (!stage) {
+      await loadStage();
+    }
+    setIsOpen(true);
+    // Request fullscreen after state update in next tick
+    setTimeout(() => {
+      const root = containerRef.current;
+      if (!root) return;
+      if (root.requestFullscreen) root.requestFullscreen().catch(() => {});
+      // vendor prefixes
+      (root as any).webkitRequestFullscreen?.();
+      (root as any).msRequestFullscreen?.();
+      setIsFullscreen(true);
+    }, 0);
+  }, [loadStage, stage]);
+
+  const closeDemo = useCallback(() => {
+    setIsOpen(false);
+    try {
+      if (document.fullscreenElement) {
+        document.exitFullscreen?.().catch(() => {});
+      }
+      (document as any).webkitExitFullscreen?.();
+      (document as any).msExitFullscreen?.();
+    } catch {}
+    setIsFullscreen(false);
+  }, []);
+
+  // Minimal, low-height teaser with CTA
+  return (
+    <section className="py-8 bg-slate-900/60 border-t border-b border-purple-500/20">
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col md:flex-row items-center gap-6">
+          <div className="flex-1">
+            <h3 className="text-2xl md:text-3xl font-bold text-purple-300 mb-2">ファンタジーモード デモ（1-1）</h3>
+            <p className="text-gray-300 text-sm md:text-base">MIDIキーボード／タッチ／クリックで、そのままの挙動を体験。クリックで全画面表示されます。</p>
+          </div>
+          <div className="flex-1">
+            <div className="relative w-full h-40 md:h-44 rounded-xl overflow-hidden bg-[url('/first-view.png')] bg-cover bg-center border border-purple-500/30 shadow-lg">
+              <div className="absolute inset-0 bg-gradient-to-r from-black/50 to-black/30" />
+              <button
+                onClick={openDemo}
+                className="absolute inset-0 m-auto h-12 w-44 md:h-14 md:w-56 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-xl"
+                aria-label="ファンタジーモード デモを再生"
+              >
+                体験する（全画面）
+              </button>
+            </div>
+            {error && (
+              <div className="text-red-400 text-sm mt-2">{error}</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div
+          ref={containerRef}
+          className="fixed inset-0 z-[1000] bg-black"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="absolute top-3 right-3 z-50">
+            <button
+              onClick={closeDemo}
+              className="px-3 py-2 rounded bg-gray-800 hover:bg-gray-700 text-sm text-white border border-white/10"
+            >
+              全画面を終了
+            </button>
+          </div>
+          <div className="absolute inset-0">
+            <Suspense fallback={<div className="w-full h-full flex items-center justify-center text-white">読み込み中...</div>}>
+              {stage && (
+                <FantasyGameScreen
+                  stage={stage}
+                  autoStart
+                  onGameComplete={() => {}}
+                  onBackToStageSelect={closeDemo}
+                  noteNameLang="en"
+                  simpleNoteName={false}
+                  lessonMode={false}
+                />
+              )}
+            </Suspense>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default LPFantasyDemo;

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -150,7 +150,6 @@ const LPFantasyDemo: React.FC = () => {
                 <FantasyGameScreen
                   stage={stage}
                   autoStart
-                  fitAllKeys
                   onGameComplete={() => {}}
                   onBackToStageSelect={closeDemo}
                   noteNameLang="en"

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState, Suspense } from 'react';
+import { MidiDeviceSelector } from '@/components/ui/MidiDeviceManager';
+import { useGameStore } from '@/stores/gameStore';
 
 const LPFantasyDemo: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -7,6 +9,7 @@ const LPFantasyDemo: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const { settings, updateSettings } = useGameStore();
 
   // Lazy import FantasyGameScreen only when modal opens
   const FantasyGameScreen = useMemo(() => React.lazy(() => import('./FantasyGameScreen')), []);
@@ -87,29 +90,41 @@ const LPFantasyDemo: React.FC = () => {
     setIsFullscreen(false);
   }, []);
 
-  // Minimal, low-height teaser with CTA
   return (
-    <section className="py-8 bg-slate-900/60 border-t border-b border-purple-500/20">
+    <section className="py-10">
       <div className="container mx-auto px-6">
-        <div className="flex flex-col md:flex-row items-center gap-6">
-          <div className="flex-1">
-            <h3 className="text-2xl md:text-3xl font-bold text-purple-300 mb-2">ファンタジーモード デモ（1-1）</h3>
-            <p className="text-gray-300 text-sm md:text-base">MIDIキーボード／タッチ／クリックで、そのままの挙動を体験。クリックで全画面表示されます。</p>
-          </div>
-          <div className="flex-1">
-            <div className="relative w-full h-40 md:h-44 rounded-xl overflow-hidden bg-[url('/first-view.png')] bg-cover bg-center border border-purple-500/30 shadow-lg">
-              <div className="absolute inset-0 bg-gradient-to-r from-black/50 to-black/30" />
-              <button
-                onClick={openDemo}
-                className="absolute inset-0 m-auto h-12 w-44 md:h-14 md:w-56 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-xl"
-                aria-label="ファンタジーモード デモを再生"
-              >
-                体験する（全画面）
-              </button>
+        <div className="rounded-2xl border border-purple-500/30 bg-slate-900/60 shadow-xl overflow-hidden">
+          <div className="grid md:grid-cols-2 gap-0">
+            {/* Visual + CTA */}
+            <div className="relative min-h-[192px] md:min-h-[224px]">
+              <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
+              <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
+                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ（1-1）</h3>
+                <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
+                <button
+                  onClick={openDemo}
+                  className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
+                  aria-label="ファンタジーモード デモを再生"
+                >
+                  体験する（全画面）
+                </button>
+                {error && <div className="text-red-400 text-xs">{error}</div>}
+              </div>
             </div>
-            {error && (
-              <div className="text-red-400 text-sm mt-2">{error}</div>
-            )}
+
+            {/* Device select + note */}
+            <div className="p-4 md:p-6 flex flex-col justify-center gap-4">
+              <div>
+                <div className="text-sm text-purple-200 font-semibold mb-2">MIDI機器を選択</div>
+                <MidiDeviceSelector
+                  value={settings.selectedMidiDevice}
+                  onChange={(id) => updateSettings({ selectedMidiDevice: id })}
+                />
+                <div className="text-xs text-gray-400 mt-2">選択した機器はデモプレイで使用されます。未選択でもマウス/タッチでプレイ可能です。</div>
+              </div>
+              <div className="text-[11px] text-gray-400">通信や環境により音声の初回起動にユーザー操作が必要な場合があります。</div>
+            </div>
           </div>
         </div>
       </div>
@@ -135,6 +150,7 @@ const LPFantasyDemo: React.FC = () => {
                 <FantasyGameScreen
                   stage={stage}
                   autoStart
+                  fitAllKeys
                   onGameComplete={() => {}}
                   onBackToStageSelect={closeDemo}
                   noteNameLang="en"

--- a/src/utils/MidiController.ts
+++ b/src/utils/MidiController.ts
@@ -38,6 +38,17 @@ const detectUserInteraction = (): Promise<void> => {
       resolve();
       return;
     }
+
+    // If Tone audio context is already running (e.g. Tone.start() was invoked),
+    // treat it as an interaction to avoid requiring a second click.
+    try {
+      const tone: any = (typeof window !== 'undefined') ? (window as any).Tone : null;
+      if (tone?.context?.state === 'running') {
+        userInteracted = true;
+        resolve();
+        return;
+      }
+    } catch {}
     
     const handleUserInteraction = () => {
       userInteracted = true;


### PR DESCRIPTION
Add a lazy-loaded Fantasy Mode 1-1 demo section to the landing page to allow immediate, full-screen gameplay with MIDI/touch/click input and no audio latency.

---
<a href="https://cursor.com/background-agent?bcId=bc-0854eeb8-0a49-4421-b28f-3e482f64ac1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0854eeb8-0a49-4421-b28f-3e482f64ac1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

