### PR TITLE
ギルド機能の変更と脱退理由の実装

### DIFF
--- a/src/components/game/ResultModal.tsx
+++ b/src/components/game/ResultModal.tsx
@@ -75,7 +75,8 @@ const ResultModal: React.FC = () => {
             if (myGuild) {
               const memberMonthly = await fetchGuildMemberMonthlyXp(myGuild.id);
               const contributors = memberMonthly.filter(m => Number(m.monthly_xp || 0) >= 1).length;
-              const b = computeGuildBonus(myGuild.level || 1, contributors);
+              // ResultModalではストリーク詳細を取得しないため、ストリークは0として計算（ストリークはチャレンジタイプに限定して別画面で反映）
+              const b = computeGuildBonus(myGuild.level || 1, contributors, 0);
               guildMultiplier = b.totalMultiplier;
             }
           } catch (e) {
@@ -686,4 +687,4 @@ const ResultModal: React.FC = () => {
   );
 };
 
-export default ResultModal; 
+export default ResultModal;

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -70,7 +70,8 @@ const GuildPage: React.FC = () => {
 
   const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
   const streakBonus = Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0);
-  const bonus = computeGuildBonus(guild?.level || 1, contributors, streakBonus);
+  const appliedStreakBonus = guild?.guild_type === 'challenge' ? streakBonus : 0;
+  const bonus = computeGuildBonus(guild?.level || 1, contributors, appliedStreakBonus);
   const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
   const mvp = mvpUserId ? members.find(x => x.user_id === mvpUserId) : undefined;
   const mvpXp = memberMonthly.find(x => x.user_id === mvpUserId)?.monthly_xp || 0;
@@ -116,7 +117,8 @@ const GuildPage: React.FC = () => {
                   <div>
                     <div className="text-2xl font-bold">{guild.name}{guild.disbanded ? '（解散したギルド）' : ''}</div>
                     <div className="text-sm text-gray-300 mt-1">Lv.{guild.level}</div>
-                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}% / ストリーク +{(bonus.streakBonus*100).toFixed(1)}%）</span></div>
+                    <div className="text-xs text-gray-400 mt-1">タイプ: {guild.guild_type === 'challenge' ? 'チャレンジ' : 'カジュアル'}</div>
+                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(bonus.totalMultiplier)} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}%{guild.guild_type === 'challenge' ? ` / ストリーク +${(bonus.streakBonus*100).toFixed(1)}%` : ''}）</span></div>
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>
@@ -159,6 +161,14 @@ const GuildPage: React.FC = () => {
               {guild.guild_type === 'challenge' && (
                 <div className="bg-slate-800 border border-slate-700 rounded p-4">
                   <h3 className="font-semibold mb-3">チャレンジ</h3>
+                  <div className="mb-3 bg-slate-900 rounded p-3 border border-slate-700">
+                    <div className="text-gray-400">ギルドクエスト（今月）</div>
+                    <div className="text-sm mt-1">今月の獲得XPを1,000,000に到達させよう。未達の場合は月末に解散となります。</div>
+                    <div className="h-2 bg-slate-700 rounded overflow-hidden mt-2">
+                      <div className="h-full bg-purple-500" style={{ width: `${Math.min(100, (seasonXp / 1000000) * 100)}%` }} />
+                    </div>
+                    <div className="text-[11px] text-gray-300 mt-1">{seasonXp.toLocaleString()} / 1,000,000</div>
+                  </div>
                   <ul className="space-y-2">
                     {members.map(m => (
                       <li key={m.user_id} className="bg-slate-900 p-2 rounded">
@@ -220,7 +230,7 @@ const GuildPage: React.FC = () => {
                           </div>
                           <div className="text-xs text-gray-400">Lv.{m.level} / {m.rank}</div>
                           {/* チャレンジギルド: 連続達成進捗 */}
-                          {streaks[m.user_id] && (
+                          {guild.guild_type === 'challenge' && streaks[m.user_id] && (
                             <div className="mt-1">
                               <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
                                 <div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />

--- a/supabase/migrations/20250902103000_guild_leave_logs_and_rpcs.sql
+++ b/supabase/migrations/20250902103000_guild_leave_logs_and_rpcs.sql
@@ -1,0 +1,122 @@
+-- Guild leave logs and helper RPCs for leave/disband; also extend kick RPC to log
+
+create table if not exists public.guild_leave_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  guild_id uuid not null references public.guilds(id) on delete cascade,
+  reason text not null check (reason in ('left','kicked','disbanded')),
+  guild_name text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists guild_leave_logs_user_created_idx on public.guild_leave_logs(user_id, created_at desc);
+
+alter table public.guild_leave_logs enable row level security;
+
+drop policy if exists guild_leave_logs_select_own on public.guild_leave_logs;
+create policy guild_leave_logs_select_own on public.guild_leave_logs for select using (user_id = auth.uid());
+
+-- Users can insert their own leave log when leaving via client (fallback). Generally logs are written via RPCs below.
+drop policy if exists guild_leave_logs_insert_self on public.guild_leave_logs;
+create policy guild_leave_logs_insert_self on public.guild_leave_logs for insert with check (user_id = auth.uid());
+
+-- RPC: Leave my guild with leader handover and logging
+create or replace function public.rpc_guild_leave()
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+  _guild_id uuid;
+  _role text;
+  _next_leader uuid;
+  _gname text;
+  _members_count integer;
+begin
+  if _uid is null then raise exception 'Auth required'; end if;
+
+  select gm.guild_id, gm.role, g.name into _guild_id, _role, _gname
+  from public.guild_members gm
+  join public.guilds g on g.id = gm.guild_id
+  where gm.user_id = _uid
+  limit 1;
+
+  if _guild_id is null then raise exception 'Not in a guild'; end if;
+
+  select count(*) into _members_count from public.guild_members where guild_id = _guild_id;
+
+  if _members_count <= 1 then
+    update public.guilds set disbanded = true, name = '解散したギルド', updated_at = now() where id = _guild_id;
+    delete from public.guild_members where guild_id = _guild_id and user_id = _uid;
+    insert into public.guild_leave_logs(user_id, guild_id, reason, guild_name)
+    values(_uid, _guild_id, 'disbanded', coalesce(_gname, ''));
+    return;
+  end if;
+
+  if _role = 'leader' then
+    select user_id into _next_leader
+    from public.guild_members
+    where guild_id = _guild_id and user_id <> _uid
+    order by joined_at asc
+    limit 1;
+    if _next_leader is null then
+      raise exception 'No candidate for next leader';
+    end if;
+    update public.guilds set leader_id = _next_leader, updated_at = now() where id = _guild_id;
+    update public.guild_members set role = 'leader' where guild_id = _guild_id and user_id = _next_leader;
+  end if;
+
+  delete from public.guild_members where guild_id = _guild_id and user_id = _uid;
+  insert into public.guild_leave_logs(user_id, guild_id, reason, guild_name)
+  values(_uid, _guild_id, 'left', coalesce(_gname, ''));
+end;
+$$;
+
+grant execute on function public.rpc_guild_leave() to anon, authenticated;
+
+-- RPC: Disband my guild (leader only), remove all members, and log for each
+create or replace function public.rpc_guild_disband()
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+  _gid uuid;
+  _gname text;
+begin
+  if _uid is null then raise exception 'Auth required'; end if;
+  select id, name into _gid, _gname from public.guilds where leader_id = _uid;
+  if _gid is null then raise exception 'Only leader can disband'; end if;
+
+  update public.guilds set disbanded = true, name = '解散したギルド', updated_at = now() where id = _gid;
+
+  -- Log for all current members
+  insert into public.guild_leave_logs(user_id, guild_id, reason, guild_name)
+  select gm.user_id, gm.guild_id, 'disbanded', coalesce(_gname, '') from public.guild_members gm where gm.guild_id = _gid;
+
+  -- Remove all members
+  delete from public.guild_members where guild_id = _gid;
+end;
+$$;
+
+grant execute on function public.rpc_guild_disband() to anon, authenticated;
+
+-- Extend kick RPC to log kicked user
+create or replace function public.rpc_guild_kick_member(p_member_user_id uuid)
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+  _gid uuid;
+  _gname text;
+begin
+  select id, name into _gid, _gname from public.guilds where leader_id = _uid;
+  if _gid is null then raise exception 'Only leader can kick'; end if;
+  if p_member_user_id = _uid then raise exception 'Leader cannot kick self via this RPC'; end if;
+
+  delete from public.guild_members where guild_id = _gid and user_id = p_member_user_id;
+  insert into public.guild_leave_logs(user_id, guild_id, reason, guild_name)
+  values(p_member_user_id, _gid, 'kicked', coalesce(_gname, ''));
+end;
+$$;
+
+grant execute on function public.rpc_guild_kick_member(uuid) to anon, authenticated;
+


### PR DESCRIPTION
Introduces guild types to control streak bonuses and add a monthly quest, and displays the reason for guild departure.

This PR implements three key features:
1.  **Guild Types:** Casual guilds no longer receive streak bonuses, while Challenge guilds do. The guild type is now visible on the dashboard and guild page.
2.  **Guild Quest:** Challenge guilds now have a monthly XP quest (1,000,000 XP target) displayed on their dashboards. Upon disbandment, all members are now removed and logged.
3.  **Leave Reason Display:** When a user leaves, is kicked from, or their guild disbands, the reason and guild name are now displayed on the unjoined guild screen, supported by new database logging and RPCs.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ddd9062-4a38-4942-ac37-a74fdc710e08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ddd9062-4a38-4942-ac37-a74fdc710e08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

