### PR TITLE
Reduce piano note velocity on input

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -497,7 +497,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     // クリック時にも音声を再生（MidiControllerの共通音声システムを使用）
     try {
       const { playNote } = await import('@/utils/MidiController');
-      await playNote(note, 80); // velocity 80で再生
+      await playNote(note, 64); // velocity 下げる
       activeNotesRef.current.add(note);
       devLog.debug('🎵 Played note via click:', note);
     } catch (error) {

--- a/src/components/fantasy/LPPIXIPiano.tsx
+++ b/src/components/fantasy/LPPIXIPiano.tsx
@@ -87,7 +87,7 @@ const LPPIXIPiano: React.FC<LPPIXIPianoProps> = ({
 
     renderer.setKeyCallbacks(
       (note: number) => {
-        playNote(note, 95);
+        playNote(note, 64);
       },
       (note: number) => {
         stopNote(note);

--- a/src/components/fantasy/OnScreenPiano.tsx
+++ b/src/components/fantasy/OnScreenPiano.tsx
@@ -81,7 +81,7 @@ const OnScreenPiano: React.FC<OnScreenPianoProps> = ({
     pointerIdToNoteRef.current.set(e.pointerId, note);
     setNoteActive(note, true);
     // velocityは固定（やや強め）
-    playNote(note, 100);
+    playNote(note, 64);
   };
 
   const handlePointerUpOrCancel = (e: React.PointerEvent) => {
@@ -106,7 +106,7 @@ const OnScreenPiano: React.FC<OnScreenPianoProps> = ({
     }
     map.set(e.pointerId, note);
     setNoteActive(note, true);
-    playNote(note, 90);
+    playNote(note, 64);
   };
 
   useEffect(() => {

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -825,7 +825,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     try {
       // 共通音声システムで音を鳴らす
       const { playNote } = await import('@/utils/MidiController');
-      await playNote(note, 100); // マウス/タッチ用の固定velocity
+      await playNote(note, 64); // マウス/タッチ用の固定velocity
       
       // ゲームエンジンにノート入力（ハイライトはGameEngineの状態更新に委ねる）
       handleNoteInput(note);


### PR DESCRIPTION
Lowered the fixed velocity for piano notes played via click/touch to 64 as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed1e354a-932c-4299-b2ce-153ea1ff481d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed1e354a-932c-4299-b2ce-153ea1ff481d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

