### PR TITLE
Improve LP demo section display

### DIFF
--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -131,12 +131,12 @@ const LPFantasyDemo: React.FC = () => {
               <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
               <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
-                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ（{selectedStageNumber}）</h3>
+                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
                 <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
                 <select
                   value={selectedStageNumber}
                   onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                  className="h-10 w-40 md:h-11 md:w-48 rounded-full bg-black/50 border border-white/20 text-white text-sm px-3"
+                  className="h-12 min-h-[44px] w-44 md:h-11 md:min-h-0 md:w-48 rounded-full bg-black/50 border border-white/20 text-white text-base md:text-sm px-3 py-2"
                   aria-label="ステージを選択"
                 >
                   <option value="1-1">1-1</option>

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -11,6 +11,20 @@ const LPFantasyDemo: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { settings, updateSettings } = useGameStore();
   const [selectedStageNumber, setSelectedStageNumber] = useState<'1-1' | '1-2' | '1-3' | '1-4'>('1-1');
+  const [isPortrait, setIsPortrait] = useState(true);
+  useEffect(() => {
+    const mq = window.matchMedia('(orientation: portrait)');
+    const update = () => setIsPortrait(mq.matches);
+    try {
+      mq.addEventListener('change', update);
+    } catch {
+      mq.addListener(update);
+    }
+    update();
+    return () => {
+      try { mq.removeEventListener('change', update); } catch { mq.removeListener(update); }
+    };
+  }, []);
 
   // Lazy import FantasyGameScreen only when modal opens
   const FantasyGameScreen = useMemo(() => React.lazy(() => import('./FantasyGameScreen')), []);
@@ -133,17 +147,35 @@ const LPFantasyDemo: React.FC = () => {
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
                 <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
                 <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
-                <select
-                  value={selectedStageNumber}
-                  onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                  className="h-12 min-h-[44px] w-44 md:h-11 md:min-h-0 md:w-48 rounded-full bg-black/50 border border-white/20 text-white text-base md:text-sm px-3 py-2"
-                  aria-label="ステージを選択"
-                >
-                  <option value="1-1">1-1</option>
-                  <option value="1-2">1-2</option>
-                  <option value="1-3">1-3</option>
-                  <option value="1-4">1-4</option>
-                </select>
+                <div className="w-full flex items-center justify-center">
+                  {isPortrait ? (
+                    <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
+                      {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
+                        <button
+                          key={num}
+                          type="button"
+                          onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
+                          aria-pressed={selectedStageNumber === num}
+                          className={`h-11 rounded-full font-semibold text-sm transition-colors ${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'}`}
+                        >
+                          {num}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <select
+                      value={selectedStageNumber}
+                      onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
+                      className="lp-stage-select"
+                      aria-label="ステージを選択"
+                    >
+                      <option value="1-1">1-1</option>
+                      <option value="1-2">1-2</option>
+                      <option value="1-3">1-3</option>
+                      <option value="1-4">1-4</option>
+                    </select>
+                  )}
+                </div>
                 <button
                   onClick={openDemo}
                   className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"

--- a/src/components/ui/MidiDeviceManager.tsx
+++ b/src/components/ui/MidiDeviceManager.tsx
@@ -197,7 +197,7 @@ export const MidiDeviceSelector: React.FC<MidiDeviceSelectorProps> = ({
             id="midi-device-select"
             value={value || ''}
             onChange={(e) => handleDeviceChange(e.target.value || null)}
-            className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-blue-600"
+            className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-blue-600 lp-mobile-select"
             disabled={isRefreshing}
           >
             <option value="">なし</option>
@@ -272,7 +272,7 @@ export const AudioDeviceSelector: React.FC<AudioDeviceSelectorProps> = ({
             id="audio-device-select"
             value={value || ''}
             onChange={(e) => onChange(e.target.value || null)}
-            className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-green-600 audio-devices"
+            className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-green-600 audio-devices lp-mobile-select"
             disabled={isRefreshing}
           >
             <option value="">マイクを選択...</option>

--- a/src/index.css
+++ b/src/index.css
@@ -489,6 +489,54 @@
     @apply select bg-slate-800 border-slate-600;
   }
   
+  /* LPデモ: ステージ選択セレクトのタップ領域を強制（iOS縦画面対策） */
+  .lp-stage-select {
+    -webkit-appearance: none;
+    appearance: none;
+    display: inline-block;
+    vertical-align: middle;
+    min-height: 44px;
+    height: auto;
+    line-height: normal;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    @apply w-44 md:h-11 md:w-48 rounded-full bg-black/50 border border-white/20 text-white text-base md:text-sm px-3;
+  }
+  
+  @media (orientation: portrait) {
+    .lp-stage-select {
+      padding-top: 12px;
+      padding-bottom: 12px;
+      font-size: 16px;
+    }
+  }
+  
+  /* iOS Safari 強制上書き（UAスタイルが高さを無視するケース対策） */
+  @supports (-webkit-touch-callout: none) {
+    @media (orientation: portrait) {
+      .lp-stage-select,
+      .lp-mobile-select {
+        height: 48px !important;
+        min-height: 44px !important;
+        line-height: 48px !important;
+        font-size: 16px !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+      }
+    }
+  }
+  
+  .lp-mobile-select {
+    -webkit-appearance: none;
+    appearance: none;
+    min-height: 44px;
+    height: auto;
+    line-height: normal;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    font-size: 16px;
+  }
+  
   /* チェックボックススタイル */
   .checkbox {
     @apply w-5 h-5 bg-slate-800 border-2 border-slate-600 rounded focus:ring-2 focus:ring-primary-500 focus:ring-offset-0 transition-colors;


### PR DESCRIPTION
Removes stage number from demo card title and increases mobile dropdown height for improved usability.

The stage selection dropdown on mobile portrait was unnaturally thin, causing poor tapability and potential zoom issues on iOS. This change ensures a minimum height of 44px for better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cbe279b-6725-416c-aa18-24f50942a4a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cbe279b-6725-416c-aa18-24f50942a4a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

