### PR TITLE
ギルド周りのUIとボーナス計算を改善

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/platform/supabaseGuilds';
 import GuildBoard from '@/components/guild/GuildBoard';
 import GameHeader from '@/components/ui/GameHeader';
-import { currentLevelXP, xpToNextLevel } from '@/utils/xpCalculator';
+import { calcLevel } from '@/platform/supabaseXp';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
 import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
@@ -242,133 +242,152 @@ const GuildDashboard: React.FC = () => {
 		);
 	}
 
-	const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
-	const bonus = computeGuildBonus(myGuild.level || 1, contributors);
+        const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
+        const streakBonus = Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0);
+        const bonus = computeGuildBonus(myGuild.level || 1, contributors, streakBonus);
+        const levelInfo = calcLevel(myTotalContribXp);
+        const levelProgress = (levelInfo.remainder / levelInfo.nextLevelXp) * 100;
+        const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
+        const mvp = mvpUserId ? members.find(x => x.user_id === mvpUserId) : undefined;
+        const mvpXp = memberMonthly.find(x => x.user_id === mvpUserId)?.monthly_xp || 0;
 
-	return (
-		<div className="container mx-auto p-4">
-			<GameHeader title={myGuild.name} />
+        return (
+                <div className="w-full h-full flex flex-col bg-gradient-game text-white">
+                        <GameHeader title={myGuild.name} />
+                        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+                                <div className="max-w-4xl mx-auto space-y-4">
+                                        <div className="bg-slate-800 border border-slate-700 rounded p-4">
+                                                <h3 className="font-semibold mb-2">ギルド情報</h3>
+                                                <p className="text-sm mb-2">{myGuild.description || 'なし'}</p>
+                                                <div className="text-sm text-gray-300">メンバー {members.length}</div>
+                                                <div className="text-sm text-gray-300">リーダー: {myGuild.leader_id === user?.id ? 'あなた' : members.find(m => m.user_id === myGuild.leader_id)?.nickname || '不明'}</div>
+                                                <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}% / ストリーク +{(bonus.streakBonus*100).toFixed(0)}%）</span></div>
+                                                <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
+                                                        <div className="bg-slate-900 rounded p-3 border border-slate-700">
+                                                                <div className="text-gray-400">累計獲得XP</div>
+                                                                <div className="text-lg font-semibold">{myTotalContribXp.toLocaleString()}</div>
+                                                        </div>
+                                                        <div className="bg-slate-900 rounded p-3 border border-slate-700">
+                                                                <div className="text-gray-400">現在のレベル</div>
+                                                                <div className="text-lg font-semibold">Lv.{levelInfo.level}</div>
+                                                                <div className="h-1.5 bg-slate-700 rounded overflow-hidden mt-1">
+                                                                        <div className="h-full bg-green-500" style={{ width: `${Math.min(100, levelProgress)}%` }} />
+                                                                </div>
+                                                                <div className="text-[10px] text-gray-400 mt-1">{levelInfo.remainder.toLocaleString()} / {levelInfo.nextLevelXp.toLocaleString()}</div>
+                                                        </div>
+                                                </div>
+                                                <div className="flex gap-2 mt-3">
+                                                        <button className="btn btn-sm btn-outline" onClick={() => { const p = new URLSearchParams(); p.set('id', myGuild.id); window.location.hash = `#guild-history?${p.toString()}`; }}>ギルドヒストリーを見る</button>
+                                                        {isLeader && (
+                                                                editingDesc ? (
+                                                                        <>
+                                                                                <textarea value={descEdit} onChange={(e)=>setDescEdit(e.target.value)} className="input input-bordered input-sm flex-1" />
+                                                                                <button onClick={handleUpdateDescription} className="btn btn-primary btn-sm" disabled={busy}>更新</button>
+                                                                        </>
+                                                                ) : (
+                                                                        <button onClick={()=>{ setDescEdit(myGuild.description || ''); setEditingDesc(true); }} className="btn btn-sm btn-outline">説明を編集</button>
+                                                                )
+                                                        )}
+                                                </div>
+                                                <div className="mt-4">
+                                                        <GuildBoard guildId={myGuild.id} />
+                                                </div>
+                                        </div>
 
-			<div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-				<div className="bg-slate-900 p-4 rounded-lg">
-					<h3>ギルド情報</h3>
-					<p>ギルド説明: {myGuild.description || 'なし'}</p>
-					<p>メンバー数: {members.length}</p>
-					<p>リーダー: {myGuild.leader_id === user?.id ? 'あなた' : members.find(m => m.user_id === myGuild.leader_id)?.nickname || '不明'}</p>
-					<p>今月合計XP: {thisMonthXp}</p>
-					<p>総貢献XP: {myTotalContribXp}</p>
-					<p>ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)}</p>
-					<p className="text-xs text-gray-400">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}%）</p>
-					<p>現在のレベル: {currentLevelXP(myTotalContribXp)}</p>
-					<p>次のレベルまで: {xpToNextLevel(myTotalContribXp)}</p>
+                                        <div className="bg-slate-800 border border-slate-700 rounded p-4">
+                                                <h3 className="font-semibold mb-3">MVP（今月）</h3>
+                                                {!mvp ? (
+                                                        <p className="text-gray-400 text-sm">該当なし</p>
+                                                ) : (
+                                                        <div className="flex items-center gap-3">
+                                                                <img src={mvp.avatar_url || DEFAULT_AVATAR_URL} className="w-10 h-10 rounded-full" />
+                                                                <div className="flex-1">
+                                                                        <div className="font-medium">{mvp.nickname}</div>
+                                                                        <div className="text-xs text-gray-400">今月XP {Number(mvpXp || 0).toLocaleString()}</div>
+                                                                </div>
+                                                        </div>
+                                                )}
+                                        </div>
 
-					{editingDesc ? (
-						<div className="mt-4">
-							<textarea value={descEdit} onChange={(e)=>setDescEdit(e.target.value)} className="input input-bordered w-full" />
-							<button onClick={handleUpdateDescription} className="btn btn-primary mt-2" disabled={busy}>説明を更新</button>
-						</div>
-					) : (
-						<button onClick={()=>setEditingDesc(true)} className="btn btn-outline btn-sm">ギルド説明を編集</button>
-					)}
+                                        <div className="bg-slate-800 border border-slate-700 rounded p-4">
+                                                <h3 className="font-semibold mb-3">メンバーリスト</h3>
+                                                {members.length === 0 ? (
+                                                        <p className="text-gray-400 text-sm">メンバーはまだいません。</p>
+                                                ) : (
+                                                        <ul className="space-y-2">
+                                                                {members.map(m => (
+                                                                        <li key={m.user_id} className="flex items-center gap-3">
+                                                                                <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} aria-label="ユーザーページへ">
+                                                                                        <img src={m.avatar_url || DEFAULT_AVATAR_URL} className="w-8 h-8 rounded-full" />
+                                                                                </button>
+                                                                                <div className="flex-1 min-w-0">
+                                                                                        <div className="flex items-center gap-2">
+                                                                                                <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} className="font-medium text-sm truncate text-left hover:text-blue-400">{m.nickname}</button>
+                                                                                                {m.selected_title && (
+                                                                                                        <div className="relative group">
+                                                                                                                <div className="flex items-center gap-1 text-yellow-400 cursor-help">
+                                                                                                                        {getTitleIcon((m.selected_title as Title) || DEFAULT_TITLE)}
+                                                                                                                        <span className="text-[10px] truncate max-w-[140px]">{(m.selected_title as Title) || DEFAULT_TITLE}</span>
+                                                                                                                </div>
+                                                                                                                <div className="absolute hidden group-hover:block z-50 bg-gray-900 text-white text-[11px] p-2 rounded shadow-lg whitespace-nowrap" style={{ top: '100%', left: 0, marginTop: '4px' }}>
+                                                                                                                        {getTitleRequirement((m.selected_title as Title) || DEFAULT_TITLE)}
+                                                                                                                        <div className="absolute w-0 h-0 border-l-4 border-r-4 border-b-4 border-transparent border-b-gray-900" style={{ top: '-4px', left: '12px' }} />
+                                                                                                                </div>
+                                                                                                        </div>
+                                                                                                )}
+                                                                                        </div>
+                                                                                        <div className="text-xs text-gray-400">Lv {m.level} / {m.rank}</div>
+                                                                                        {streaks[m.user_id] && (
+                                                                                                <div className="mt-1">
+                                                                                                        <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
+                                                                                                                <div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
+                                                                                                        </div>
+                                                                                                        <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
+                                                                                                </div>
+                                                                                        )}
+                                                                                </div>
+                                                                                {m.role === 'leader' && (
+                                                                                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-yellow-500 text-black font-bold">Leader</span>
+                                                                                )}
+                                                                                {memberMonthly.some(x=>x.user_id===m.user_id && Number(x.monthly_xp||0)>=1) && (
+                                                                                        <FaCheckCircle className="text-green-400 text-sm" title="今月のギルド貢献にカウント済み" />
+                                                                                )}
+                                                                                {isLeader && m.role !== 'leader' && m.user_id !== user?.id && (
+                                                                                        <button className="btn btn-xs btn-outline text-red-300 border-red-600" disabled={busy} onClick={async()=>{ if(!confirm('このメンバーを除名しますか？')) return; if(!confirm('最終確認: 除名すると元に戻せません。よろしいですか？')) return; try { setBusy(true); await kickMember(m.user_id); setMembers(prev => prev.filter(x => x.user_id !== m.user_id)); } catch(e:any){ alert(e?.message || '除名に失敗しました'); } finally { setBusy(false); } }}>除名</button>
+                                                                                )}
+                                                                        </li>
+                                                                ))}
+                                                        </ul>
+                                                )}
+                                        </div>
 
-					<h3 className="mt-4">ギルドボード</h3>
-					<GuildBoard guildId={myGuild.id} />
-				</div>
+                                        <div className="bg-slate-800 border border-slate-700 rounded p-4">
+                                                <h3 className="font-semibold mb-3">参加リクエスト</h3>
+                                                {joinRequests.length === 0 ? (
+                                                        <p className="text-gray-400 text-sm">参加リクエストはありません。</p>
+                                                ) : (
+                                                        <ul className="space-y-2">
+                                                                {joinRequests.map(req => (
+                                                                        <li key={req.id} className="bg-slate-900 p-2 rounded-lg">
+                                                                                <p>{req.requester_nickname || 'ユーザー'} からの参加リクエスト</p>
+                                                                                <button onClick={() => handleApproveJoinRequest(req.id)} className="btn btn-xs btn-success mr-2">承認</button>
+                                                                                <button onClick={() => handleRejectJoinRequest(req.id)} className="btn btn-xs btn-error">拒否</button>
+                                                                        </li>
+                                                                ))}
+                                                        </ul>
+                                                )}
+                                        </div>
 
-				<div className="bg-slate-900 p-4 rounded-lg">
-					<h3>メンバーリスト</h3>
-					{members.length === 0 ? (
-						<p>メンバーはまだいません。</p>
-					) : (
-						<ul className="grid grid-cols-1 md:grid-cols-2 gap-2">
-							{members.map(m => (
-								<li key={m.user_id} className="flex items-center gap-3 bg-slate-900 p-2 rounded border border-slate-700">
-									<button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} aria-label="ユーザーページへ">
-										<img src={m.avatar_url || DEFAULT_AVATAR_URL} className="w-8 h-8 rounded-full" />
-									</button>
-									<div className="flex-1 min-w-0">
-										<div className="flex items-center gap-2">
-											<button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} className="font-medium text-sm truncate text-left hover:text-blue-400">{m.nickname}</button>
-											{m.selected_title && (
-												<div className="relative">
-													<div className="flex items-center gap-1 text-yellow-400 cursor-help group">
-														{getTitleIcon((m.selected_title as Title) || DEFAULT_TITLE)}
-														<span className="text-[10px] truncate max-w-[140px]">{(m.selected_title as Title) || DEFAULT_TITLE}</span>
-													</div>
-													<div className="absolute hidden group-hover:block z-50 bg-gray-900 text-white text-[11px] p-2 rounded shadow-lg whitespace-nowrap" style={{ top: '100%', left: 0, marginTop: '4px' }}>
-														{getTitleRequirement((m.selected_title as Title) || DEFAULT_TITLE)}
-														<div className="absolute w-0 h-0 border-l-4 border-r-4 border-b-4 border-transparent border-b-gray-900" style={{ top: '-4px', left: '12px' }} />
-													</div>
-												</div>
-											)}
-										</div>
-										<div className="text-xs text-gray-400">Lv {m.level} / {m.rank}</div>
-										{streaks[m.user_id] && (
-											<div className="mt-1">
-												<div className="h-1.5 bg-slate-800 rounded overflow-hidden">
-													<div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
-												</div>
-												<div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
-											</div>
-										)}
-									</div>
-									{m.role === 'leader' && (
-										<span className="text-[10px] px-2 py-0.5 rounded-full bg-yellow-500 text-black font-bold">Leader</span>
-									)}
-									{memberMonthly.some(x=>x.user_id===m.user_id && Number(x.monthly_xp||0)>=1) && (
-										<FaCheckCircle className="text-green-400 text-sm" title="今月のギルド貢献にカウント済み" />
-									)}
-									{isLeader && m.role !== 'leader' && m.user_id !== user?.id && (
-										<button
-											className="btn btn-xs btn-outline text-red-300 border-red-600"
-											disabled={busy}
-											onClick={async()=>{
-												if(!confirm('このメンバーを除名しますか？')) return;
-												if(!confirm('最終確認: 除名すると元に戻せません。よろしいですか？')) return;
-												try {
-													setBusy(true);
-													await kickMember(m.user_id);
-													setMembers(prev => prev.filter(x => x.user_id !== m.user_id));
-												} catch(e: any) {
-													alert(e?.message || '除名に失敗しました');
-												} finally {
-													setBusy(false);
-												}
-											}}
-										>除名</button>
-									)}
-								</li>
-							))}
-						</ul>
-					)}
-				</div>
-
-				<div className="bg-slate-900 p-4 rounded-lg">
-					<h3>参加リクエスト</h3>
-					{joinRequests.length === 0 ? (
-						<p>参加リクエストはありません。</p>
-					) : (
-						<ul>
-							{joinRequests.map(req => (
-								<li key={req.id} className="bg-slate-800 p-2 rounded-lg mb-2">
-									<p>{req.requester_nickname || 'ユーザー'} からの参加リクエスト</p>
-									<button onClick={() => handleApproveJoinRequest(req.id)} className="btn btn-xs btn-success mr-2">承認</button>
-									<button onClick={() => handleRejectJoinRequest(req.id)} className="btn btn-xs btn-error">拒否</button>
-								</li>
-							))}
-						</ul>
-					)}
-				</div>
-			</div>
-
-			<div className="flex justify-end gap-2 mt-4">
-				<button onClick={handleLeaveGuild} className="btn btn-outline text-red-300 border-red-600">ギルドから退出</button>
-				{isLeader && (
-					<button onClick={handleDisbandGuild} className="btn btn-outline text-red-300 border-red-600">ギルドを解散</button>
-				)}
-			</div>
-		</div>
-	);
+                                        <div className="flex justify-end gap-2">
+                                                <button onClick={handleLeaveGuild} className="btn btn-outline text-red-300 border-red-600">ギルドから退出</button>
+                                                {isLeader && (
+                                                        <button onClick={handleDisbandGuild} className="btn btn-outline text-red-300 border-red-600">ギルドを解散</button>
+                                                )}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        );
 };
 
 export default GuildDashboard;

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -69,7 +69,8 @@ const GuildPage: React.FC = () => {
   if (!open) return null;
 
   const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
-  const bonus = computeGuildBonus(guild?.level || 1, contributors);
+  const streakBonus = Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0);
+  const bonus = computeGuildBonus(guild?.level || 1, contributors, streakBonus);
   const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
   const mvp = mvpUserId ? members.find(x => x.user_id === mvpUserId) : undefined;
   const mvpXp = memberMonthly.find(x => x.user_id === mvpUserId)?.monthly_xp || 0;
@@ -115,7 +116,7 @@ const GuildPage: React.FC = () => {
                   <div>
                     <div className="text-2xl font-bold">{guild.name}{guild.disbanded ? '（解散したギルド）' : ''}</div>
                     <div className="text-sm text-gray-300 mt-1">Lv.{guild.level} / メンバー {guild.members_count}</div>
-                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}%）</span></div>
+                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}% / ストリーク +{(bonus.streakBonus*100).toFixed(0)}%）</span></div>
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>
@@ -205,8 +206,8 @@ const GuildPage: React.FC = () => {
                             <button className="hover:text-blue-400 truncate" onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }}>{m.nickname}</button>
                             {/* 称号（ホバー/タップで条件表示） */}
                             {m.selected_title && (
-                              <div className="relative">
-                                <div className="flex items-center gap-1 text-yellow-400 cursor-help group">
+                              <div className="relative group">
+                                <div className="flex items-center gap-1 text-yellow-400 cursor-help">
                                   {getTitleIcon((m.selected_title as Title) || DEFAULT_TITLE)}
                                   <span className="text-[11px] truncate max-w-[160px]">{(m.selected_title as Title) || DEFAULT_TITLE}</span>
                                 </div>

--- a/src/utils/guildBonus.ts
+++ b/src/utils/guildBonus.ts
@@ -3,6 +3,7 @@
 export interface GuildBonusBreakdown {
   levelBonus: number; // 例: 0.034 => +3.4%
   memberBonus: number; // 例: 0.2 => +20%
+  streakBonus: number; // 例: 0.25 => +25%
   totalMultiplier: number; // 例: 1.234
 }
 
@@ -12,12 +13,13 @@ export interface GuildBonusBreakdown {
  * - メンバー倍率: 当月XP>=1のメンバー人数 x +10% (0.1) 上限+50% (0.5)
  * - 合算方式: levelBonus + memberBonus を加算し、1に足す
  */
-export function computeGuildBonus(level: number, contributedMemberCount: number): GuildBonusBreakdown {
+export function computeGuildBonus(level: number, contributedMemberCount: number, streakPercentSum = 0): GuildBonusBreakdown {
   const safeLevel = Math.max(0, Math.floor(level || 0));
   const levelBonus = safeLevel * 0.001; // +0.1%/Lv
   const memberBonus = Math.min(0.5, Math.max(0, Math.floor(contributedMemberCount || 0)) * 0.1);
-  const totalMultiplier = 1 + levelBonus + memberBonus;
-  return { levelBonus, memberBonus, totalMultiplier };
+  const streakBonus = Math.max(0, streakPercentSum);
+  const totalMultiplier = 1 + levelBonus + memberBonus + streakBonus;
+  return { levelBonus, memberBonus, streakBonus, totalMultiplier };
 }
 
 /** 数値倍率から "+1.20x (+20.00%)" のような表記を返す */
@@ -27,9 +29,10 @@ export function formatMultiplier(multiplier: number): string {
 }
 
 /** ボーナス内訳 "(Lv +x.xx, Mem +y.yy)" のような短い表示 */
-export function formatBonusBreakdown(levelBonus: number, memberBonus: number): string {
+export function formatBonusBreakdown(levelBonus: number, memberBonus: number, streakBonus = 0): string {
   const lvPct = (levelBonus * 100).toFixed(2);
   const memPct = (memberBonus * 100).toFixed(0);
-  return `(Lv +${lvPct}%, Mem +${memPct}%)`;
+  const stPct = (streakBonus * 100).toFixed(0);
+  return `(Lv +${lvPct}%, Mem +${memPct}%, St +${stPct}%)`;
 }
 


### PR DESCRIPTION
## 概要
- ギルドページで称号ホバー時に獲得条件を表示
- ギルドダッシュボードを1カラム化しスクロール対応、MVPや進捗バーを追加
- ストリーク分も含めたギルドボーナス計算を実装

## テスト
- `npm run lint` (失敗: 既存のlintエラー)
- `npm test` (スクリプト未定義)


------
https://chatgpt.com/codex/tasks/task_e_68a3cdcdbe6c832882aefa1357be7575