### PR TITLE
ランキングページ仕様定義と段階読み込み実装

### DIFF
--- a/src/components/ranking/LevelRanking.tsx
+++ b/src/components/ranking/LevelRanking.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { fetchLevelRanking, RankingEntry, fetchLevelRankingByView, fetchUserGlobalRank } from '@/platform/supabaseRanking';
+import { fetchLevelRanking, RankingEntry, fetchLevelRankingByView, fetchUserGlobalRank, fetchLessonRankingByRpc, fetchUserLessonRank } from '@/platform/supabaseRanking';
 import { useAuthStore } from '@/stores/authStore';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
@@ -109,38 +109,37 @@ const LevelRanking: React.FC = () => {
   const scrollToMyRow = async () => {
     if (!user) return;
 
-    // 1) RPCで自分の全体順位を取得
     try {
-      const globalRank = await fetchUserGlobalRank(user.id);
-      if (!globalRank || globalRank <= 0) {
-        // 既存の読み込み範囲にあるかを試しにスクロール
-        const el = document.querySelector(`[data-user-id="${user.id}"]`);
-        if (el && 'scrollIntoView' in el) {
-          (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
-          return;
-        }
-        alert('あなたの順位を特定できませんでした。もう一度お試しください。');
-        return;
+      const PAGE_SIZE_NUM = 50;
+
+      if (sortKey === 'lessons' && !isStandardGlobal) {
+        // レッスン数ベースの順位でページジャンプ
+        const lessonRank = await fetchUserLessonRank(user.id);
+        if (!lessonRank || lessonRank <= 0) throw new Error('rank not found');
+        const pageOffset = Math.floor((lessonRank - 1) / PAGE_SIZE_NUM) * PAGE_SIZE_NUM;
+        const page = await fetchLessonRankingByRpc(PAGE_SIZE_NUM, pageOffset);
+        const adjusted = page; // レッスン列はnon-standardのみ表示なのでそのまま
+        setEntries(prev => {
+          const map = new Map(prev.map(e => [e.id, e] as const));
+          adjusted.forEach(e => map.set(e.id, e));
+          return sortEntries(Array.from(map.values()), sortKey);
+        });
+      } else {
+        // レベルベースの順位でページジャンプ
+        const globalRank = await fetchUserGlobalRank(user.id);
+        if (!globalRank || globalRank <= 0) throw new Error('rank not found');
+        const pageOffset = Math.floor((globalRank - 1) / PAGE_SIZE_NUM) * PAGE_SIZE_NUM;
+        const page = await fetchLevelRankingByView(PAGE_SIZE_NUM, pageOffset);
+        const adjusted = isStandardGlobal
+          ? page.map(e => ({ ...e, lessons_cleared: 0, missions_completed: 0 }))
+          : page;
+        setEntries(prev => {
+          const exist = new Map(prev.map(e => [e.id, e] as const));
+          adjusted.forEach(e => exist.set(e.id, e));
+          return sortEntries(Array.from(exist.values()), sortKey);
+        });
       }
 
-      // 2) 対象ページのoffsetを算出（50件単位）
-      const PAGE_SIZE_NUM = 50;
-      const pageOffset = Math.floor((globalRank - 1) / PAGE_SIZE_NUM) * PAGE_SIZE_NUM;
-
-      // 3) 対象ページをRPCで一発取得
-      const page = await fetchLevelRankingByView(PAGE_SIZE_NUM, pageOffset);
-      const adjusted = isStandardGlobal
-        ? page.map(e => ({ ...e, lessons_cleared: 0, missions_completed: 0 }))
-        : page;
-
-      // 4) 現在のentriesにマージして再ソート
-      setEntries(prev => {
-        const exist = new Map(prev.map(e => [e.id, e] as const));
-        adjusted.forEach(e => exist.set(e.id, e));
-        return sortEntries(Array.from(exist.values()), sortKey);
-      });
-
-      // 5) スクロール
       setTimeout(() => {
         const el = document.querySelector(`[data-user-id="${user.id}"]`);
         if (el && 'scrollIntoView' in el) {

--- a/src/components/ranking/MissionRanking.tsx
+++ b/src/components/ranking/MissionRanking.tsx
@@ -3,20 +3,23 @@ import { fetchMissionRanking, MissionRankingEntry } from '@/platform/supabaseRan
 import { useMissionStore } from '@/stores/missionStore';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { FaArrowLeft, FaTrophy, FaMedal, FaCrown, FaGem, FaStar } from 'react-icons/fa';
+import { FaArrowLeft, FaTrophy, FaMedal, FaCrown, FaGem, FaStar, FaSearch, FaPlus } from 'react-icons/fa';
 import { useAuthStore } from '@/stores/authStore';
 
 const MissionRanking: React.FC = () => {
   const [open, setOpen] = useState(window.location.hash === '#mission-ranking'); // This page will not be reachable for Standard(Global)
   const [entries, setEntries] = useState<MissionRankingEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { monthly } = useMissionStore();
   const [missionId, setMissionId] = useState<string | null>(null);
   // If needed later, we can add gating like in LevelRanking header.
-  const { profile } = useAuthStore();
+  const { profile, user } = useAuthStore();
   const isStandardGlobal = profile?.rank === 'standard_global';
-
+  const PAGE_SIZE = 50;
+  const [offset, setOffset] = useState(0);
 
   useEffect(() => {
     const handler = () => setOpen(window.location.hash === '#mission-ranking');
@@ -30,21 +33,47 @@ const MissionRanking: React.FC = () => {
     }
   }, [open, monthly, missionId]);
 
+  const resetAndLoad = async (mId: string) => {
+    setLoading(true);
+    setError(null);
+    setEntries([]);
+    setHasMore(true);
+    setOffset(0);
+    try {
+      const data = await fetchMissionRanking(mId, PAGE_SIZE, 0);
+      setEntries(data);
+      setOffset(PAGE_SIZE);
+      setHasMore(data.length >= PAGE_SIZE);
+    } catch (err) {
+      console.error('ミッションランキング取得エラー:', err);
+      setError('ランキングデータの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMore = async () => {
+    if (!missionId || loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const data = await fetchMissionRanking(missionId, PAGE_SIZE, offset);
+      setEntries(prev => {
+        const exist = new Set(prev.map(e => e.user_id));
+        return [...prev, ...data.filter(e => !exist.has(e.user_id))];
+      });
+      setOffset(prev => prev + PAGE_SIZE);
+      setHasMore(data.length >= PAGE_SIZE);
+    } catch (err) {
+      console.error('ミッションランキング取得エラー:', err);
+      setError('ランキングデータの取得に失敗しました');
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
   useEffect(() => {
     if (open && missionId) {
-      (async () => {
-        setLoading(true);
-        setError(null);
-        try {
-          const data = await fetchMissionRanking(missionId);
-          setEntries(data);
-        } catch (err) {
-          console.error('ミッションランキング取得エラー:', err);
-          setError('ランキングデータの取得に失敗しました');
-        } finally {
-          setLoading(false);
-        }
-      })();
+      resetAndLoad(missionId);
     }
   }, [open, missionId]);
 
@@ -95,6 +124,16 @@ const MissionRanking: React.FC = () => {
     }
   };
 
+  const scrollToMyRow = () => {
+    if (!user) return;
+    const el = document.querySelector(`[data-user-id="${user.id}"]`);
+    if (el && 'scrollIntoView' in el) {
+      (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+      alert('現在の表示範囲内にあなたのデータはありません。必要に応じて「さらに読み込む」を押してください。');
+    }
+  };
+
   return (
     <div className="w-full h-full flex flex-col bg-gradient-game text-white">
       <GameHeader />
@@ -132,6 +171,23 @@ const MissionRanking: React.FC = () => {
             </div>
           )}
 
+          {/* アクションバー */}
+          <div className="flex flex-wrap items-center justify-center gap-2 mb-4">
+            <button
+              onClick={scrollToMyRow}
+              className="px-3 py-2 rounded-lg text-sm font-medium transition-colors bg-slate-700 text-gray-200 hover:bg-slate-600 inline-flex items-center gap-2"
+            >
+              <FaSearch /> 自分を探す
+            </button>
+            <button
+              onClick={loadMore}
+              disabled={!hasMore || loadingMore}
+              className={`px-3 py-2 rounded-lg text-sm font-medium inline-flex items-center gap-2 ${!hasMore ? 'bg-slate-800 text-gray-500' : 'bg-primary-600 text-white hover:bg-primary-500'} ${loadingMore ? 'opacity-70' : ''}`}
+            >
+              <FaPlus /> さらに読み込む（50件）
+            </button>
+          </div>
+
           {/* エラー表示 */}
           {error && (
             <div className="mb-6 p-4 bg-red-900/50 border border-red-700 rounded-lg">
@@ -166,7 +222,7 @@ const MissionRanking: React.FC = () => {
                   </thead>
                   <tbody>
                     {entries.map((entry, idx) => (
-                      <tr key={entry.user_id} className="border-b border-slate-700 hover:bg-slate-700/50 transition-colors">
+                      <tr key={entry.user_id} data-user-id={entry.user_id} className="border-b border-slate-700 hover:bg-slate-700/50 transition-colors">
                         <td className="py-4 px-4">
                           <div className="flex items-center space-x-2">
                             {getRankIcon(idx)}
@@ -200,7 +256,7 @@ const MissionRanking: React.FC = () => {
                               entry.rank === 'premium' ? 'bg-yellow-600 text-white' :
                               entry.rank === 'standard' ? 'bg-blue-600 text-white' :
                               'bg-gray-600 text-white'
-                            }`}>
+                            }` }>
                               {entry.rank.toUpperCase()}
                             </span>
                           </div>

--- a/src/platform/supabaseRanking.ts
+++ b/src/platform/supabaseRanking.ts
@@ -168,3 +168,30 @@ export async function fetchUserMissionRank(missionId: string, userId: string): P
   if (error) throw error;
   return (data as number | null) ?? null;
 }
+
+export async function fetchLessonRankingByRpc(limit = 50, offset = 0): Promise<RankingEntry[]> {
+  const { data, error } = await getSupabaseClient()
+    .rpc('rpc_get_lesson_ranking', { limit_count: limit, offset_count: offset });
+  if (error) throw error;
+  const rows = (data ?? []) as any[];
+  return rows.map((r) => ({
+    id: r.id,
+    nickname: r.nickname,
+    level: r.level,
+    xp: Number(r.xp),
+    rank: r.rank,
+    lessons_cleared: r.lessons_cleared ?? 0,
+    missions_completed: r.missions_completed ?? 0,
+    avatar_url: r.avatar_url ?? undefined,
+    twitter_handle: r.twitter_handle ?? undefined,
+    selected_title: r.selected_title ?? undefined,
+    fantasy_current_stage: r.fantasy_current_stage !== null && r.fantasy_current_stage !== undefined ? String(r.fantasy_current_stage) : undefined,
+  })) as unknown as RankingEntry[];
+}
+
+export async function fetchUserLessonRank(userId: string): Promise<number | null> {
+  const { data, error } = await getSupabaseClient()
+    .rpc('rpc_get_user_lesson_rank', { target_user_id: userId });
+  if (error) throw error;
+  return (data as number | null) ?? null;
+}

--- a/src/platform/supabaseRanking.ts
+++ b/src/platform/supabaseRanking.ts
@@ -154,3 +154,17 @@ export async function fetchUserGlobalRank(userId: string): Promise<number | null
   if (error) throw error;
   return (data as number | null) ?? null;
 }
+
+export async function fetchMissionRankingByRpc(missionId: string, limit = 50, offset = 0): Promise<MissionRankingEntry[]> {
+  const { data, error } = await getSupabaseClient()
+    .rpc('rpc_get_mission_ranking', { mission_id: missionId, limit_count: limit, offset_count: offset });
+  if (error) throw error;
+  return (data ?? []) as MissionRankingEntry[];
+}
+
+export async function fetchUserMissionRank(missionId: string, userId: string): Promise<number | null> {
+  const { data, error } = await getSupabaseClient()
+    .rpc('rpc_get_user_mission_rank', { mission_id: missionId, target_user_id: userId });
+  if (error) throw error;
+  return (data as number | null) ?? null;
+}

--- a/supabase/migrations/20250817093000_create_level_ranking_view_and_rpc.sql
+++ b/supabase/migrations/20250817093000_create_level_ranking_view_and_rpc.sql
@@ -1,0 +1,72 @@
+-- Create or replace view and RPC for accurate level ranking with global rank
+
+-- Safety first
+DROP VIEW IF EXISTS public.view_level_ranking CASCADE;
+
+CREATE VIEW public.view_level_ranking AS
+SELECT
+  p.id,
+  p.nickname,
+  p.level,
+  p.xp,
+  p.rank,
+  p.avatar_url,
+  p.twitter_handle,
+  p.selected_title,
+  f.current_stage_number AS fantasy_current_stage,
+  COALESCE(l.lessons_cleared, 0) AS lessons_cleared,
+  COALESCE(m.missions_completed, 0) AS missions_completed,
+  ROW_NUMBER() OVER (ORDER BY p.level DESC, p.xp DESC, p.id ASC) AS global_rank
+FROM public.profiles AS p
+LEFT JOIN (
+  SELECT ulp.user_id, COUNT(*) AS lessons_cleared
+  FROM public.user_lesson_progress ulp
+  WHERE ulp.completed = true
+  GROUP BY ulp.user_id
+) AS l ON l.user_id = p.id
+LEFT JOIN (
+  SELECT ucp.user_id, COALESCE(SUM(ucp.clear_count), 0) AS missions_completed
+  FROM public.user_challenge_progress ucp
+  WHERE ucp.completed = true
+  GROUP BY ucp.user_id
+) AS m ON m.user_id = p.id
+LEFT JOIN (
+  SELECT fup.user_id, fup.current_stage_number
+  FROM public.fantasy_user_progress fup
+) AS f ON f.user_id = p.id
+WHERE p.nickname IS NOT NULL
+  AND p.nickname <> p.email;
+
+-- RPC: get paginated ranking from the view
+DROP FUNCTION IF EXISTS public.rpc_get_level_ranking(limit_count integer, offset_count integer);
+
+CREATE FUNCTION public.rpc_get_level_ranking(limit_count integer DEFAULT 50, offset_count integer DEFAULT 0)
+RETURNS SETOF public.view_level_ranking
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT *
+  FROM public.view_level_ranking
+  ORDER BY global_rank
+  OFFSET offset_count
+  LIMIT limit_count;
+$$;
+
+-- RPC: get a user's global rank
+DROP FUNCTION IF EXISTS public.rpc_get_user_global_rank(target_user_id uuid);
+
+CREATE FUNCTION public.rpc_get_user_global_rank(target_user_id uuid)
+RETURNS integer
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT v.global_rank
+  FROM public.view_level_ranking v
+  WHERE v.id = target_user_id
+  LIMIT 1;
+$$;
+
+-- Optional grants (adjust roles as needed)
+-- GRANT SELECT ON public.view_level_ranking TO anon, authenticated;
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_level_ranking(integer, integer) TO anon, authenticated;
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_user_global_rank(uuid) TO anon, authenticated;

--- a/supabase/migrations/20250817094500_create_mission_ranking_rpcs.sql
+++ b/supabase/migrations/20250817094500_create_mission_ranking_rpcs.sql
@@ -1,0 +1,63 @@
+-- Mission ranking RPCs: paginated fetch and user rank by mission
+
+-- Drop if exist to allow idempotent re-apply in staging
+DROP FUNCTION IF EXISTS public.rpc_get_mission_ranking(mission_id uuid, limit_count integer, offset_count integer);
+DROP FUNCTION IF EXISTS public.rpc_get_user_mission_rank(mission_id uuid, target_user_id uuid);
+
+-- Paginated mission ranking for a given mission_id
+CREATE FUNCTION public.rpc_get_mission_ranking(
+  mission_id uuid,
+  limit_count integer DEFAULT 50,
+  offset_count integer DEFAULT 0
+)
+RETURNS TABLE (
+  user_id uuid,
+  clear_count integer,
+  nickname text,
+  avatar_url text,
+  level integer,
+  rank text
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    ucp.user_id,
+    ucp.clear_count,
+    p.nickname,
+    p.avatar_url,
+    p.level,
+    p.rank
+  FROM public.user_challenge_progress ucp
+  JOIN public.profiles p ON p.id = ucp.user_id
+  WHERE ucp.challenge_id = mission_id
+    AND ucp.completed = true
+  ORDER BY ucp.clear_count DESC, p.level DESC, p.xp DESC, ucp.user_id ASC
+  OFFSET offset_count
+  LIMIT limit_count;
+$$;
+
+-- Get a user's rank for a given mission
+CREATE FUNCTION public.rpc_get_user_mission_rank(
+  mission_id uuid,
+  target_user_id uuid
+)
+RETURNS integer
+LANGUAGE sql
+STABLE
+AS $$
+  WITH ranked AS (
+    SELECT
+      ucp.user_id,
+      ROW_NUMBER() OVER (ORDER BY ucp.clear_count DESC, p.level DESC, p.xp DESC, ucp.user_id ASC) AS rn
+    FROM public.user_challenge_progress ucp
+    JOIN public.profiles p ON p.id = ucp.user_id
+    WHERE ucp.challenge_id = mission_id
+      AND ucp.completed = true
+  )
+  SELECT rn FROM ranked WHERE user_id = target_user_id LIMIT 1;
+$$;
+
+-- Optional grants
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_mission_ranking(uuid, integer, integer) TO anon, authenticated;
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_user_mission_rank(uuid, uuid) TO anon, authenticated;

--- a/supabase/migrations/20250817095500_create_lesson_ranking_rpcs.sql
+++ b/supabase/migrations/20250817095500_create_lesson_ranking_rpcs.sql
@@ -1,0 +1,114 @@
+-- Lesson ranking RPCs: paginated fetch and user rank by lessons cleared
+
+-- Idempotent drops for re-apply
+DROP FUNCTION IF EXISTS public.rpc_get_lesson_ranking(limit_count integer, offset_count integer);
+DROP FUNCTION IF EXISTS public.rpc_get_user_lesson_rank(target_user_id uuid);
+
+-- Paginated lesson ranking (by lessons_cleared DESC, then level DESC, xp DESC, id ASC)
+CREATE FUNCTION public.rpc_get_lesson_ranking(
+  limit_count integer DEFAULT 50,
+  offset_count integer DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  nickname text,
+  level integer,
+  xp bigint,
+  rank text,
+  avatar_url text,
+  twitter_handle text,
+  selected_title text,
+  fantasy_current_stage text,
+  lessons_cleared integer,
+  missions_completed integer
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH l AS (
+    SELECT ulp.user_id, COUNT(*) AS lessons_cleared
+    FROM public.user_lesson_progress ulp
+    WHERE ulp.completed = true
+    GROUP BY ulp.user_id
+  ),
+  m AS (
+    SELECT ucp.user_id, COALESCE(SUM(ucp.clear_count), 0) AS missions_completed
+    FROM public.user_challenge_progress ucp
+    WHERE ucp.completed = true
+    GROUP BY ucp.user_id
+  ),
+  f AS (
+    SELECT fup.user_id, fup.current_stage_number
+    FROM public.fantasy_user_progress fup
+  ),
+  base AS (
+    SELECT
+      p.id,
+      p.nickname,
+      p.level,
+      p.xp,
+      p.rank,
+      p.avatar_url,
+      p.twitter_handle,
+      p.selected_title,
+      f.current_stage_number AS fantasy_current_stage,
+      COALESCE(l.lessons_cleared, 0) AS lessons_cleared,
+      COALESCE(m.missions_completed, 0) AS missions_completed
+    FROM public.profiles p
+    LEFT JOIN l ON l.user_id = p.id
+    LEFT JOIN m ON m.user_id = p.id
+    LEFT JOIN f ON f.user_id = p.id
+    WHERE p.nickname IS NOT NULL
+      AND p.nickname <> p.email
+  ), ranked AS (
+    SELECT *, ROW_NUMBER() OVER (ORDER BY lessons_cleared DESC, level DESC, xp DESC, id ASC) AS rn
+    FROM base
+  )
+  SELECT
+    id,
+    nickname,
+    level,
+    xp,
+    rank,
+    avatar_url,
+    twitter_handle,
+    selected_title,
+    fantasy_current_stage,
+    lessons_cleared,
+    missions_completed
+  FROM ranked
+  ORDER BY rn
+  OFFSET offset_count
+  LIMIT limit_count;
+$$;
+
+-- Get user's lesson rank
+CREATE FUNCTION public.rpc_get_user_lesson_rank(
+  target_user_id uuid
+)
+RETURNS integer
+LANGUAGE sql
+STABLE
+AS $$
+  WITH l AS (
+    SELECT ulp.user_id, COUNT(*) AS lessons_cleared
+    FROM public.user_lesson_progress ulp
+    WHERE ulp.completed = true
+    GROUP BY ulp.user_id
+  ),
+  base AS (
+    SELECT p.id, p.level, p.xp, COALESCE(l.lessons_cleared, 0) AS lessons_cleared
+    FROM public.profiles p
+    LEFT JOIN l ON l.user_id = p.id
+    WHERE p.nickname IS NOT NULL
+      AND p.nickname <> p.email
+  ), ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY lessons_cleared DESC, level DESC, xp DESC, id ASC) AS rn
+    FROM base
+  )
+  SELECT rn FROM ranked WHERE id = target_user_id LIMIT 1;
+$$;
+
+-- Optional grants
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_lesson_ranking(integer, integer) TO anon, authenticated;
+-- GRANT EXECUTE ON FUNCTION public.rpc_get_user_lesson_rank(uuid) TO anon, authenticated;


### PR DESCRIPTION
Add 'find my rank' and paginated loading to ranking pages for improved user experience.

This PR addresses user requests to easily find their own rank and browse more entries via 50-item incremental loading. It also enables Mission Ranking visibility for 'Standard' plan users, while maintaining existing restrictions for 'Standard(Global)' users. Server-side views and RPCs are included for future integration of exact global rank display.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae609761-ecd6-4bf2-bbcc-09fbe97bfdc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae609761-ecd6-4bf2-bbcc-09fbe97bfdc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

