### PR TITLE
ギルド関連UIとボーナス計算の修正

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -259,10 +259,17 @@ const GuildDashboard: React.FC = () => {
                                         <div className="bg-slate-800 border border-slate-700 rounded p-4">
                                                 <h3 className="font-semibold mb-2">ギルド情報</h3>
                                                 <p className="text-sm mb-2">{myGuild.description || 'なし'}</p>
-                                                <div className="text-sm text-gray-300">メンバー {members.length}</div>
                                                 <div className="text-sm text-gray-300">リーダー: {myGuild.leader_id === user?.id ? 'あなた' : members.find(m => m.user_id === myGuild.leader_id)?.nickname || '不明'}</div>
-                                                <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}% / ストリーク +{(bonus.streakBonus*100).toFixed(0)}%）</span></div>
+                                                <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
                                                 <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
+                                                        <div className="bg-slate-900 rounded p-3 border border-slate-700">
+                                                                <div className="text-gray-400">今月XP</div>
+                                                                <div className="text-lg font-semibold">{thisMonthXp.toLocaleString()}</div>
+                                                        </div>
+                                                        <div className="bg-slate-900 rounded p-3 border border-slate-700">
+                                                                <div className="text-gray-400">今月の順位</div>
+                                                                <div className="text-lg font-semibold">{myRank ? `${myRank}位` : '-'}</div>
+                                                        </div>
                                                         <div className="bg-slate-900 rounded p-3 border border-slate-700">
                                                                 <div className="text-gray-400">累計獲得XP</div>
                                                                 <div className="text-lg font-semibold">{myTotalContribXp.toLocaleString()}</div>
@@ -280,19 +287,17 @@ const GuildDashboard: React.FC = () => {
                                                         <button className="btn btn-sm btn-outline" onClick={() => { const p = new URLSearchParams(); p.set('id', myGuild.id); window.location.hash = `#guild-history?${p.toString()}`; }}>ギルドヒストリーを見る</button>
                                                         {isLeader && (
                                                                 editingDesc ? (
-                                                                        <>
+                                                                        <div className="flex gap-2 flex-1">
                                                                                 <textarea value={descEdit} onChange={(e)=>setDescEdit(e.target.value)} className="input input-bordered input-sm flex-1" />
                                                                                 <button onClick={handleUpdateDescription} className="btn btn-primary btn-sm" disabled={busy}>更新</button>
-                                                                        </>
+                                                                                <button onClick={()=>{ setEditingDesc(false); setDescEdit(myGuild.description || ''); }} className="btn btn-sm btn-outline">キャンセル</button>
+                                                                        </div>
                                                                 ) : (
                                                                         <button onClick={()=>{ setDescEdit(myGuild.description || ''); setEditingDesc(true); }} className="btn btn-sm btn-outline">説明を編集</button>
                                                                 )
                                                         )}
                                                 </div>
-                                                <div className="mt-4">
-                                                        <GuildBoard guildId={myGuild.id} />
-                                                </div>
-                                        </div>
+                                       </div>
 
                                         <div className="bg-slate-800 border border-slate-700 rounded p-4">
                                                 <h3 className="font-semibold mb-3">MVP（今月）</h3>
@@ -310,11 +315,11 @@ const GuildDashboard: React.FC = () => {
                                         </div>
 
                                         <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                                                <h3 className="font-semibold mb-3">メンバーリスト</h3>
+                                                <h3 className="font-semibold mb-3">メンバーリスト ({members.length}/5)</h3>
                                                 {members.length === 0 ? (
                                                         <p className="text-gray-400 text-sm">メンバーはまだいません。</p>
                                                 ) : (
-                                                        <ul className="space-y-2">
+                                                        <ul className="space-y-2 text-base">
                                                                 {members.map(m => (
                                                                         <li key={m.user_id} className="flex items-center gap-3">
                                                                                 <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} aria-label="ユーザーページへ">
@@ -322,7 +327,7 @@ const GuildDashboard: React.FC = () => {
                                                                                 </button>
                                                                                 <div className="flex-1 min-w-0">
                                                                                         <div className="flex items-center gap-2">
-                                                                                                <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} className="font-medium text-sm truncate text-left hover:text-blue-400">{m.nickname}</button>
+                                                                                                <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} className="font-medium text-base truncate text-left hover:text-blue-400">{m.nickname}</button>
                                                                                                 {m.selected_title && (
                                                                                                         <div className="relative group">
                                                                                                                 <div className="flex items-center gap-1 text-yellow-400 cursor-help">
@@ -383,6 +388,10 @@ const GuildDashboard: React.FC = () => {
                                                 {isLeader && (
                                                         <button onClick={handleDisbandGuild} className="btn btn-outline text-red-300 border-red-600">ギルドを解散</button>
                                                 )}
+                                        </div>
+
+                                        <div className="bg-slate-800 border border-slate-700 rounded p-4">
+                                                <GuildBoard guildId={myGuild.id} />
                                         </div>
                                 </div>
                         </div>

--- a/src/components/guild/GuildHistory.tsx
+++ b/src/components/guild/GuildHistory.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { fetchGuildContributorsWithProfiles, fetchGuildMonthlyXpSingle, fetchGuildRankForMonth, getMyGuild } from '@/platform/supabaseGuilds';
+import { fetchGuildContributorsWithProfiles, fetchGuildMonthlyXpSingle, fetchGuildRankForMonth, getMyGuild, getGuildById } from '@/platform/supabaseGuilds';
 
 type MonthData = {
 	month: string;
@@ -31,20 +31,25 @@ const GuildHistory: React.FC = () => {
 		(async () => {
 			setLoading(true);
 			try {
-				const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
-				const id = params.get('id');
-				let gid = id;
-				if (!gid) {
-					const g = await getMyGuild();
-					gid = g?.id || null;
-					if (g?.name) setGuildName(g.name);
-				}
-				setGuildId(gid);
-			} finally {
-				setLoading(false);
-			}
-		})();
-	}, [open]);
+                                const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+                                const id = params.get('id');
+                                let gid = id;
+                                let gname = '';
+                                if (!gid) {
+                                        const g = await getMyGuild();
+                                        gid = g?.id || null;
+                                        gname = g?.name || '';
+                                } else {
+                                        const g = await getGuildById(gid);
+                                        gname = g?.name || '';
+                                }
+                                setGuildId(gid);
+                                setGuildName(gname);
+                        } finally {
+                                setLoading(false);
+                        }
+                })();
+        }, [open]);
 
 	const monthList = useMemo(() => {
 		const list: string[] = [];
@@ -91,7 +96,7 @@ const GuildHistory: React.FC = () => {
 						<p className="text-gray-300 text-sm">ギルドが特定できません。ギルドダッシュボードからアクセスしてください。</p>
 					) : (
 						<>
-							<p className="text-gray-300 text-sm">ギルドID: <span className="font-mono">{guildId}</span></p>
+                                                        <p className="text-gray-300 text-sm">ギルド名: {guildName || '-'}</p>
 							<div className="space-y-6">
 								{monthList.map((m) => {
 									const d = dataByMonth[m];

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -115,8 +115,8 @@ const GuildPage: React.FC = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <div className="text-2xl font-bold">{guild.name}{guild.disbanded ? '（解散したギルド）' : ''}</div>
-                    <div className="text-sm text-gray-300 mt-1">Lv.{guild.level} / メンバー {guild.members_count}</div>
-                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(0)}% / ストリーク +{(bonus.streakBonus*100).toFixed(0)}%）</span></div>
+                    <div className="text-sm text-gray-300 mt-1">Lv.{guild.level}</div>
+                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>
@@ -191,11 +191,11 @@ const GuildPage: React.FC = () => {
               )}
 
               <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                <h3 className="font-semibold mb-3">メンバー</h3>
+                <h3 className="font-semibold mb-3">メンバーリスト ({members.length}/5)</h3>
                 {members.length === 0 ? (
                   <p className="text-gray-400 text-sm">メンバーがいません</p>
                 ) : (
-                  <ul className="space-y-2">
+                  <ul className="space-y-2 text-base">
                     {members.map(m => (
                       <li key={m.user_id} className="flex items-center gap-2">
                         <button onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }} aria-label="ユーザーページへ">

--- a/src/utils/guildBonus.ts
+++ b/src/utils/guildBonus.ts
@@ -24,15 +24,16 @@ export function computeGuildBonus(level: number, contributedMemberCount: number,
 
 /** 数値倍率から "+1.20x (+20.00%)" のような表記を返す */
 export function formatMultiplier(multiplier: number): string {
-  const percent = (multiplier - 1) * 100;
-  return `+${multiplier.toFixed(2)}x (+${percent.toFixed(2)}%)`;
+  const rounded = Number(multiplier.toFixed(2));
+  const percent = (rounded - 1) * 100;
+  return `+${rounded.toFixed(2)}x (+${percent.toFixed(1)}%)`;
 }
 
 /** ボーナス内訳 "(Lv +x.xx, Mem +y.yy)" のような短い表示 */
 export function formatBonusBreakdown(levelBonus: number, memberBonus: number, streakBonus = 0): string {
-  const lvPct = (levelBonus * 100).toFixed(2);
-  const memPct = (memberBonus * 100).toFixed(0);
-  const stPct = (streakBonus * 100).toFixed(0);
+  const lvPct = (levelBonus * 100).toFixed(1);
+  const memPct = (memberBonus * 100).toFixed(1);
+  const stPct = (streakBonus * 100).toFixed(1);
   return `(Lv +${lvPct}%, Mem +${memPct}%, St +${stPct}%)`;
 }
 


### PR DESCRIPTION
## 概要
- ギルドボーナス計算にストリークを含め小数表示を揃えました
- ギルド情報に今月のXP/順位を追加し、メンバーリスト文字サイズや掲示板配置を調整
- ギルドID表示を廃止しギルド名を表示、説明編集にキャンセルボタンを追加

## テスト
- `npm run lint` (失敗: 既存のanyなど多数)
- `npm run type-check` (失敗: 既存の型エラー多数)
- `npm test` (スクリプト未定義)


------
https://chatgpt.com/codex/tasks/task_e_68a3d4765cb48328ae90c484e99c7541