### PR TITLE
Remove lesson and user diary headers

### DIFF
--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -210,17 +210,6 @@ const DiaryPage: React.FC = () => {
       <GameHeader />
       <div className="flex-1 overflow-y-auto p-4">
         <div className="fixed inset-0 z-40 flex flex-col bg-slate-900 text-white">
-          {/* ヘッダー */}
-          <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-700">
-            <button
-              onClick={handleClose}
-              className="p-2 hover:bg-slate-800 rounded-lg transition-colors"
-              aria-label="戻る"
-            >
-              <FaArrowLeft />
-            </button>
-            <div className="w-8" /> {/* スペーサー */}
-          </div>
 
           {/* コンテンツエリア - プロフィールと日記を一緒にスクロール */}
           <div className="flex-1 overflow-y-auto">

--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -219,7 +219,6 @@ const DiaryPage: React.FC = () => {
             >
               <FaArrowLeft />
             </button>
-            <h2 className="text-xl font-bold text-center flex-1">ユーザー日記</h2>
             <div className="w-8" /> {/* スペーサー */}
           </div>
 

--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -209,7 +209,7 @@ const DiaryPage: React.FC = () => {
     <div className="w-full h-full flex flex-col bg-gradient-game text-white">
       <GameHeader />
       <div className="flex-1 overflow-y-auto p-4">
-        <div className="fixed inset-0 z-40 flex flex-col bg-slate-900 text-white">
+        <div className="fixed inset-0 z-40 flex flex-col bg-slate-900 text-white pt-14 sm:pt-16">
 
           {/* コンテンツエリア - プロフィールと日記を一緒にスクロール */}
           <div className="flex-1 overflow-y-auto">

--- a/src/components/lesson/LessonPage.tsx
+++ b/src/components/lesson/LessonPage.tsx
@@ -390,7 +390,6 @@ const LessonPage: React.FC = () => {
             >
               <FaArrowLeft />
             </button>
-            <h1 className="text-xl font-bold">レッスン</h1>
             <div className="w-8" /> {/* スペーサー */}
           </div>
 

--- a/src/components/lesson/LessonPage.tsx
+++ b/src/components/lesson/LessonPage.tsx
@@ -380,7 +380,7 @@ const LessonPage: React.FC = () => {
     <div className="w-full h-full flex flex-col bg-gradient-game text-white">
       <GameHeader />
       <div className="flex-1 overflow-y-auto p-4">
-        <div className="fixed inset-0 z-50 bg-slate-900 text-white flex flex-col">
+        <div className="fixed inset-0 z-50 bg-slate-900 text-white flex flex-col pt-14 sm:pt-16">
 
           {loading ? (
             <div className="flex-1 flex items-center justify-center">

--- a/src/components/lesson/LessonPage.tsx
+++ b/src/components/lesson/LessonPage.tsx
@@ -381,17 +381,6 @@ const LessonPage: React.FC = () => {
       <GameHeader />
       <div className="flex-1 overflow-y-auto p-4">
         <div className="fixed inset-0 z-50 bg-slate-900 text-white flex flex-col">
-          {/* ヘッダー */}
-          <div className="flex items-center justify-between p-4 border-b border-slate-700">
-            <button
-              onClick={handleClose}
-              className="p-2 hover:bg-slate-800 rounded-lg transition-colors"
-              aria-label="戻る"
-            >
-              <FaArrowLeft />
-            </button>
-            <div className="w-8" /> {/* スペーサー */}
-          </div>
 
           {loading ? (
             <div className="flex-1 flex items-center justify-center">


### PR DESCRIPTION
Remove 'レッスン' and 'ユーザー日記' headers from Lesson and Diary pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-e62b4e75-fdfa-488c-8703-669376781729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e62b4e75-fdfa-488c-8703-669376781729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

