### PR TITLE
Add iphone frame to demo section

### DIFF
--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -141,49 +141,53 @@ const LPFantasyDemo: React.FC = () => {
         <div className="rounded-2xl border border-purple-500/30 bg-slate-900/60 shadow-xl overflow-hidden">
           <div className="grid md:grid-cols-2 gap-0">
             {/* Visual + CTA */}
-            <div className="relative min-h-[192px] md:min-h-[224px]">
-              <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
-              <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
-                <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
-                <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
-                <div className="w-full flex items-center justify-center">
-                  {isPortrait ? (
-                    <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
-                      {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
-                        <button
-                          key={num}
-                          type="button"
-                          onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
-                          aria-pressed={selectedStageNumber === num}
-                          className={`h-11 rounded-full font-semibold text-sm transition-colors ${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'}`}
+            <div className="relative py-6 md:py-8 flex items-center justify-center">
+              <div className="lp-iphone">
+                <div className="lp-iphone-screen">
+                  <div className="absolute inset-0 bg-[url('/default_avater/default-avater.png')] bg-cover bg-center" />
+                  <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-black/30" />
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
+                    <h3 className="text-xl md:text-2xl font-bold text-purple-200 text-center">ファンタジーモード デモ</h3>
+                    <p className="text-gray-200 text-xs md:text-sm text-center max-w-md">MIDIキーボード／タッチ／クリック対応。全画面でシームレスにプレイ。</p>
+                    <div className="w-full flex items-center justify-center">
+                      {isPortrait ? (
+                        <div role="group" aria-label="ステージを選択" className="grid grid-cols-4 gap-2 w-64">
+                          {(['1-1','1-2','1-3','1-4'] as const).map((num) => (
+                            <button
+                              key={num}
+                              type="button"
+                              onClick={() => { setSelectedStageNumber(num); setStage(null); setError(null); }}
+                              aria-pressed={selectedStageNumber === num}
+                              className={`h-11 rounded-full font-semibold text-sm transition-colors ${selectedStageNumber === num ? 'bg-purple-600 text-white' : 'bg-black/50 text-white border border-white/20'}`}
+                            >
+                              {num}
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <select
+                          value={selectedStageNumber}
+                          onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
+                          className="lp-stage-select"
+                          aria-label="ステージを選択"
                         >
-                          {num}
-                        </button>
-                      ))}
+                          <option value="1-1">1-1</option>
+                          <option value="1-2">1-2</option>
+                          <option value="1-3">1-3</option>
+                          <option value="1-4">1-4</option>
+                        </select>
+                      )}
                     </div>
-                  ) : (
-                    <select
-                      value={selectedStageNumber}
-                      onChange={(e) => { setSelectedStageNumber(e.target.value as '1-1' | '1-2' | '1-3' | '1-4'); setStage(null); setError(null); }}
-                      className="lp-stage-select"
-                      aria-label="ステージを選択"
+                    <button
+                      onClick={openDemo}
+                      className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
+                      aria-label="ファンタジーモード デモを再生"
                     >
-                      <option value="1-1">1-1</option>
-                      <option value="1-2">1-2</option>
-                      <option value="1-3">1-3</option>
-                      <option value="1-4">1-4</option>
-                    </select>
-                  )}
+                      体験する（全画面）
+                    </button>
+                    {error && <div className="text-red-400 text-xs">{error}</div>}
+                  </div>
                 </div>
-                <button
-                  onClick={openDemo}
-                  className="h-11 w-56 md:h-12 md:w-64 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white font-bold shadow-2xl"
-                  aria-label="ファンタジーモード デモを再生"
-                >
-                  体験する（全画面）
-                </button>
-                {error && <div className="text-red-400 text-xs">{error}</div>}
               </div>
             </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -536,6 +536,55 @@
     padding-bottom: 10px;
     font-size: 16px;
   }
+
+  /* LPデモ: iPhone風フレーム */
+  .lp-iphone {
+    position: relative;
+    width: 16rem; /* 256px */
+    border-radius: 2.5rem;
+    background: #000;
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5), inset 0 0 8px rgba(255, 255, 255, 0.05);
+    padding: 14px 10px 42px; /* 上, 左右, 下(ホームボタン分) */
+  }
+  @media (min-width: 768px) {
+    .lp-iphone {
+      width: 18rem; /* 288px */
+      padding-bottom: 52px;
+    }
+  }
+  .lp-iphone::before {
+    content: '';
+    position: absolute;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 64px;
+    height: 6px;
+    background: #333;
+    border-radius: 9999px; /* 受話口 */
+  }
+  .lp-iphone::after {
+    content: '';
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 42px;
+    height: 42px;
+    border: 2px solid #666;
+    border-radius: 9999px; /* ホームボタン */
+    box-shadow: inset 0 0 4px rgba(255,255,255,0.2), 0 0 10px rgba(0,0,0,0.6);
+    background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.06), rgba(255,255,255,0.02) 60%, rgba(255,255,255,0) 70%);
+  }
+  .lp-iphone-screen {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 9 / 19.5; /* 画面比率 */
+    border-radius: 2rem;
+    overflow: hidden;
+    background: #0b0b0f;
+  }
   
   /* チェックボックススタイル */
   .checkbox {


### PR DESCRIPTION
Add an iPhone-style frame to the LP demo section to enhance its visual presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-139a5c38-1c8b-418a-a608-8a34c6564544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-139a5c38-1c8b-418a-a608-8a34c6564544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

