### PR TITLE
Add smartphone frame to LP demo cards

### DIFF
--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -141,7 +141,7 @@ const LPFantasyDemo: React.FC = () => {
         <div className="rounded-2xl border border-purple-500/30 bg-slate-900/60 shadow-xl overflow-hidden">
           <div className="grid md:grid-cols-2 gap-0">
             {/* Visual + CTA */}
-            <div className="relative min-h-[192px] md:min-h-[224px]">
+            <div className="relative min-h-[192px] md:min-h-[224px] lp-phone-mock">
               <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
               <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
@@ -156,7 +156,7 @@ const LPFantasyDemo: React.FC = () => {
                           type="button"
                           onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
                           aria-pressed={selectedStageNumber === num}
-                          className={`h-11 rounded-full font-semibold text-sm transition-colors ${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'}`}
+                          className={`${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'} h-11 rounded-full font-semibold text-sm transition-colors`}
                         >
                           {num}
                         </button>

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -141,50 +141,57 @@ const LPFantasyDemo: React.FC = () => {
         <div className="rounded-2xl border border-purple-500/30 bg-slate-900/60 shadow-xl overflow-hidden">
           <div className="grid md:grid-cols-2 gap-0">
             {/* Visual + CTA */}
-            <div className="relative min-h-[192px] md:min-h-[224px] lp-phone-mock">
-              <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
-              <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
-                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
-                <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
-                <div className="w-full flex items-center justify-center">
-                  {isPortrait ? (
-                    <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
-                      {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
-                        <button
-                          key={num}
-                          type="button"
-                          onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
-                          aria-pressed={selectedStageNumber === num}
-                          className={`${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'} h-11 rounded-full font-semibold text-sm transition-colors`}
-                        >
-                          {num}
-                        </button>
-                      ))}
-                    </div>
-                  ) : (
-                    <select
-                      value={selectedStageNumber}
-                      onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                      className="lp-stage-select"
-                      aria-label="ステージを選択"
-                    >
-                      <option value="1-1">1-1</option>
-                      <option value="1-2">1-2</option>
-                      <option value="1-3">1-3</option>
-                      <option value="1-4">1-4</option>
-                    </select>
-                  )}
+            <div className="relative min-h-[192px] md:min-h-[240px] lp-phone-mock">
+              <div className="lp-phone-screen">
+                <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
+                <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
+                  <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
+                  <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
+                  <div className="w-full flex items-center justify-center">
+                    {isPortrait ? (
+                      <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
+                        {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
+                          <button
+                            key={num}
+                            type="button"
+                            onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
+                            aria-pressed={selectedStageNumber === num}
+                            className={`${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'} h-11 rounded-full font-semibold text-sm transition-colors`}
+                          >
+                            {num}
+                          </button>
+                        ))}
+                      </div>
+                    ) : (
+                      <select
+                        value={selectedStageNumber}
+                        onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
+                        className="lp-stage-select"
+                        aria-label="ステージを選択"
+                      >
+                        <option value="1-1">1-1</option>
+                        <option value="1-2">1-2</option>
+                        <option value="1-3">1-3</option>
+                        <option value="1-4">1-4</option>
+                      </select>
+                    )}
+                  </div>
+                  <button
+                    onClick={openDemo}
+                    className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
+                    aria-label="ファンタジーモード デモを再生"
+                  >
+                    体験する（全画面）
+                  </button>
+                  {error && <div className="text-red-400 text-xs">{error}</div>}
                 </div>
-                <button
-                  onClick={openDemo}
-                  className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
-                  aria-label="ファンタジーモード デモを再生"
-                >
-                  体験する（全画面）
-                </button>
-                {error && <div className="text-red-400 text-xs">{error}</div>}
+                <div className="lp-home-indicator" />
               </div>
+              <div className="lp-phone-decor"><div className="lp-speaker-grille" /></div>
+              <div className="lp-btn-left-top" />
+              <div className="lp-btn-left-bottom" />
+              <div className="lp-btn-right" />
             </div>
 
             {/* Device select + note */}

--- a/src/index.css
+++ b/src/index.css
@@ -926,6 +926,67 @@
   backdrop-filter: blur(5px);
 }
 
+/* LP デモ：スマホ風フレーム */
+.lp-phone-mock {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  /* 内側ベゼル */
+  box-shadow:
+    inset 0 0 0 8px rgba(0, 0, 0, 0.65),
+    inset 0 0 0 9px rgba(255, 255, 255, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+@media (min-width: 768px) {
+  .lp-phone-mock {
+    border-radius: 28px;
+  }
+}
+
+.lp-phone-mock::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 42%;
+  max-width: 180px;
+  height: 14px;
+  background: rgba(0, 0, 0, 0.9);
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.lp-phone-mock::after {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: calc(50% + 56px);
+  width: 6px;
+  height: 6px;
+  background: radial-gradient(circle, rgba(255,255,255,0.8) 0%, rgba(200,200,255,0.4) 40%, rgba(0,0,0,0.9) 60%);
+  border-radius: 50%;
+  filter: blur(0.2px);
+  pointer-events: none;
+  z-index: 21;
+}
+
+@media (max-width: 640px) {
+  .lp-phone-mock::before {
+    width: 52%;
+    height: 12px;
+  }
+  .lp-phone-mock::after {
+    left: calc(50% + 44px);
+    width: 5px;
+    height: 5px;
+  }
+}
+
 .pricing-card {
   background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
   border: 2px solid rgba(120, 119, 198, 0.3);

--- a/src/index.css
+++ b/src/index.css
@@ -926,25 +926,50 @@
   backdrop-filter: blur(5px);
 }
 
-/* LP デモ：スマホ風フレーム */
+/* LP デモ：スマホ風フレーム（強調版） */
 .lp-phone-mock {
   position: relative;
-  border-radius: 24px;
+  border-radius: 28px;
   overflow: hidden;
-  /* 内側ベゼル */
+  background: linear-gradient(135deg, #0e0e12, #1a1b22);
   box-shadow:
-    inset 0 0 0 8px rgba(0, 0, 0, 0.65),
-    inset 0 0 0 9px rgba(255, 255, 255, 0.06),
-    0 8px 24px rgba(0, 0, 0, 0.5);
+    0 14px 36px rgba(0, 0, 0, 0.6),
+    0 0 0 2px rgba(255, 255, 255, 0.04),
+    0 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
-@media (min-width: 768px) {
-  .lp-phone-mock {
-    border-radius: 28px;
-  }
+@media (max-width: 640px) {
+  .lp-phone-mock { border-radius: 24px; }
 }
 
-.lp-phone-mock::before {
+.lp-phone-screen {
+  position: absolute;
+  inset: 10px;
+  border-radius: 22px;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 8px rgba(0, 0, 0, 0.7),
+    inset 0 0 0 9px rgba(255, 255, 255, 0.06);
+}
+
+.lp-phone-screen::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 30%, rgba(255,255,255,0) 70%, rgba(255, 255, 255, 0.06) 100%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.lp-phone-decor {
+  position: absolute;
+  inset: 10px;
+  border-radius: 22px;
+  pointer-events: none;
+  z-index: 25;
+}
+
+.lp-phone-decor::before {
   content: '';
   position: absolute;
   top: 6px;
@@ -956,36 +981,73 @@
   background: rgba(0, 0, 0, 0.9);
   border-bottom-left-radius: 12px;
   border-bottom-right-radius: 12px;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
-  pointer-events: none;
-  z-index: 20;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.06);
 }
 
-.lp-phone-mock::after {
+.lp-phone-decor::after {
   content: '';
   position: absolute;
   top: 10px;
   left: calc(50% + 56px);
   width: 6px;
   height: 6px;
-  background: radial-gradient(circle, rgba(255,255,255,0.8) 0%, rgba(200,200,255,0.4) 40%, rgba(0,0,0,0.9) 60%);
+  background: radial-gradient(circle, rgba(255,255,255,0.85) 0%, rgba(200,200,255,0.4) 40%, rgba(0,0,0,0.9) 60%);
   border-radius: 50%;
   filter: blur(0.2px);
-  pointer-events: none;
-  z-index: 21;
 }
 
 @media (max-width: 640px) {
-  .lp-phone-mock::before {
+  .lp-phone-decor::before {
     width: 52%;
     height: 12px;
   }
-  .lp-phone-mock::after {
+  .lp-phone-decor::after {
     left: calc(50% + 44px);
     width: 5px;
     height: 5px;
   }
 }
+
+.lp-home-indicator {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 56px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.35);
+  z-index: 24;
+}
+
+/* デコレーション: スピーカー穴とサイドボタン */
+.lp-speaker-grille {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(45,45,55,0.95), rgba(15,15,20,0.95));
+  border-radius: 9999px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -1px 0 rgba(0,0,0,0.5);
+}
+
+.lp-btn-left-top,
+.lp-btn-left-bottom,
+.lp-btn-right {
+  position: absolute;
+  width: 3px;
+  background: linear-gradient(180deg, rgba(45,45,55,0.85), rgba(20,20,26,0.9));
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.1);
+  z-index: 26;
+}
+
+.lp-btn-left-top { left: -1px; top: 40px; height: 28px; }
+.lp-btn-left-bottom { left: -1px; top: 76px; height: 40px; }
+.lp-btn-right { right: -1px; top: 58px; height: 52px; }
 
 .pricing-card {
   background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));


### PR DESCRIPTION
Add a smartphone-like frame to the demo play section card on the LP.

---
<a href="https://cursor.com/background-agent?bcId=bc-166ee180-2957-4519-8a7b-c9931c04c390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-166ee180-2957-4519-8a7b-c9931c04c390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

