### PR TITLE
Fix guild page embed error

### DIFF
--- a/src/platform/supabaseGuilds.ts
+++ b/src/platform/supabaseGuilds.ts
@@ -369,7 +369,7 @@ export async function fetchPendingInvitationsForMe(): Promise<GuildInvitation[]>
   if (!user) return [];
   const { data, error } = await supabase
     .from('guild_invitations')
-    .select('id, guild_id, inviter_id, invitee_id, status, guilds(name), inviter:profiles(nickname)')
+    .select('id, guild_id, inviter_id, invitee_id, status, guilds(name), inviter:profiles!guild_invitations_inviter_id_fkey(nickname)')
     .eq('invitee_id', user.id)
     .eq('status', 'pending')
     .order('created_at', { ascending: false });


### PR DESCRIPTION
Specify foreign key for `inviter:profiles` relationship to resolve ambiguity and fix guild page loading error.

The `guild_invitations` table has two foreign keys to `profiles` (`inviter_id` and `invitee_id`). When embedding `profiles` from `guild_invitations`, Supabase could not determine which relationship to use, leading to the error 'Could not embed because more than one relationship was found for 'guild_invitations' and 'profiles''. Explicitly naming the `inviter_id` foreign key (`guild_invitations_inviter_id_fkey`) in the select statement resolves this ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f056208-93d9-4640-a00b-60c6eb6a913f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f056208-93d9-4640-a00b-60c6eb6a913f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

