### PR TITLE
ユーザーアイコンから詳細ページへ遷移

### DIFF
--- a/src/components/diary/DiaryFeed.tsx
+++ b/src/components/diary/DiaryFeed.tsx
@@ -152,7 +152,9 @@ const DiaryFeed: React.FC = () => {
       {diaries.map(d => (
         <div key={d.id} className="p-3 sm:p-4 bg-slate-800 rounded-lg">
           <div className="flex items-center mb-2 space-x-2 text-sm text-gray-300">
-            <Avatar url={d.avatar_url} />
+            <button onClick={()=>{window.location.hash=`#diary-user?id=${d.user_id}`;}} className="rounded-full">
+              <Avatar url={d.avatar_url} />
+            </button>
             <div className="flex-1 min-w-0">
               <button
                 onClick={() => {
@@ -271,7 +273,9 @@ const DiaryFeed: React.FC = () => {
                 <div className="absolute right-0 top-full mt-1 z-10 bg-slate-700 p-2 rounded shadow-lg w-52 max-h-60 overflow-y-auto space-y-1 whitespace-nowrap">
                   {likeUsers[d.id]?.map(u=> (
                     <div key={u.user_id} className="flex items-center space-x-2 text-xs text-gray-200">
-                      <Avatar url={u.avatar_url} />
+                      <button onClick={()=>{window.location.hash=`#diary-user?id=${u.user_id}`;}} className="rounded-full">
+                        <Avatar url={u.avatar_url} />
+                      </button>
                       <button
                         onClick={()=>{window.location.hash=`#diary-user?id=${u.user_id}`;}}
                         className="font-semibold truncate hover:text-blue-400 transition-colors"

--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -371,8 +371,10 @@ const DiaryPage: React.FC = () => {
                             <div className="absolute right-4 top-12 bg-slate-700 rounded shadow-lg p-2 w-52 max-h-60 overflow-y-auto space-y-1 z-20 whitespace-nowrap">
                               {likeUsers[diary.id].map(u=>(
                                 <div key={u.user_id} className="flex items-center space-x-2 text-xs text-gray-200">
-                                  <img src={u.avatar_url||DEFAULT_AVATAR_URL} className="w-6 h-6 rounded-full object-cover" />
-                                  <span className="truncate">{u.nickname}</span>
+                                  <button onClick={()=>{window.location.href=`/main#diary-user?id=${u.user_id}`;}}>
+                                    <img src={u.avatar_url||DEFAULT_AVATAR_URL} className="w-6 h-6 rounded-full object-cover" />
+                                  </button>
+                                  <button className="truncate hover:text-blue-400" onClick={()=>{window.location.href=`/main#diary-user?id=${u.user_id}`;}}>{u.nickname}</button>
                                   <span className="text-yellow-400">Lv.{u.level}</span>
                                   <div className="flex items-center space-x-1">
                                     {getRankIcon(u.rank)}


### PR DESCRIPTION
Enable navigation to user profile pages by tapping user icons/avatars on diary-related pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6daaa61-069c-4bab-a9e4-19f3dd864469">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6daaa61-069c-4bab-a9e4-19f3dd864469">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

