### PR TITLE
fix guild bonus display and diary page hooks

### DIFF
--- a/src/components/diary/DiaryPage.tsx
+++ b/src/components/diary/DiaryPage.tsx
@@ -56,6 +56,8 @@ const DiaryPage: React.FC = () => {
   const [editText, setEditText] = useState<string>('');
   const toast = useToast();
   const [joinedGuild, setJoinedGuild] = useState<Guild | null>(null);
+  const [hoveredTitle, setHoveredTitle] = useState<boolean>(false);
+  const [clickedTitle, setClickedTitle] = useState<boolean>(false);
 
   useEffect(() => {
     const checkHash = () => {
@@ -210,8 +212,6 @@ const DiaryPage: React.FC = () => {
     }
   };
 
-  const [hoveredTitle, setHoveredTitle] = useState<boolean>(false);
-  const [clickedTitle, setClickedTitle] = useState<boolean>(false);
 
   return (
     <div className="w-full h-full flex flex-col bg-gradient-game text-white">

--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -25,7 +25,7 @@ import GuildBoard from '@/components/guild/GuildBoard';
 import GameHeader from '@/components/ui/GameHeader';
 import { calcLevel } from '@/platform/supabaseXp';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
+import { computeGuildBonus } from '@/utils/guildBonus';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
 import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from 'react-icons/fa';
 
@@ -245,6 +245,7 @@ const GuildDashboard: React.FC = () => {
         const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
         const streakBonus = Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0);
         const bonus = computeGuildBonus(myGuild.level || 1, contributors, streakBonus);
+        const totalPercent = (bonus.levelBonus + bonus.memberBonus + bonus.streakBonus) * 100;
         const levelInfo = calcLevel(myTotalContribXp);
         const levelProgress = (levelInfo.remainder / levelInfo.nextLevelXp) * 100;
         const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
@@ -253,14 +254,17 @@ const GuildDashboard: React.FC = () => {
 
         return (
                 <div className="w-full h-full flex flex-col bg-gradient-game text-white">
-                        <GameHeader title={myGuild.name} />
+                        <GameHeader />
                         <div className="flex-1 overflow-y-auto p-4 sm:p-6">
                                 <div className="max-w-4xl mx-auto space-y-4">
                                         <div className="bg-slate-800 border border-slate-700 rounded p-4">
                                                 <h3 className="font-semibold mb-2">ギルド情報</h3>
-                                                <p className="text-sm mb-2">{myGuild.description || 'なし'}</p>
+                                                <p className="text-sm font-bold mb-1">{myGuild.name}</p>
+                                                {myGuild.description && (
+                                                        <p className="text-sm mb-2">{myGuild.description}</p>
+                                                )}
                                                 <div className="text-sm text-gray-300">リーダー: {myGuild.leader_id === user?.id ? 'あなた' : members.find(m => m.user_id === myGuild.leader_id)?.nickname || '不明'}</div>
-                                                <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
+                                                <div className="text-sm text-green-400 mt-1">ギルドボーナス: +{totalPercent.toFixed(1)}% <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
                                                 <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                                                         <div className="bg-slate-900 rounded p-3 border border-slate-700">
                                                                 <div className="text-gray-400">今月XP</div>

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -4,7 +4,7 @@ import { DEFAULT_AVATAR_URL } from '@/utils/constants';
 import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild, fetchGuildDailyStreaks } from '@/platform/supabaseGuilds';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
 import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from 'react-icons/fa';
-import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
+import { computeGuildBonus } from '@/utils/guildBonus';
 
 const GuildPage: React.FC = () => {
   const [open, setOpen] = useState(window.location.hash.startsWith('#guild'));
@@ -71,6 +71,7 @@ const GuildPage: React.FC = () => {
   const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
   const streakBonus = Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0);
   const bonus = computeGuildBonus(guild?.level || 1, contributors, streakBonus);
+  const totalPercent = (bonus.levelBonus + bonus.memberBonus + bonus.streakBonus) * 100;
   const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
   const mvp = mvpUserId ? members.find(x => x.user_id === mvpUserId) : undefined;
   const mvpXp = memberMonthly.find(x => x.user_id === mvpUserId)?.monthly_xp || 0;
@@ -116,7 +117,7 @@ const GuildPage: React.FC = () => {
                   <div>
                     <div className="text-2xl font-bold">{guild.name}{guild.disbanded ? '（解散したギルド）' : ''}</div>
                     <div className="text-sm text-gray-300 mt-1">Lv.{guild.level}</div>
-                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
+                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: +{totalPercent.toFixed(1)}% <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>


### PR DESCRIPTION
## Summary
- show guild names and precise bonus percentages on dashboards
- compute total guild bonus with level bonus and remove multiplier display
- prevent hook order errors on user diary page

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run type-check` *(fails: Type 'unknown'...)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d7b092b88328a18e9c9e8277a3fd