### PR TITLE
Fix midi device sound loading and duplication

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -494,14 +494,16 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
       return;
     }
     
-    // クリック時にも音声を再生（MidiControllerの共通音声システムを使用）
-    try {
-      const { playNote } = await import('@/utils/MidiController');
-      await playNote(note, 64); // velocity 下げる
-      activeNotesRef.current.add(note);
-      devLog.debug('🎵 Played note via click:', note);
-    } catch (error) {
-      console.error('Failed to play note:', error);
+    // クリック時のみ音声を再生（MIDI経由はMIDIController側で再生する）
+    if (source === 'mouse') {
+      try {
+        const { playNote } = await import('@/utils/MidiController');
+        await playNote(note, 64); // velocity 下げる
+        activeNotesRef.current.add(note);
+        devLog.debug('🎵 Played note via click:', note);
+      } catch (error) {
+        console.error('Failed to play note:', error);
+      }
     }
     
     // ファンタジーゲームエンジンにのみ送信

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -105,6 +105,23 @@ const LPFantasyDemo: React.FC = () => {
       loadStage(selectedStageNumber);
     }
     setIsOpen(true);
+
+    // 音声システムを先行初期化（PIXIとは独立して即時応答性を確保）
+    try {
+      import('@/utils/MidiController').then(({ initializeAudioSystem, updateGlobalVolume }) => {
+        initializeAudioSystem().then(() => {
+          try { updateGlobalVolume(0.8); } catch {}
+        }).catch(() => {});
+      }).catch(() => {});
+    } catch {}
+
+    try {
+      import('@/utils/FantasySoundManager').then(async (mod) => {
+        const FSM = (mod as any).FantasySoundManager ?? mod.default;
+        try { await FSM?.init(settings.soundEffectVolume ?? 0.8, settings.rootSoundVolume ?? 0.5, true); } catch {}
+      }).catch(() => {});
+    } catch {}
+
     // dvh フォールバック変数を設定
     try {
       const setDvh = () => {

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -171,7 +171,9 @@ const LPFantasyDemo: React.FC = () => {
                   <div className="w-full max-w-[640px]">
                     {pianoVisible ? (
                       <Suspense fallback={<div className="text-center text-gray-300 text-sm">PIXIを読み込み中...</div>}>
-                        <LPPIXIPiano midiDeviceId={settings.selectedMidiDevice} height={isPortrait ? 120 : 150} />
+                        {!isOpen && (
+                          <LPPIXIPiano midiDeviceId={settings.selectedMidiDevice} height={isPortrait ? 120 : 150} />
+                        )}
                       </Suspense>
                     ) : (
                       <div className="w-full h-[120px] md:h-[150px] bg-black/40 rounded-md border border-white/10" />

--- a/src/utils/MidiController.ts
+++ b/src/utils/MidiController.ts
@@ -147,9 +147,8 @@ export const initializeAudioSystem = async (): Promise<void> => {
       usingPianoInstrument = true;
       console.log('🎹 Using @tonejs/piano instrument');
 
-      // すべてのサンプルを事前読み込み
-      await piano.load();
-      console.log('✅ Piano samples loaded');
+      // 事前読み込みはバックグラウンドで実行して初回音出しをブロックしない
+      piano.load().then(() => console.log('✅ Piano samples loaded (bg)')).catch((err: any) => console.warn('⚠️ Piano preload failed (bg):', err));
     } catch (e) {
       console.warn('⚠️ Failed to initialize @tonejs/piano. Falling back to Tone.Sampler:', e);
 


### PR DESCRIPTION
Optimizes initial sound loading and resolves sound duplication issues in demo mode.

Previously, initial tone loading blocked the UI for ~10 seconds due to synchronous sample preloading. Sound duplication occurred in demo mode because both the LP mini-piano and the demo's sound system were playing notes from MIDI input, and the demo itself was redundantly playing notes received via MIDI.

---
<a href="https://cursor.com/background-agent?bcId=bc-03103df1-17e5-4bec-a115-bcae53dc36b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03103df1-17e5-4bec-a115-bcae53dc36b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

