### PR TITLE
Reset previous song on new selection

### DIFF
--- a/src/components/game/ChordOverlay.tsx
+++ b/src/components/game/ChordOverlay.tsx
@@ -16,6 +16,11 @@ const ChordOverlay: React.FC = () => {
     return () => clearInterval(interval);
   }, [chords]);
 
+  // 楽曲が切り替わったら即座にクリア
+  useEffect(() => {
+    setCurrentChord('');
+  }, [chords]);
+
   return (
     <div
       className="pointer-events-none absolute inset-0 flex items-start justify-center"

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -129,9 +129,29 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       audio.preload = 'metadata';
       
       return () => {
+        // 旧リスナー解除
         audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
         audio.removeEventListener('error', handleError);
         audio.removeEventListener('canplay', handleCanPlay);
+        
+        // 旧音声の停止と解放
+        try { audio.pause(); } catch {}
+        try { audio.currentTime = 0; } catch {}
+        
+        // AudioNode/Toneノードの切断と解放
+        try {
+          if (mediaSourceRef.current) {
+            mediaSourceRef.current.disconnect();
+          }
+        } catch {}
+        try {
+          if (pitchShiftRef.current) {
+            pitchShiftRef.current.disconnect();
+          }
+        } catch {}
+        
+        // 再生同期ループ停止
+        stopTimeSync();
       };
     } else if (currentSong && (!currentSong.audioFile || currentSong.audioFile.trim() === '')) {
       // 音声ファイルなしの楽曲の場合

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -160,6 +160,10 @@ const GameScreen: React.FC = () => {
           }
           
           // レッスン設定を先に適用（loadSongの前に実行）
+          // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
+          gameActions.stop();
+          gameActions.clearSong();
+          
           await gameActions.updateSettings({
             transpose: key,
             playbackSpeed: speed,
@@ -358,6 +362,10 @@ const GameScreen: React.FC = () => {
           });
           
           // ミッション曲の条件を先に設定に適用（loadSongの前に実行）
+          // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
+          gameActions.stop();
+          gameActions.clearSong();
+          
           await gameActions.updateSettings({
             transpose: challengeSong.key_offset,
             playbackSpeed: challengeSong.min_speed,
@@ -747,6 +755,10 @@ const SongSelectionScreen: React.FC = () => {
                   // 通常曲選択時はレッスンコンテキストとミッションコンテキストをクリア
                   gameActions.clearLessonContext();
                   gameActions.clearMissionContext();
+                  
+                  // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
+                  gameActions.stop();
+                  gameActions.clearSong();
                   
                   console.log(`曲を選択: ${song.title}`);
                   try {


### PR DESCRIPTION
Add explicit song reset and audio resource cleanup to prevent duplicate playback and visual glitches on song change.

---
<a href="https://cursor.com/background-agent?bcId=bc-f72d2982-0c7a-48cb-b42f-f1488d8aff8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f72d2982-0c7a-48cb-b42f-f1488d8aff8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

