### PR TITLE
Investigate game mode loading issues and caching

### DIFF
--- a/src/platform/supabaseRanking.ts
+++ b/src/platform/supabaseRanking.ts
@@ -1,4 +1,5 @@
 import { getSupabaseClient } from '@/platform/supabaseClient';
+import { fetchWithCache } from '@/platform/supabaseClient';
 
 export interface RankingEntry {
   id: string;
@@ -14,17 +15,25 @@ export interface RankingEntry {
   fantasy_current_stage?: string;
 }
 
+// 短時間の連打切替対策: ランキング用キャッシュTTL
+const RANKING_TTL_MS = 1000 * 30; // 30秒
+const RANKING_USER_TTL_MS = 1000 * 60; // 60秒（ユーザー単体順位）
+
 export async function fetchLevelRanking(limit = 50, offset = 0): Promise<RankingEntry[]> {
   const supabase = getSupabaseClient();
   
   // プロフィール情報を取得（nickname=emailなどの自動生成ユーザーが混ざる可能性があるため余剰取得）
-  const { data: profilesData, error: profilesError } = await supabase
-    .from('profiles')
-    .select('id, nickname, level, xp, rank, avatar_url, twitter_handle, selected_title, email')
-    .not('nickname', 'is', null)
-    .order('level', { ascending: false })
-    .order('xp', { ascending: false })
-    .range(offset, offset + (limit * 2) - 1);
+  const { data: profilesData, error: profilesError } = await fetchWithCache<any[]>(
+    `ranking:profiles:${limit}:${offset}`,
+    async () => await supabase
+      .from('profiles')
+      .select('id, nickname, level, xp, rank, avatar_url, twitter_handle, selected_title, email')
+      .not('nickname', 'is', null)
+      .order('level', { ascending: false })
+      .order('xp', { ascending: false })
+      .range(offset, offset + (limit * 2) - 1) as any,
+    RANKING_TTL_MS
+  );
   
   if (profilesError) throw profilesError;
   
@@ -38,30 +47,43 @@ export async function fetchLevelRanking(limit = 50, offset = 0): Promise<Ranking
   }
   
   const userIds = filteredProfiles.map(p => p.id);
+  const joinedIds = userIds.slice().sort().join(',');
   
   // レッスン完了数を集計
-  const { data: lessonCounts, error: lessonError } = await supabase
-    .from('user_lesson_progress')
-    .select('user_id')
-    .eq('completed', true)
-    .in('user_id', userIds);
+  const { data: lessonCounts, error: lessonError } = await fetchWithCache<any[]>(
+    `ranking:lessons_completed:${joinedIds}`,
+    async () => await supabase
+      .from('user_lesson_progress')
+      .select('user_id')
+      .eq('completed', true)
+      .in('user_id', userIds) as any,
+    RANKING_TTL_MS
+  );
   
   if (lessonError) throw lessonError;
   
   // ミッション完了数を集計
-  const { data: missionCounts, error: missionError } = await supabase
-    .from('user_challenge_progress')
-    .select('user_id, clear_count')
-    .eq('completed', true)
-    .in('user_id', userIds);
+  const { data: missionCounts, error: missionError } = await fetchWithCache<any[]>(
+    `ranking:missions_completed:${joinedIds}`,
+    async () => await supabase
+      .from('user_challenge_progress')
+      .select('user_id, clear_count')
+      .eq('completed', true)
+      .in('user_id', userIds) as any,
+    RANKING_TTL_MS
+  );
   
   if (missionError) throw missionError;
   
   // ファンタジーモード進捗情報を取得
-  const { data: fantasyProgress, error: fantasyError } = await supabase
-    .from('fantasy_user_progress')
-    .select('user_id, current_stage_number')
-    .in('user_id', userIds);
+  const { data: fantasyProgress, error: fantasyError } = await fetchWithCache<any[]>(
+    `ranking:fantasy_progress:${joinedIds}`,
+    async () => await supabase
+      .from('fantasy_user_progress')
+      .select('user_id, current_stage_number')
+      .in('user_id', userIds) as any,
+    RANKING_TTL_MS
+  );
   
   if (fantasyError) throw fantasyError;
   
@@ -108,13 +130,17 @@ export interface MissionRankingEntry {
 
 export async function fetchMissionRanking(missionId: string, limit = 50, offset = 0): Promise<MissionRankingEntry[]> {
   const supabase = getSupabaseClient();
-  const { data, error } = await supabase
-    .from('user_challenge_progress')
-    .select('user_id, clear_count, profiles(nickname, avatar_url, level, rank)')
-    .eq('challenge_id', missionId)
-    .eq('completed', true)
-    .order('clear_count', { ascending: false })
-    .range(offset, offset + limit - 1);
+  const { data, error } = await fetchWithCache<any[]>(
+    `ranking:mission:basic:${missionId}:${limit}:${offset}`,
+    async () => await supabase
+      .from('user_challenge_progress')
+      .select('user_id, clear_count, profiles(nickname, avatar_url, level, rank)')
+      .eq('challenge_id', missionId)
+      .eq('completed', true)
+      .order('clear_count', { ascending: false })
+      .range(offset, offset + limit - 1) as any,
+    RANKING_TTL_MS
+  );
   if (error) throw error;
   return (data ?? []).map((d: any) => ({
     user_id: d.user_id,
@@ -128,8 +154,13 @@ export async function fetchMissionRanking(missionId: string, limit = 50, offset 
 
 // ===== RPC based helpers for accurate global rank and paginated pages =====
 export async function fetchLevelRankingByView(limit = 50, offset = 0): Promise<RankingEntry[]> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_level_ranking', { limit_count: limit, offset_count: offset });
+  const cacheKey = `ranking:level:view:${limit}:${offset}`;
+  const { data, error } = await fetchWithCache<any[]>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_level_ranking', { limit_count: limit, offset_count: offset }) as any,
+    RANKING_TTL_MS
+  );
   if (error) throw error;
   const rows = (data ?? []) as any[];
   return rows.map((r) => ({
@@ -149,29 +180,49 @@ export async function fetchLevelRankingByView(limit = 50, offset = 0): Promise<R
 }
 
 export async function fetchUserGlobalRank(userId: string): Promise<number | null> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_user_global_rank', { target_user_id: userId });
+  const cacheKey = `ranking:user_global_rank:${userId}`;
+  const { data, error } = await fetchWithCache<number | null>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_user_global_rank', { target_user_id: userId }) as any,
+    RANKING_USER_TTL_MS
+  );
   if (error) throw error;
   return (data as number | null) ?? null;
 }
 
 export async function fetchMissionRankingByRpc(missionId: string, limit = 50, offset = 0): Promise<MissionRankingEntry[]> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_mission_ranking', { mission_id: missionId, limit_count: limit, offset_count: offset });
+  const cacheKey = `ranking:mission:${missionId}:${limit}:${offset}`;
+  const { data, error } = await fetchWithCache<MissionRankingEntry[]>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_mission_ranking', { mission_id: missionId, limit_count: limit, offset_count: offset }) as any,
+    RANKING_TTL_MS
+  );
   if (error) throw error;
   return (data ?? []) as MissionRankingEntry[];
 }
 
 export async function fetchUserMissionRank(missionId: string, userId: string): Promise<number | null> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_user_mission_rank', { mission_id: missionId, target_user_id: userId });
+  const cacheKey = `ranking:user_mission_rank:${missionId}:${userId}`;
+  const { data, error } = await fetchWithCache<number | null>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_user_mission_rank', { mission_id: missionId, target_user_id: userId }) as any,
+    RANKING_USER_TTL_MS
+  );
   if (error) throw error;
   return (data as number | null) ?? null;
 }
 
 export async function fetchLessonRankingByRpc(limit = 50, offset = 0): Promise<RankingEntry[]> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_lesson_ranking', { limit_count: limit, offset_count: offset });
+  const cacheKey = `ranking:lesson:view:${limit}:${offset}`;
+  const { data, error } = await fetchWithCache<any[]>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_lesson_ranking', { limit_count: limit, offset_count: offset }) as any,
+    RANKING_TTL_MS
+  );
   if (error) throw error;
   const rows = (data ?? []) as any[];
   return rows.map((r) => ({
@@ -190,8 +241,13 @@ export async function fetchLessonRankingByRpc(limit = 50, offset = 0): Promise<R
 }
 
 export async function fetchUserLessonRank(userId: string): Promise<number | null> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_get_user_lesson_rank', { target_user_id: userId });
+  const cacheKey = `ranking:user_lesson_rank:${userId}`;
+  const { data, error } = await fetchWithCache<number | null>(
+    cacheKey,
+    async () => await getSupabaseClient()
+      .rpc('rpc_get_user_lesson_rank', { target_user_id: userId }) as any,
+    RANKING_USER_TTL_MS
+  );
   if (error) throw error;
   return (data as number | null) ?? null;
 }


### PR DESCRIPTION
Add short-TTL memory cache to ranking API calls to prevent "loading stuck" issues during rapid mode switching.

The existing codebase had short-TTL caches for lessons, missions, and songs, but ranking-related data fetches were not adequately cached. This led to multiple identical queries being fired in quick succession when users rapidly switched to/from ranking views, causing the UI to appear stuck in a loading state. This change introduces 30-60 second caches for various ranking fetches, reducing redundant network requests and improving responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-88199ad1-1bab-4378-aef4-8a02dc8c8c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88199ad1-1bab-4378-aef4-8a02dc8c8c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

