### PR TITLE
ストリークレベルの実装とダッシュボード表示

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import {
-	getMyGuild,
-	getGuildMembers,
-	searchGuilds,
-	requestJoin,
-	createGuild,
-	fetchMyGuildRank,
-	fetchGuildMemberMonthlyXp,
-	fetchJoinRequestsForMyGuild,
-	approveJoinRequest,
-	rejectJoinRequest,
-	Guild,
-	GuildMember,
-	GuildJoinRequest,
+        getMyGuild,
+        getGuildMembers,
+        searchGuilds,
+        requestJoin,
+        createGuild,
+        fetchMyGuildRank,
+        fetchGuildMemberMonthlyXp,
+        fetchJoinRequestsForMyGuild,
+        approveJoinRequest,
+        rejectJoinRequest,
+        Guild,
+        GuildMember,
+        GuildJoinRequest,
         fetchMyGuildContributionTotal,
         updateGuildDescription,
         disbandMyGuild,
@@ -24,6 +24,7 @@ import {
         acceptInvitation,
         rejectInvitation,
         GuildInvitation,
+        type GuildStreak,
 } from '@/platform/supabaseGuilds';
 import GuildBoard from '@/components/guild/GuildBoard';
 import GameHeader from '@/components/ui/GameHeader';
@@ -62,7 +63,7 @@ const GuildDashboard: React.FC = () => {
 	const [descEdit, setDescEdit] = useState<string>('');
 	const [editingDesc, setEditingDesc] = useState<boolean>(false);
 	const [isLeader, setIsLeader] = useState<boolean>(false);
-	const [streaks, setStreaks] = useState<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>>({});
+        const [streaks, setStreaks] = useState<Record<string, GuildStreak>>({});
 	const [newGuildType, setNewGuildType] = useState<'casual'|'challenge'>('casual');
 	const [lastGuildInfo, setLastGuildInfo] = useState<{ id: string; name: string } | null>(null);
         const [lastGuildEvent, setLastGuildEvent] = useState<'left'|'kicked'|'disband'|null>(null);
@@ -521,15 +522,15 @@ const GuildDashboard: React.FC = () => {
 																</div>
 															)}
 														</div>
-														<div className="text-xs text-gray-400">Lv {m.level} / {m.rank}</div>
-														{myGuild.guild_type === 'challenge' && streaks[m.user_id] && (
-															<div className="mt-1">
-																<div className="h-1.5 bg-slate-700 rounded overflow-hidden">
-																	<div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
-																</div>
-																<div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
-															</div>
-														)}
+                                                                                                                <div className="text-xs text-gray-400">Lv {m.level} / {m.rank}{myGuild.guild_type === 'challenge' && streaks[m.user_id] ? ` / ストリークLv${streaks[m.user_id].level}` : ''}</div>
+                                                                                                                {myGuild.guild_type === 'challenge' && streaks[m.user_id] && (
+                                                                                                                        <div className="mt-1">
+                                                                                                                                <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
+                                                                                                                                        <div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
+                                                                                                                                </div>
+                                                                                                                                <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
+                                                                                                                        </div>
+                                                                                                                )}
 													</div>
 													{m.role === 'leader' && (
 														<span className="text-[10px] px-2 py-0.5 rounded-full bg-yellow-500 text-black font-bold">Leader</span>

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild, fetchGuildDailyStreaks } from '@/platform/supabaseGuilds';
+import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild, fetchGuildDailyStreaks, type GuildStreak } from '@/platform/supabaseGuilds';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
 import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from 'react-icons/fa';
 import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
@@ -17,7 +17,7 @@ const GuildPage: React.FC = () => {
   const [rank, setRank] = useState<number | null>(null);
   const [isMember, setIsMember] = useState<boolean>(false);
   const [busy, setBusy] = useState<boolean>(false);
-  const [streaks, setStreaks] = useState<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>>({});
+  const [streaks, setStreaks] = useState<Record<string, GuildStreak>>({});
 
   useEffect(() => {
     const handler = () => setOpen(window.location.hash.startsWith('#guild'));
@@ -176,14 +176,14 @@ const GuildPage: React.FC = () => {
                                 {(() => {
                                   const s = streaks[m.user_id];
                                   if (!s) return 'Lv.0 (+0%)';
-                                  return `Lv.${Math.min(s.daysCurrentStreak, s.tierMaxDays)} (+${Math.round(s.tierPercent*100)}%)`;
+                                  return `Lv.${s.level} (+${Math.round(s.tierPercent*100)}%)`;
                                 })()}
                               </span>
                             </div>
                             <div className="h-1.5 bg-slate-700 rounded overflow-hidden mt-1">
                               <div className="h-full bg-green-500" style={{ width: `${streaks[m.user_id] ? Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100) : 0}%` }} />
                             </div>
-                            <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id]?.display || '0/5 +0%'}</div>
+                            <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id]?.display || 'Lv0 0/5 +0%'}</div>
                           </div>
                           {/* チャレンジボーナス倍率 */}
                           <div className="text-xs text-green-400 whitespace-nowrap">×{(1 + (streaks[m.user_id]?.tierPercent || 0)).toFixed(2)}</div>
@@ -222,7 +222,7 @@ const GuildPage: React.FC = () => {
                               </div>
                             )}
                           </div>
-                          <div className="text-xs text-gray-400">Lv.{m.level} / {m.rank}</div>
+                          <div className="text-xs text-gray-400">Lv.{m.level} / {m.rank}{guild.guild_type === 'challenge' && streaks[m.user_id] ? ` / ストリークLv${streaks[m.user_id].level}` : ''}</div>
                           {/* チャレンジギルド: 連続達成進捗 */}
                           {guild.guild_type === 'challenge' && streaks[m.user_id] && (
                             <div className="mt-1">

--- a/src/platform/supabaseGuilds.ts
+++ b/src/platform/supabaseGuilds.ts
@@ -105,30 +105,36 @@ export async function getGuildMembers(guildId: string): Promise<GuildMember[]> {
   }));
 }
 
+export interface GuildStreak {
+  level: number;
+  daysCurrentStreak: number; // 現在のレベル内での達成日数
+  tierPercent: number; // レベルに応じたボーナス（例: 0.15）
+  tierMaxDays: number; // 常に5
+  display: string; // 例: "Lv3 2/5 +15%"
+}
+
 /**
- * ギルド内メンバーの当月日次貢献ストリークを取得（xp_historyベース、クライアント集計）
- * 戻り値: ユーザーID -> { daysCurrentStreak, tierPercent, tierMaxDays, display }
+ * ギルド内メンバーの日次貢献ストリークを取得（xp_historyベース、クライアント集計）
+ * 月を跨いでもリセットされない
+ * 戻り値: ユーザーID -> GuildStreak
  */
 export async function fetchGuildDailyStreaks(
   guildId: string,
   baseDate?: Date,
-): Promise<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>> {
+): Promise<Record<string, GuildStreak>> {
   const supabase = getSupabaseClient();
   const now = baseDate ? new Date(baseDate) : new Date();
-  const monthStartUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const monthStartStr = monthStartUtc.toISOString();
 
   // ギルドメンバー一覧
   const members = await getGuildMembers(guildId);
   const userIds = members.map(m => m.user_id);
   if (userIds.length === 0) return {};
 
-  // 当月の xp_history を取得
+  // 全期間の xp_history を取得
   const { data, error } = await supabase
     .from('xp_history')
     .select('user_id, created_at, gained_xp')
-    .in('user_id', userIds)
-    .gte('created_at', monthStartStr);
+    .in('user_id', userIds);
   if (error) {
     console.warn('fetchGuildDailyStreaks xp_history error:', error);
     return {};
@@ -139,49 +145,48 @@ export async function fetchGuildDailyStreaks(
   (data || []).forEach((r: any) => {
     const uid = r.user_id as string;
     const dt = new Date(r.created_at);
-    // UTC日付キー
     const key = new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate())).toISOString().slice(0, 10);
     if (!byUser.has(uid)) byUser.set(uid, new Set<string>());
     if (Number(r.gained_xp || 0) > 0) byUser.get(uid)!.add(key);
   });
 
-  // 連続達成ストリークを計算（最後の貢献日から遡って連続している日数）
-  const result: Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }> = {};
-  const todayKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString().slice(0, 10);
+  const result: Record<string, GuildStreak> = {};
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const todayKey = today.toISOString().slice(0, 10);
 
   for (const uid of userIds) {
     const days = byUser.get(uid) || new Set<string>();
-    // 最新貢献日（文字列比較でOK: YYYY-MM-DD）
-    const sortedDays = Array.from(days.values()).sort();
-    let streak = 0;
-    if (sortedDays.length > 0) {
-      // 最新日から遡ってカウント
-      let cursor = new Date(sortedDays[sortedDays.length - 1] + 'T00:00:00.000Z');
-      while (true) {
-        const key = cursor.toISOString().slice(0, 10);
-        if (days.has(key)) {
-          streak += 1;
-          // 前日へ
-          cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth(), cursor.getUTCDate() - 1));
-        } else {
-          break;
-        }
-      }
+    if (days.size === 0) {
+      result[uid] = { level: 0, daysCurrentStreak: 0, tierPercent: 0, tierMaxDays: 5, display: 'Lv0 0/5 +0%' };
+      continue;
     }
 
-    // ティア計算
-    let tierPercent = 0;
-    let tierMaxDays = 5;
-    if (streak >= 26) { tierPercent = 0.30; tierMaxDays = 30; }
-    else if (streak >= 21) { tierPercent = 0.25; tierMaxDays = 25; }
-    else if (streak >= 16) { tierPercent = 0.20; tierMaxDays = 20; }
-    else if (streak >= 11) { tierPercent = 0.15; tierMaxDays = 15; }
-    else if (streak >= 6)  { tierPercent = 0.10; tierMaxDays = 10; }
-    else if (streak >= 1)  { tierPercent = 0.05; tierMaxDays = 5; }
-    else { tierPercent = 0; tierMaxDays = 5; }
+    const sorted = Array.from(days.values()).sort();
+    let level = 0;
+    let progress = 0;
+    let cursor = new Date(sorted[0] + 'T00:00:00.000Z');
 
-    const display = streak > 0 ? `${Math.min(streak, tierMaxDays)}/${tierMaxDays} +${Math.round(tierPercent * 100)}%` : '0/5 +0%';
-    result[uid] = { daysCurrentStreak: streak, tierPercent, tierMaxDays, display };
+    while (cursor <= today) {
+      const key = cursor.toISOString().slice(0, 10);
+      const success = days.has(key);
+      if (success) {
+        progress += 1;
+        if (progress >= 5) {
+          if (level < 6) level += 1;
+          progress = 0;
+        }
+      } else {
+        if (key !== todayKey) {
+          if (level > 0) level -= 1;
+          progress = 0;
+        }
+      }
+      cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth(), cursor.getUTCDate() + 1));
+    }
+
+    const tierPercent = level * 0.05;
+    const display = `Lv${level} ${progress}/5 +${Math.round(tierPercent * 100)}%`;
+    result[uid] = { level, daysCurrentStreak: progress, tierPercent, tierMaxDays: 5, display };
   }
 
   return result;


### PR DESCRIPTION
## 概要
- ストリークレベルを5日ごとに加算し、未達成日はレベルが1下がるよう集計を更新
- ストリークは月でリセットされず、最大レベル6で+30%XPボーナス
- ギルドダッシュボードとギルドページにストリークレベル表示を追加

## テスト
- `npm run lint` (エラー有り)
- `npm run type-check` (エラー有り)


------
https://chatgpt.com/codex/tasks/task_e_68a4166985e88328aecd56fea896f633