### PR TITLE
Remove extra community header from diary page

### DIFF
--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -140,19 +140,6 @@ const DiaryPage: React.FC = () => {
         <GameHeader />
         <div className="flex-1 overflow-y-auto p-4">
           <div className="fixed inset-0 z-40 flex flex-col bg-slate-900 text-white overflow-y-auto">
-            {/* ヘッダー */}
-            <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-700">
-              <button
-                onClick={handleClose}
-                className="p-2 hover:bg-slate-800 rounded-lg transition-colors"
-                aria-label="戻る"
-              >
-                <FaArrowLeft />
-              </button>
-              <h2 className="text-xl font-bold text-center flex-1">コミュニティ</h2>
-              <div className="w-8" /> {/* スペーサー */}
-            </div>
-
             <div className="p-4 flex-1 overflow-y-auto space-y-4">
               <DiaryEditor />
               <DiaryFeed />


### PR DESCRIPTION
Remove the redundant 'Community' header from the diary page while retaining the game header.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a4b6571-54fc-458a-8c9f-c13a4456a937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a4b6571-54fc-458a-8c9f-c13a4456a937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

