### PR TITLE
Investigate taiko fantasy mode note flow bug

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -717,7 +717,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const lookAheadTime = 4; // 4秒先まで表示
       const noteSpeed = 400; // ピクセル/秒
       const previewWindow = 2 * secPerMeasure; // 次ループのプレビューは2小節分
-      const leftWindow = 0.6; // 判定ライン左側に残す時間（秒）
+      const leftWindow = 0.15; // 判定ライン左側に残す時間（秒）= Miss猶予と同程度に揃える
       
       // カウントイン中は複数ノーツを先行表示
       if (currentTime < 0) {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -717,6 +717,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       const lookAheadTime = 4; // 4秒先まで表示
       const noteSpeed = 400; // ピクセル/秒
       const previewWindow = 2 * secPerMeasure; // 次ループのプレビューは2小節分
+      const leftWindow = 0.6; // 判定ライン左側に残す時間（秒）
       
       // カウントイン中は複数ノーツを先行表示
       if (currentTime < 0) {
@@ -757,11 +758,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
         // 現在ループ基準の時間差
         const timeUntilHit = note.hitTime - normalizedTime;
 
-        // 判定ライン左側（過去）は描画しない
-        const lowerBound = 0;
-
-        // 表示範囲内のノーツ（現在ループのみ）
-        if (timeUntilHit >= lowerBound && timeUntilHit <= lookAheadTime) {
+        // 判定ライン左側も一定時間だけ表示する
+        if (timeUntilHit >= -leftWindow && timeUntilHit <= lookAheadTime) {
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
           notesToDisplay.push({
             id: note.id,
@@ -797,6 +795,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           if (timeUntilHit <= 0) continue;
           // 2小節分だけに制限
           if (timeUntilHit > previewWindow) break;
+
+          // 直近で判定ラインを越えたばかりのノーツは、左側表示を優先しプレビューに出さない
+          const currentLoopDelta = note.hitTime - normalizedTime; // 現在ループでの差（負値=通過済み）
+          if (currentLoopDelta > -leftWindow) continue;
 
           const x = judgeLinePos.x + timeUntilHit * noteSpeed;
           notesToDisplay.push({

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2066,7 +2066,12 @@ export class FantasyPIXIInstance {
     this.activeNotes.forEach((note, id) => {
       if (!notes.find(n => n.id === id)) {
         try {
-          if (note && !(note as any).destroyed) note.destroy({ children: true });
+          if (note && !(note as any).destroyed) {
+            if ((note as any).parent) {
+              (note as any).parent.removeChild(note as any);
+            }
+            (note as any).destroy({ children: true });
+          }
         } catch {}
         this.activeNotes.delete(id);
       }
@@ -2084,6 +2089,12 @@ export class FantasyPIXIInstance {
       } else {
         // 破棄済みなら作り直す
         if ((note as any).destroyed || !(note as any).transform) {
+          try {
+            if ((note as any).parent) {
+              (note as any).parent.removeChild(note as any);
+            }
+            (note as any).destroy?.({ children: true });
+          } catch {}
           note = this.createTaikoNote(noteData.id, noteData.chord, noteData.x);
           this.notesContainer.addChild(note);
           this.activeNotes.set(noteData.id, note);
@@ -2107,7 +2118,14 @@ export class FantasyPIXIInstance {
       // シングルモードの場合、判定ラインを非表示
       this.judgeLineContainer.visible = false;
       // ノーツもクリア
-      this.activeNotes.forEach(note => note.destroy());
+      this.activeNotes.forEach(note => {
+        try {
+          if ((note as any).parent) {
+            (note as any).parent.removeChild(note as any);
+          }
+          (note as any).destroy?.({ children: true });
+        } catch {}
+      });
       this.activeNotes.clear();
     }
   }

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2081,6 +2081,19 @@ export class FantasyPIXIInstance {
     notes.forEach(noteData => {
       let note = this.activeNotes.get(noteData.id);
       
+      // 画面外（極左）クリーンアップ（安全側）
+      if (note && !(note as any).destroyed && (note as any).transform) {
+        // 判定ラインは this.judgeLineX。大きく左に抜けているなら破棄
+        if (note.x < this.judgeLineX - 2000) {
+          try {
+            if ((note as any).parent) (note as any).parent.removeChild(note as any);
+            (note as any).destroy?.({ children: true });
+          } catch {}
+          this.activeNotes.delete(noteData.id);
+          note = undefined as any;
+        }
+      }
+      
       if (!note) {
         // 新しいノーツを作成
         note = this.createTaikoNote(noteData.id, noteData.chord, noteData.x);


### PR DESCRIPTION
Fix Taiko mode notes not flowing left past the judgment line and prevent immediate reappearance of the last note before a loop.

Previously, notes in Taiko Fantasy mode would disappear immediately upon crossing the judgment line. This PR introduces a `leftWindow` to keep them visible for a short period after passing the line. To prevent a regression where the last note of a loop would immediately reappear as a preview for the next loop, a proximity guard has been added to the preview logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-21bf151f-9e9b-4f60-8afc-c6901ff3e25d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21bf151f-9e9b-4f60-8afc-c6901ff3e25d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

