### PR TITLE
Fix fantasy mode sound bug on iOS Safari

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -383,7 +383,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     }
 
     // ルート音を再生（非同期対応）
-    const allowRootSound = stage?.playRootOnCorrect === true;
+    const allowRootSound = stage?.playRootOnCorrect !== false;
     if (allowRootSound) {
       try {
         const mod = await import('@/utils/FantasySoundManager');
@@ -482,6 +482,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   const handleNoteInputBridge = useCallback(async (note: number, source: 'mouse' | 'midi' = 'mouse') => {
     // iOS/Safari 対策: 最初のユーザー操作でオーディオを解放
     try { await (window as any).Tone?.start?.(); } catch {}
+    try {
+      const mod = await import('@/utils/FantasySoundManager');
+      const FSM = (mod as any).FantasySoundManager ?? mod.default;
+      await FSM?.unlock?.();
+    } catch {}
 
     // マウスクリック時のみ重複チェック（MIDI経由ではスキップしない）
     if (source === 'mouse' && activeNotesRef.current.has(note)) {


### PR DESCRIPTION
Add iOS Safari audio unlock to enable fantasy mode sounds.

On iOS Safari, audio contexts require a user interaction to start and resume. This PR implements a robust unlock mechanism that activates both Web Audio (Tone.js) and HTML Audio contexts on the first user interaction, ensuring correct and root sounds play as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-619d8416-1fb0-4d80-a411-202c89f0e08a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-619d8416-1fb0-4d80-a411-202c89f0e08a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

