### PR TITLE
Improve LP demo section display

### DIFF
--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -371,11 +371,6 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
           />
         </div>
         
-        {/* ステージ番号 */}
-        <div className="text-white text-lg sm:text-xl font-bold flex-shrink-0 w-14 sm:w-16 text-center">
-          {stage.stageNumber}
-        </div>
-        
         {/* コンテンツ部分 */}
         <div className="min-w-0 flex-grow">
           {/* ステージ名 */}

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -131,12 +131,12 @@ const LPFantasyDemo: React.FC = () => {
               <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
               <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
-                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ（{selectedStageNumber}）</h3>
+                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
                 <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
                 <select
                   value={selectedStageNumber}
                   onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                  className="h-10 w-40 md:h-11 md:w-48 rounded-full bg-black/50 border border-white/20 text-white text-sm px-3"
+                  className="lp-select w-40 md:w-48 rounded-full bg-black/50 border border-white/20 text-white px-3"
                   aria-label="ステージを選択"
                 >
                   <option value="1-1">1-1</option>

--- a/src/index.css
+++ b/src/index.css
@@ -470,6 +470,18 @@
     @apply input cursor-pointer;
   }
   
+  /* LP demo: cross-browser stable select sizing */
+  .lp-select {
+    -webkit-appearance: none;
+    appearance: none;
+    line-height: 1.5; /* keep text vertically centered */
+    padding-top: 0.5rem; /* 8px */
+    padding-bottom: 0.5rem; /* 8px */
+    min-height: 2.75rem; /* ~44px tap target */
+    font-size: 1rem; /* 16px to avoid iOS zoom and keep stable in portrait */
+    background-clip: padding-box;
+  }
+  
   /* 管理画面用のフォームスタイル */
   .input-bordered,
   .textarea-bordered,


### PR DESCRIPTION
Remove stage numbers from LP demo and stage selection cards, and improve the mobile portrait dropdown height for LP demo stage selection.

The dropdown height fix addresses an "unnatural" appearance in mobile portrait by applying specific CSS properties (`appearance` reset, `line-height`, padding, 16px font-size) for cross-browser consistency and to prevent iOS zoom, rather than just a fixed height.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffb6ebc6-833b-43ab-81c3-bc2c01ac844b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffb6ebc6-833b-43ab-81c3-bc2c01ac844b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

