### PR TITLE
Add smartphone frame to demo mode

### DIFF
--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -141,50 +141,55 @@ const LPFantasyDemo: React.FC = () => {
         <div className="rounded-2xl border border-purple-500/30 bg-slate-900/60 shadow-xl overflow-hidden">
           <div className="grid md:grid-cols-2 gap-0">
             {/* Visual + CTA */}
-            <div className="relative min-h-[192px] md:min-h-[224px]">
-              <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
-              <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
-                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
-                <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
-                <div className="w-full flex items-center justify-center">
-                  {isPortrait ? (
-                    <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
-                      {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
-                        <button
-                          key={num}
-                          type="button"
-                          onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
-                          aria-pressed={selectedStageNumber === num}
-                          className={`h-11 rounded-full font-semibold text-sm transition-colors ${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'}`}
+            <div className="relative min-h-[192px] md:min-h-[224px] flex items-center justify-center p-4">
+              <div className="relative w-[280px] sm:w-[320px] md:w-[360px]">
+                <div className="relative rounded-[2rem] border border-white/20 bg-black/60 shadow-2xl overflow-hidden">
+                  <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
+                  <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/30" />
+                  <div className="absolute top-0 left-1/2 -translate-x-1/2 w-28 h-5 bg-black/70 rounded-b-2xl" aria-hidden="true" />
+                  <div className="relative flex flex-col items-center justify-center gap-3 p-5">
+                    <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
+                    <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
+                    <div className="w-full flex items-center justify-center">
+                      {isPortrait ? (
+                        <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
+                          {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
+                            <button
+                              key={num}
+                              type="button"
+                              onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
+                              aria-pressed={selectedStageNumber === num}
+                              className={`${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'} h-11 rounded-full font-semibold text-sm transition-colors`}
+                            >
+                              {num}
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <select
+                          value={selectedStageNumber}
+                          onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
+                          className="lp-stage-select"
+                          aria-label="ステージを選択"
                         >
-                          {num}
-                        </button>
-                      ))}
+                          <option value="1-1">1-1</option>
+                          <option value="1-2">1-2</option>
+                          <option value="1-3">1-3</option>
+                          <option value="1-4">1-4</option>
+                        </select>
+                      )}
                     </div>
-                  ) : (
-                    <select
-                      value={selectedStageNumber}
-                      onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                      className="lp-stage-select"
-                      aria-label="ステージを選択"
+                    <button
+                      onClick={openDemo}
+                      className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
+                      aria-label="ファンタジーモード デモを再生"
                     >
-                      <option value="1-1">1-1</option>
-                      <option value="1-2">1-2</option>
-                      <option value="1-3">1-3</option>
-                      <option value="1-4">1-4</option>
-                    </select>
-                  )}
+                      体験する（全画面）
+                    </button>
+                  </div>
                 </div>
-                <button
-                  onClick={openDemo}
-                  className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
-                  aria-label="ファンタジーモード デモを再生"
-                >
-                  体験する（全画面）
-                </button>
-                {error && <div className="text-red-400 text-xs">{error}</div>}
               </div>
+              {error && <div className="absolute bottom-3 left-0 right-0 mx-auto text-center text-red-400 text-xs">{error}</div>}
             </div>
 
             {/* Device select + note */}


### PR DESCRIPTION
Add a smartphone-like frame to the LP demo mode section's call-to-action content to visually represent it as a mobile device.

---
<a href="https://cursor.com/background-agent?bcId=bc-68ba2501-a6f3-4b4b-bbb7-363c895ba442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68ba2501-a6f3-4b4b-bbb7-363c895ba442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

