### PR TITLE
Fix lp midi device selection and audio settings

### DIFF
--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -13,6 +13,7 @@ import { PIXINotesRenderer, PIXINotesRendererInstance } from './PIXINotesRendere
 import ChordOverlay from './ChordOverlay';
 import * as Tone from 'tone';
 import { devLog, log, perfLog } from '@/utils/logger';
+import { updateGlobalVolume } from '@/utils/MidiController';
 
 // iOS検出関数
 const isIOS = (): boolean => {
@@ -382,6 +383,11 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       updateEngineSettings();
     }
   }, [settings.playbackSpeed, gameEngine, updateEngineSettings, isPlaying, currentTime]);
+
+  // MIDI音量が変更されたらグローバル音量へ即時反映（LP/ファンタジーと統一）
+  useEffect(() => {
+    try { updateGlobalVolume(settings.midiVolume); } catch {}
+  }, [settings.midiVolume]);
   
   // ===== 時間更新処理を軽量なsetIntervalで復活（競合ループ回避） =====
   const timeIntervalRef = useRef<number | null>(null);


### PR DESCRIPTION
Fix MIDI input not working after LP page reload and unify MIDI volume across modes.

The Web Audio context in LP did not initialize automatically after a page reload without user interaction, preventing MIDI input from producing sound. This PR ensures audio system initialization and MIDI connection restoration in LP, and standardizes MIDI volume application across all modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-99781df5-b9d6-4416-b6e2-17ce2cf3be8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99781df5-b9d6-4416-b6e2-17ce2cf3be8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

