### PR TITLE
Fix keyboard height for demo play HP/SP display

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -954,7 +954,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     });
     
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center fantasy-game-screen">
+      <div className="min-h-[var(--dvh,100dvh)] bg-black flex items-center justify-center fantasy-game-screen">
         <div className="text-white text-center">
           <div className="text-6xl mb-6">🎮</div>
           <h2 className="text-3xl font-bold mb-4">
@@ -995,7 +995,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   
   return (
     <div className={cn(
-      `${fitAllKeys ? 'h-full' : 'h-screen'} bg-black text-white relative overflow-hidden select-none flex flex-col fantasy-game-screen`
+      `${fitAllKeys ? 'h-full' : 'min-h-[var(--dvh,100dvh)]'} bg-black text-white relative overflow-hidden select-none flex flex-col fantasy-game-screen`
     )}>
       {/* ===== ヘッダー ===== */}
       <div className="relative z-30 p-1 text-white flex-shrink-0" style={{ minHeight: '40px' }}>

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -66,6 +66,18 @@ const LPFantasyDemo: React.FC = () => {
       await loadStage();
     }
     setIsOpen(true);
+    // dvh フォールバック変数を設定
+    try {
+      const setDvh = () => {
+        const dvh = Math.max(window.innerHeight, document.documentElement.clientHeight);
+        document.documentElement.style.setProperty('--dvh', dvh + 'px');
+      };
+      setDvh();
+      window.addEventListener('resize', setDvh, { passive: true });
+      // 一度だけのタイマーで再計測（ソフトキーボード対策）
+      setTimeout(setDvh, 200);
+      setTimeout(setDvh, 500);
+    } catch {}
     // Request fullscreen after state update in next tick
     setTimeout(() => {
       const root = containerRef.current;
@@ -75,6 +87,8 @@ const LPFantasyDemo: React.FC = () => {
       (root as any).webkitRequestFullscreen?.();
       (root as any).msRequestFullscreen?.();
       setIsFullscreen(true);
+      // レイアウト確定後にresizeを明示発火（dvh反映とResizeObserver起動用）
+      try { window.dispatchEvent(new Event('resize')); } catch {}
     }, 0);
   }, [loadStage, stage]);
 
@@ -88,6 +102,10 @@ const LPFantasyDemo: React.FC = () => {
       (document as any).msExitFullscreen?.();
     } catch {}
     setIsFullscreen(false);
+    // dvh 変数のクリア
+    try {
+      document.documentElement.style.removeProperty('--dvh');
+    } catch {}
   }, []);
 
   return (
@@ -132,7 +150,7 @@ const LPFantasyDemo: React.FC = () => {
       {isOpen && (
         <div
           ref={containerRef}
-          className="fixed inset-0 z-[1000] bg-black"
+          className="fixed inset-0 z-[1000] bg-black min-h-[var(--dvh,100dvh)] flex flex-col"
           role="dialog"
           aria-modal="true"
         >


### PR DESCRIPTION
Adjusts demo play screen height calculation and layout to prevent HP/SP bar cutoff on mobile devices.

Replaces `100vh` with `100dvh` (dynamic viewport height) and adds explicit resize triggers to address inconsistent viewport height behavior on mobile browsers, especially Safari, which caused UI elements to be clipped.

---
<a href="https://cursor.com/background-agent?bcId=bc-99e86091-efde-4c92-8543-1500055e1c9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99e86091-efde-4c92-8543-1500055e1c9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

