### PR TITLE
Investigate fantasy mode taiko note scrolling issue

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -778,6 +778,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const lastCompletedIndex = gameState.taikoNotes.length > 0
         ? (gameState.currentNoteIndex - 1 + gameState.taikoNotes.length) % gameState.taikoNotes.length
         : -1;
+      const lastCompletedChordId = lastCompletedIndex >= 0 ? gameState.taikoNotes[lastCompletedIndex].chord.id : null;
       
       // ループ対応：次ループは「2小節分だけ」先読みし、判定ライン右側のみ表示
       const timeToLoop = loopDuration - normalizedTime;
@@ -787,8 +788,12 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
 
           // 直前に消化したノーツはプレビューで復活させない
           if (i === lastCompletedIndex) continue;
+          // 直前の音と同一コードは、次ループ頭で一瞬に重なるため抑制（フラッシュ防止）
+          if (lastCompletedChordId && note.chord.id === lastCompletedChordId) continue;
           // すでに通常ノーツで表示しているものは重複させない
           if (displayedBaseIds.has(note.id)) continue;
+          // そのフレームでヒット済みのノーツはプレビューに出さない（復活防止）
+          if (note.isHit) continue;
 
           const virtualHitTime = note.hitTime + loopDuration;
           const timeUntilHit = virtualHitTime - normalizedTime;

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -757,8 +757,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 現在ループ基準の時間差
         const timeUntilHit = note.hitTime - normalizedTime;
 
-        // 判定ライン左側（過去）は描画しない
-        const lowerBound = 0;
+        // 判定ライン左側（過去）は短時間だけ表示して左へ流す
+        const lowerBound = -0.5;
 
         // 表示範囲内のノーツ（現在ループのみ）
         if (timeUntilHit >= lowerBound && timeUntilHit <= lookAheadTime) {


### PR DESCRIPTION
Fixes Taiko mode notes not flowing left of the judgment line in Fantasy mode.

Previously, the `lowerBound` for note rendering was set to `0` in `FantasyGameScreen.tsx`, causing notes to disappear immediately after passing the judgment line. This change sets `lowerBound` to `-0.5`, allowing notes to be visible for a short duration as they flow past the line.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e0f0fcd-5d75-41e5-980c-d5af41a66655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e0f0fcd-5d75-41e5-980c-d5af41a66655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

