### PR TITLE
Fix jsx syntax errors in guild dashboard

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -232,6 +232,7 @@ const GuildDashboard: React.FC = () => {
 										</div>
 									</div>
 								</div>
+							</div>
 							<div className="mt-3 text-right">
 								<button className="btn btn-sm btn-outline" onClick={() => { const params = new URLSearchParams(); params.set('id', myGuild.id); window.location.hash = `#guild-history?${params.toString()}`; }}>ギルドヒストリーを見る</button>
 							</div>


### PR DESCRIPTION
Fixes JSX build error by adding a missing closing `div` tag in `GuildDashboard.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-33319229-602c-471a-a5f7-78881753b23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33319229-602c-471a-a5f7-78881753b23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

