### PR TITLE
Keep game header visible on guild button press

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -322,8 +322,26 @@ const GuildDashboard: React.FC = () => {
 		}
 	};
 
-	if (loading) return <div className="text-center py-8">Loading...</div>;
-	if (!user) return <div className="text-center py-8">Please log in to view this page.</div>;
+	if (loading) return (
+		<div className="w-full h-full flex flex-col bg-gradient-game text-white">
+					<GameHeader />
+					<div className="flex-1 overflow-y-auto p-4 sm:p-6">
+							<div className="max-w-4xl mx-auto">
+									<p className="text-center py-8">Loading...</p>
+							</div>
+					</div>
+		</div>
+	);
+	if (!user) return (
+		<div className="w-full h-full flex flex-col bg-gradient-game text-white">
+					<GameHeader />
+					<div className="flex-1 overflow-y-auto p-4 sm:p-6">
+							<div className="max-w-4xl mx-auto">
+									<p className="text-center py-8">Please log in to view this page.</p>
+							</div>
+					</div>
+		</div>
+	);
         if (!myGuild) {
                 return (
                         <div className="w-full h-full flex flex-col bg-gradient-game text-white">


### PR DESCRIPTION
Ensure the game header remains visible when navigating to the Guild Dashboard, even during loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-63c76a3e-2f2f-4638-a92a-c777b43f907f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63c76a3e-2f2f-4638-a92a-c777b43f907f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

