### PR TITLE
Keep header when loading guilds page

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -322,8 +322,26 @@ const GuildDashboard: React.FC = () => {
 		}
 	};
 
-	if (loading) return <div className="text-center py-8">Loading...</div>;
-	if (!user) return <div className="text-center py-8">Please log in to view this page.</div>;
+	if (loading) return (
+		<div className="w-full h-full flex flex-col bg-gradient-game text-white">
+					<GameHeader />
+					<div className="flex-1 overflow-y-auto p-4 sm:p-6">
+								<div className="max-w-4xl mx-auto space-y-4 text-center">
+										<div className="text-center py-8">Loading...</div>
+								</div>
+					</div>
+		</div>
+	);
+	if (!user) return (
+		<div className="w-full h-full flex flex-col bg-gradient-game text-white">
+					<GameHeader />
+					<div className="flex-1 overflow-y-auto p-4 sm:p-6">
+								<div className="max-w-4xl mx-auto space-y-4 text-center">
+										<div className="text-center py-8">ログインが必要です。</div>
+								</div>
+					</div>
+		</div>
+	);
         if (!myGuild) {
                 return (
                         <div className="w-full h-full flex flex-col bg-gradient-game text-white">


### PR DESCRIPTION
Ensure `GameHeader` is always displayed on the Guilds dashboard to prevent it from disappearing during loading or when not logged in.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e4b6543-874c-4f3d-a0f1-dfca2524983f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e4b6543-874c-4f3d-a0f1-dfca2524983f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

