### PR TITLE
Separate fantasy mode into basic and advanced stages

### DIFF
--- a/src/components/admin/FantasyStageManager.tsx
+++ b/src/components/admin/FantasyStageManager.tsx
@@ -57,6 +57,8 @@ interface StageFormValues {
   allowed_chords: any[]; // string or {chord,inversion,octave}
   chord_progression: any[]; // for order
   chord_progression_data: TimingRow[]; // for timing
+  // 新規: ステージ種別
+  stage_tier: 'basic' | 'advanced';
 }
 
 const defaultValues: StageFormValues = {
@@ -82,7 +84,8 @@ const defaultValues: StageFormValues = {
   chord_progression: [],
   chord_progression_data: [],
   bgm_url: '',
-  mp3_url: ''
+  mp3_url: '',
+  stage_tier: 'basic'
 };
 
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
@@ -174,6 +177,7 @@ const FantasyStageManager: React.FC = () => {
         allowed_chords: Array.isArray(s.allowed_chords) ? s.allowed_chords : [],
         chord_progression: (Array.isArray(s.chord_progression) ? s.chord_progression : []) as any[],
         chord_progression_data: (s as any).chord_progression_data || [],
+        stage_tier: (s as any).stage_tier || 'basic'
       };
       reset(v);
     } catch (e: any) {
@@ -209,6 +213,7 @@ const FantasyStageManager: React.FC = () => {
       chord_progression: v.chord_progression,
       chord_progression_data: v.chord_progression_data,
       note_interval_beats: v.note_interval_beats ?? null,
+      stage_tier: v.stage_tier
     };
 
     // モードに応じた不要フィールドの削除
@@ -352,6 +357,13 @@ const FantasyStageManager: React.FC = () => {
                 <div>
                   <SmallLabel>正解時にルート音を鳴らす</SmallLabel>
                   <input type="checkbox" className="toggle toggle-primary" {...register('play_root_on_correct')} />
+                </div>
+                <div>
+                  <SmallLabel>ステージ種別 *</SmallLabel>
+                  <select className="select select-bordered w-full" {...register('stage_tier', { required: true })}>
+                    <option value="basic">Basic</option>
+                    <option value="advanced">Advanced</option>
+                  </select>
                 </div>
               </Row>
             </Section>

--- a/src/components/admin/FantasyStageSelector.tsx
+++ b/src/components/admin/FantasyStageSelector.tsx
@@ -96,6 +96,9 @@ export const FantasyStageSelector: React.FC<FantasyStageSelectorProps> = ({
                     <span className="text-xs px-2 py-1 bg-gray-100 rounded">
                       モード: {stage.mode === 'single' ? 'シングル' : stage.mode === 'progression_order' ? 'リズム・順番' : stage.mode === 'progression_random' ? 'リズム・ランダム' : stage.mode === 'progression_timing' ? 'リズム・カスタム' : 'プログレッション'}
                     </span>
+                    <span className="text-xs px-2 py-1 bg-purple-100 text-purple-700 rounded">
+                      種別: {(stage as any).stage_tier === 'advanced' ? 'Advanced' : 'Basic'}
+                    </span>
                     <span className="text-xs px-2 py-1 bg-gray-100 rounded">
                       敵数: {stage.enemy_count}
                     </span>

--- a/src/components/fantasy/FantasyGameEngine.tsx
+++ b/src/components/fantasy/FantasyGameEngine.tsx
@@ -67,6 +67,8 @@ export interface FantasyStage {
   timeSignature?: number;
   // ステージ設定: 正解時にルート音を鳴らすか
   playRootOnCorrect?: boolean;
+  // 新規: ステージ種別（Basic/Advanced）
+  tier?: 'basic' | 'advanced';
 }
 
 export interface MonsterState {

--- a/src/components/fantasy/LPFantasyDemo.tsx
+++ b/src/components/fantasy/LPFantasyDemo.tsx
@@ -74,22 +74,21 @@ const LPFantasyDemo: React.FC = () => {
         enemyHp: dbStage.enemy_hp,
         minDamage: dbStage.min_damage,
         maxDamage: dbStage.max_damage,
-        mode: (dbStage as any).mode,
-        allowedChords: (dbStage as any).allowed_chords,
-        chordProgression: (dbStage as any).chord_progression,
-        chordProgressionData: (dbStage as any).chord_progression_data,
+        mode: (dbStage.mode as any) || 'single',
+        allowedChords: Array.isArray(dbStage.allowed_chords) ? dbStage.allowed_chords : [],
+        chordProgression: Array.isArray(dbStage.chord_progression) ? dbStage.chord_progression : undefined,
         showSheetMusic: false,
-        showGuide: dbStage.show_guide,
-        simultaneousMonsterCount: dbStage.simultaneous_monster_count || 1,
+        showGuide: !!dbStage.show_guide,
         monsterIcon: 'dragon',
+        bgmUrl: (dbStage as any).bgm_url || (dbStage as any).mp3_url,
+        simultaneousMonsterCount: (dbStage as any).simultaneous_monster_count || 1,
         bpm: (dbStage as any).bpm || 120,
-        bgmUrl: dbStage.bgm_url || (dbStage as any).mp3_url || '/demo-1.mp3',
         measureCount: (dbStage as any).measure_count,
         countInMeasures: (dbStage as any).count_in_measures,
         timeSignature: (dbStage as any).time_signature,
-        noteIntervalBeats: (dbStage as any).note_interval_beats,
-        playRootOnCorrect: (dbStage as any).play_root_on_correct ?? true
-      } as const;
+        playRootOnCorrect: (dbStage as any).play_root_on_correct ?? true,
+        tier: (dbStage as any).stage_tier || 'basic',
+      } as any;
       setStage(mapped);
     } catch (e: any) {
       console.error(e);

--- a/src/components/ranking/LevelRanking.tsx
+++ b/src/components/ranking/LevelRanking.tsx
@@ -305,7 +305,7 @@ const LevelRanking: React.FC = () => {
                 <th className="py-3 px-2 min-w-[3rem]">Lv</th>
                 {!isStandardGlobal && <th className="py-3 px-2 min-w-[4rem]">レッスン</th>}
                 {!isStandardGlobal && <th className="py-3 px-2 min-w-[4rem]">ミッション</th>}
-                <th className="py-3 px-2 min-w-[4rem]">ファンタジー</th>
+                <th className="py-3 px-2 min-w-[4rem]">F クリア</th>
                 {!isStandardGlobal && <th className="py-3 px-2 min-w-[5rem] sm:min-w-[4rem]">ランク</th>}
                 <th className="py-3 px-2 min-w-[8rem] sm:min-w-[6rem]">Twitter</th>
               </tr>
@@ -379,7 +379,7 @@ const LevelRanking: React.FC = () => {
                   <td className="py-3 px-2">{e.level}</td>
                   {!isStandardGlobal && <td className="py-3 px-2">{e.lessons_cleared}</td>}
                   {!isStandardGlobal && <td className="py-3 px-2">{e.missions_completed || 0}</td>}
-                  <td className="py-3 px-2 text-purple-300">{e.fantasy_current_stage || '-'}</td>
+                  <td className="py-3 px-2 text-purple-300">{e.fantasy_cleared_stages ?? 0}</td>
                   {!isStandardGlobal && (
                     <td className="py-3 px-2">
                       <div className="flex items-center space-x-1">

--- a/src/platform/supabaseFantasyStages.ts
+++ b/src/platform/supabaseFantasyStages.ts
@@ -174,6 +174,8 @@ export interface UpsertFantasyStagePayload {
   count_in_measures?: number;
   note_interval_beats?: number | null;
   play_root_on_correct?: boolean;
+  // 新規: ステージ種別（Basic/Advanced）
+  stage_tier?: 'basic' | 'advanced';
 }
 
 /**

--- a/src/platform/supabaseRanking.ts
+++ b/src/platform/supabaseRanking.ts
@@ -11,7 +11,7 @@ export interface RankingEntry {
   avatar_url?: string;
   twitter_handle?: string;
   selected_title?: string;
-  fantasy_current_stage?: string;
+  fantasy_cleared_stages?: number;
 }
 
 export async function fetchLevelRanking(limit = 50, offset = 0): Promise<RankingEntry[]> {
@@ -58,11 +58,12 @@ export async function fetchLevelRanking(limit = 50, offset = 0): Promise<Ranking
   if (missionError) throw missionError;
   
   // ファンタジーモード進捗情報を取得
-  const { data: fantasyProgress, error: fantasyError } = await supabase
-    .from('fantasy_user_progress')
-    .select('user_id, current_stage_number')
+  const { data: fantasyClears, error: fantasyError } = await supabase
+    .from('fantasy_stage_clears')
+    .select('user_id')
+    .eq('clear_type', 'clear')
     .in('user_id', userIds);
-  
+
   if (fantasyError) throw fantasyError;
   
   // ユーザーごとにカウントを集計
@@ -79,9 +80,10 @@ export async function fetchLevelRanking(limit = 50, offset = 0): Promise<Ranking
   });
   
   // ファンタジー進捗情報のマップを作成
-  const fantasyProgressMap = new Map<string, string>();
-  (fantasyProgress ?? []).forEach(record => {
-    fantasyProgressMap.set(record.user_id, record.current_stage_number);
+  const fantasyClearsMap = new Map<string, number>();
+  (fantasyClears ?? []).forEach(record => {
+    const count = fantasyClearsMap.get(record.user_id) || 0;
+    fantasyClearsMap.set(record.user_id, count + 1);
   });
   
   // プロフィールデータと集計データを結合
@@ -91,7 +93,7 @@ export async function fetchLevelRanking(limit = 50, offset = 0): Promise<Ranking
       ...profile,
       lessons_cleared: lessonCountMap.get(p.id) || 0,
       missions_completed: missionCountMap.get(p.id) || 0,
-      fantasy_current_stage: fantasyProgressMap.get(p.id),
+      fantasy_cleared_stages: fantasyClearsMap.get(p.id) || 0,
     };
   });
   
@@ -144,7 +146,7 @@ export async function fetchLevelRankingByView(limit = 50, offset = 0): Promise<R
     avatar_url: r.avatar_url ?? undefined,
     twitter_handle: r.twitter_handle ?? undefined,
     selected_title: r.selected_title ?? undefined,
-    fantasy_current_stage: r.fantasy_current_stage !== null && r.fantasy_current_stage !== undefined ? String(r.fantasy_current_stage) : undefined,
+    fantasy_cleared_stages: r.fantasy_cleared_stages !== null && r.fantasy_cleared_stages !== undefined ? Number(r.fantasy_cleared_stages) : 0,
   })) as unknown as RankingEntry[];
 }
 
@@ -185,7 +187,7 @@ export async function fetchLessonRankingByRpc(limit = 50, offset = 0): Promise<R
     avatar_url: r.avatar_url ?? undefined,
     twitter_handle: r.twitter_handle ?? undefined,
     selected_title: r.selected_title ?? undefined,
-    fantasy_current_stage: r.fantasy_current_stage !== null && r.fantasy_current_stage !== undefined ? String(r.fantasy_current_stage) : undefined,
+    fantasy_cleared_stages: r.fantasy_cleared_stages !== null && r.fantasy_cleared_stages !== undefined ? Number(r.fantasy_cleared_stages) : 0,
   })) as unknown as RankingEntry[];
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -651,6 +651,8 @@ export interface FantasyStage {
   noteIntervalBeats?: number;
   // 新規: 正解時にルート音を鳴らす
   play_root_on_correct?: boolean;
+  // 新規: ステージ種別（Basic/Advanced）
+  stage_tier?: 'basic' | 'advanced';
 }
 
 export interface LessonContext {

--- a/supabase/migrations/20250817120000_add_stage_tier_to_fantasy_stages.sql
+++ b/supabase/migrations/20250817120000_add_stage_tier_to_fantasy_stages.sql
@@ -1,0 +1,11 @@
+-- Add stage_tier (Basic/Advanced) to fantasy_stages
+-- Created at: 2025-08-17
+
+BEGIN;
+
+ALTER TABLE public.fantasy_stages
+  ADD COLUMN IF NOT EXISTS stage_tier text NOT NULL DEFAULT 'basic' CHECK (stage_tier IN ('basic','advanced'));
+
+COMMENT ON COLUMN public.fantasy_stages.stage_tier IS 'ステージ種別: basic or advanced';
+
+COMMIT;

--- a/supabase/migrations/20250817121000_insert_sample_advanced_stage_A1.sql
+++ b/supabase/migrations/20250817121000_insert_sample_advanced_stage_A1.sql
@@ -1,0 +1,15 @@
+-- Insert sample Advanced stage A-1 into fantasy_stages
+-- Created at: 2025-08-17
+
+BEGIN;
+
+INSERT INTO public.fantasy_stages (
+  stage_number, name, description, max_hp, enemy_count, enemy_hp, min_damage, max_damage,
+  enemy_gauge_seconds, mode, allowed_chords, chord_progression, show_guide, bgm_url,
+  simultaneous_monster_count, play_root_on_correct, stage_tier, bpm, time_signature, measure_count, count_in_measures
+) VALUES
+('A-1', '深淵への門', 'テンション系コード中心の高難度ステージ', 5, 3, 6, 1, 1, 3.5, 'single',
+  '["CM7", "Dm7", "G7", "C9", "Cm9", "F13"]'::jsonb, '[]'::jsonb, false, NULL, 2, true, 'advanced', 140, 4, 8, 0)
+ON CONFLICT (stage_number) DO NOTHING;
+
+COMMIT;

--- a/supabase/migrations/20250817121100_insert_sample_advanced_stage_A2.sql
+++ b/supabase/migrations/20250817121100_insert_sample_advanced_stage_A2.sql
@@ -1,0 +1,15 @@
+-- Insert sample Advanced stage A-2 into fantasy_stages
+-- Created at: 2025-08-17
+
+BEGIN;
+
+INSERT INTO public.fantasy_stages (
+  stage_number, name, description, max_hp, enemy_count, enemy_hp, min_damage, max_damage,
+  enemy_gauge_seconds, mode, allowed_chords, chord_progression, show_guide, bgm_url,
+  simultaneous_monster_count, play_root_on_correct, stage_tier, bpm, time_signature, measure_count, count_in_measures
+) VALUES
+('A-2', '星落つる塔', 'ii-V-Iを高テンポで。ミス許容量が少ない', 4, 3, 6, 1, 1, 3.2, 'progression_order',
+  '[]'::jsonb, '["Dm7", "G7", "CM7", "Am7", "Dm7", "G7", "CM7"]'::jsonb, false, NULL, 2, true, 'advanced', 160, 4, 8, 1)
+ON CONFLICT (stage_number) DO NOTHING;
+
+COMMIT;

--- a/supabase/migrations/20250817121500_create_fantasy_clears_ranking_rpc.sql
+++ b/supabase/migrations/20250817121500_create_fantasy_clears_ranking_rpc.sql
@@ -1,0 +1,69 @@
+-- Create RPCs for fantasy cleared stages ranking (optional, for future use)
+-- Created at: 2025-08-17
+
+DROP FUNCTION IF EXISTS public.rpc_get_fantasy_clears_ranking(limit_count integer, offset_count integer);
+DROP FUNCTION IF EXISTS public.rpc_get_user_fantasy_clears_rank(target_user_id uuid);
+
+CREATE FUNCTION public.rpc_get_fantasy_clears_ranking(
+  limit_count integer DEFAULT 50,
+  offset_count integer DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  nickname text,
+  level integer,
+  xp bigint,
+  rank text,
+  avatar_url text,
+  twitter_handle text,
+  selected_title text,
+  fantasy_cleared_stages integer
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH fs AS (
+    SELECT fsc.user_id, COUNT(*) AS cleared_count
+    FROM public.fantasy_stage_clears fsc
+    WHERE fsc.clear_type = 'clear'
+    GROUP BY fsc.user_id
+  ), base AS (
+    SELECT p.id, p.nickname, p.level, p.xp, p.rank, p.avatar_url, p.twitter_handle, p.selected_title,
+           COALESCE(fs.cleared_count, 0) AS fantasy_cleared_stages
+    FROM public.profiles p
+    LEFT JOIN fs ON fs.user_id = p.id
+    WHERE p.nickname IS NOT NULL
+      AND p.nickname <> p.email
+  ), ranked AS (
+    SELECT *, ROW_NUMBER() OVER (ORDER BY fantasy_cleared_stages DESC, level DESC, xp DESC, id ASC) AS rn
+    FROM base
+  )
+  SELECT id, nickname, level, xp, rank, avatar_url, twitter_handle, selected_title, fantasy_cleared_stages
+  FROM ranked
+  ORDER BY rn
+  OFFSET offset_count
+  LIMIT limit_count;
+$$;
+
+CREATE FUNCTION public.rpc_get_user_fantasy_clears_rank(target_user_id uuid)
+RETURNS integer
+LANGUAGE sql
+STABLE
+AS $$
+  WITH fs AS (
+    SELECT fsc.user_id, COUNT(*) AS cleared_count
+    FROM public.fantasy_stage_clears fsc
+    WHERE fsc.clear_type = 'clear'
+    GROUP BY fsc.user_id
+  ), base AS (
+    SELECT p.id, COALESCE(fs.cleared_count, 0) AS fantasy_cleared_stages, p.level, p.xp
+    FROM public.profiles p
+    LEFT JOIN fs ON fs.user_id = p.id
+    WHERE p.nickname IS NOT NULL
+      AND p.nickname <> p.email
+  ), ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY fantasy_cleared_stages DESC, level DESC, xp DESC, id ASC) AS rn
+    FROM base
+  )
+  SELECT rn FROM ranked WHERE id = target_user_id LIMIT 1;
+$$;

--- a/supabase/migrations/20250817122500_add_indexes_for_fantasy_clears.sql
+++ b/supabase/migrations/20250817122500_add_indexes_for_fantasy_clears.sql
@@ -1,0 +1,5 @@
+-- Indexes to speed up fantasy clears aggregations
+-- Created at: 2025-08-17
+
+CREATE INDEX IF NOT EXISTS fantasy_stage_clears_clear_type_user_id_idx
+  ON public.fantasy_stage_clears (clear_type, user_id);


### PR DESCRIPTION
Introduces Basic and Advanced stages for Fantasy Mode, updates ranking to display total cleared stages, and adds sample Advanced stage migrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-bed2d8c5-4b5e-48ed-a9c5-d8bc40c81384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bed2d8c5-4b5e-48ed-a9c5-d8bc40c81384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

