### PR TITLE
Keep header when loading guilds page

### DIFF
--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -7,7 +7,6 @@ import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from '
 import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
 
 const GuildPage: React.FC = () => {
-  const [open, setOpen] = useState(window.location.hash.startsWith('#guild'));
   const [guildId, setGuildId] = useState<string | null>(null);
   const [guild, setGuild] = useState<Guild | null>(null);
   const [members, setMembers] = useState<Array<{ user_id: string; nickname: string; avatar_url?: string; level: number; rank: string; role: 'leader' | 'member' }>>([]);
@@ -20,17 +19,16 @@ const GuildPage: React.FC = () => {
   const [streaks, setStreaks] = useState<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>>({});
 
   useEffect(() => {
-    const handler = () => setOpen(window.location.hash.startsWith('#guild'));
-    window.addEventListener('hashchange', handler);
-    return () => window.removeEventListener('hashchange', handler);
+    const updateGuildId = () => {
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      const id = params.get('id');
+      setGuildId(id);
+    };
+    
+    updateGuildId();
+    window.addEventListener('hashchange', updateGuildId);
+    return () => window.removeEventListener('hashchange', updateGuildId);
   }, []);
-
-  useEffect(() => {
-    if (!open) return;
-    const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
-    const id = params.get('id');
-    setGuildId(id);
-  }, [open]);
 
   useEffect(() => {
     (async () => {
@@ -66,7 +64,7 @@ const GuildPage: React.FC = () => {
     })();
   }, [guildId]);
 
-  if (!open) return null;
+
 
   const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
   const streakBonus = guild?.guild_type === 'challenge' ? Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0) : 0;


### PR DESCRIPTION
Remove redundant `open` state from GuildPage to fix header disappearance on navigation.

The `GuildPage` component was conditionally returning `null` based on an internal `open` state, which was redundant as the `LegacyApp.tsx` already handles its rendering based on the URL hash. This caused the entire page, including the header, to disappear upon navigation. Removing this state ensures the page renders consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-c700f280-bece-4b82-8a9f-31bede54d7b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c700f280-bece-4b82-8a9f-31bede54d7b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

