### PR TITLE
Improve piano audio enable text visibility

### DIFF
--- a/src/components/fantasy/LPPIXIPiano.tsx
+++ b/src/components/fantasy/LPPIXIPiano.tsx
@@ -191,8 +191,11 @@ const LPPIXIPiano: React.FC<LPPIXIPianoProps> = ({
             setShowPrompt(false);
             setAudioReady(true);
           }}
-          className="absolute bottom-2 right-2 z-10 px-2 py-1 text-[11px] text-white/80 bg-transparent hover:text-white"
+          className="absolute bottom-3 right-3 z-20 px-3 py-2 text-white text-[13px] md:text-sm bg-black/60 backdrop-blur-sm rounded-full shadow-lg ring-1 ring-white/20 hover:bg-black/70 hover:ring-white/30 transition pointer-events-auto select-none font-medium flex items-center gap-1.5 animate-pulse"
+          aria-label="音声を有効化"
+          title="音声を有効化"
         >
+          <span className="inline-block">🔊</span>
           タップして音声を有効化
         </button>
       )}


### PR DESCRIPTION
Improve visibility of "Tap to enable audio" text in LP demo's iPhone frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-78a5dd07-65f6-447e-b206-5a7f8fc44474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78a5dd07-65f6-447e-b206-5a7f8fc44474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

