### PR TITLE
ゲームの曲選択をレジェンドモードに変更

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -383,7 +383,7 @@ const Dashboard: React.FC = () => {
                 >
                   <div className="flex items-center space-x-3 mb-3">
                     <FaMusic className="w-6 h-6 text-green-400" />
-                    <h3 className="text-lg font-semibold">曲練習</h3>
+                    <h3 className="text-lg font-semibold">レジェンドモード</h3>
                   </div>
                   <p className="text-sm text-gray-400">
                     楽曲を選んで練習を開始

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -660,7 +660,7 @@ const SongSelectionScreen: React.FC = () => {
     <div className="flex-1 p-3 sm:p-6 overflow-auto">
       <div className="max-w-6xl mx-auto">
         <div className="flex items-center justify-between mb-4 sm:mb-6">
-          <h2 className="text-xl sm:text-2xl font-bold text-white">楽曲選択</h2>
+          <h2 className="text-xl sm:text-2xl font-bold text-white">レジェンドモード</h2>
           <div className="text-sm text-gray-400">
             {sortedSongs.length} 曲
           </div>

--- a/src/components/ui/GameHeader.tsx
+++ b/src/components/ui/GameHeader.tsx
@@ -37,7 +37,7 @@ const GameHeader: React.FC = () => {
               }}
               disabled={isGuest}
             >
-              曲選択
+              レジェンド
             </HashButton>
           )}
 


### PR DESCRIPTION
Update UI text for song selection to "レジェンドモード" and "レジェンド" as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d080765-cbcf-4806-8f7d-fc3289b5a262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d080765-cbcf-4806-8f7d-fc3289b5a262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

