### PR TITLE
ギルド関連UIの調整

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -404,6 +404,7 @@ const GuildDashboard: React.FC = () => {
                                                                                 <li key={g.id} onClick={() => requestJoin(g.id)} className="cursor-pointer hover:bg-slate-800 p-2 rounded flex items-center gap-2">
                                                                                         <span className="font-medium">{g.name}</span>
                                                                                         <span className={`text-sm px-2 py-0.5 rounded-full ${g.guild_type === 'challenge' ? 'bg-pink-500 text-white' : 'bg-slate-600 text-white'}`}>{g.guild_type === 'challenge' ? 'チャレンジ' : 'カジュアル'}</span>
+                                                                                        <span className="text-xs text-gray-300 ml-auto">メンバー数:{g.members_count}/5名</span>
                                                                                 </li>
                                                                         ))}
                                                                 </ul>

--- a/src/components/guild/GuildInfoPage.tsx
+++ b/src/components/guild/GuildInfoPage.tsx
@@ -48,7 +48,7 @@ const GuildInfoPage: React.FC = () => {
                                                         </div>
                                                         <div>
                                                                 <h4 className="font-medium text-lg mb-1">メンバー独立性</h4>
-                                                                <p className="text-sm text-gray-300">各メンバーのストリークは独立して管理されます。メンバー5人全員がレベル6の場合、合計で150％のストリークボーナスを獲得できます。</p>
+                                                                <p className="text-sm text-gray-300">各メンバーのストリークは独立して管理されます。メンバー5人全員がレベル6の場合、合計で+150％(2.5倍)のストリークボーナスを獲得できます。さらにメンバーボーナスと合わせて+200%(3倍)のギルドボーナスになります。</p>
                                                         </div>
                                                         <div>
                                                                 <h4 className="font-medium text-lg mb-1">月跨ぎ対応</h4>

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -10,7 +10,7 @@ const GuildPage: React.FC = () => {
   const [open, setOpen] = useState(window.location.hash.startsWith('#guild'));
   const [guildId, setGuildId] = useState<string | null>(null);
   const [guild, setGuild] = useState<Guild | null>(null);
-  const [members, setMembers] = useState<Array<{ user_id: string; nickname: string; avatar_url?: string; level: number; rank: string; role: 'leader' | 'member' }>>([]);
+  const [members, setMembers] = useState<Array<{ user_id: string; nickname: string; avatar_url?: string; level: number; rank: string; role: 'leader' | 'member'; selected_title?: string | null }>>([]);
   const [loading, setLoading] = useState(true);
   const [memberMonthly, setMemberMonthly] = useState<Array<{ user_id: string; monthly_xp: number }>>([]);
   const [seasonXp, setSeasonXp] = useState<number>(0);
@@ -121,7 +121,10 @@ const GuildPage: React.FC = () => {
                       </span>
                     </div>
                     <div className="text-sm text-gray-300 mt-1">Lv.{guild.level}</div>
+                    <div className="text-sm text-gray-300 mt-1">メンバー数: {guild.members_count}/5名</div>
+                    {isMember && (
                     <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(1 + bonus.levelBonus + bonus.memberBonus + (guild.guild_type==='challenge'?bonus.streakBonus:0))} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}%{guild.guild_type==='challenge' ? ` / ストリーク +${(bonus.streakBonus*100).toFixed(1)}%` : ''}）</span></div>
+                    )}
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>
@@ -145,7 +148,7 @@ const GuildPage: React.FC = () => {
                 )}
               </div>
 
-              {guild.guild_type === 'challenge' && (
+              {isMember && guild.guild_type === 'challenge' && (
                 <div className="bg-slate-800 border border-slate-700 rounded p-4">
                   <h3 className="font-semibold mb-2">ギルドクエスト</h3>
                   <p className="text-sm text-gray-300">今月の獲得経験値が1,000,000に達しないと、月末にギルドは解散（メンバー0人）となります。</p>
@@ -159,41 +162,7 @@ const GuildPage: React.FC = () => {
                 </div>
               )}
 
-              {/* チャレンジギルド: チャレンジ見出し */}
-              {guild.guild_type === 'challenge' && (
-                <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                  <h3 className="font-semibold mb-3">チャレンジ</h3>
-                  <ul className="space-y-2">
-                    {members.map(m => (
-                      <li key={m.user_id} className="bg-slate-900 p-2 rounded">
-                        <div className="flex items-center gap-3">
-                          <img src={m.avatar_url || DEFAULT_AVATAR_URL} className="w-8 h-8 rounded-full" />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <button className="hover:text-blue-400 truncate" onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }}>{m.nickname}</button>
-                              {/* レベル（チャレンジレベル=連続日数ティア） */}
-                              <span className="text-xs text-yellow-400">
-                                {(() => {
-                                  const s = streaks[m.user_id];
-                                  if (!s) return 'Lv.0 (+0%)';
-                                  return `Lv.${Math.min(s.daysCurrentStreak, s.tierMaxDays)} (+${Math.round(s.tierPercent*100)}%)`;
-                                })()}
-                              </span>
-                            </div>
-                            <div className="h-1.5 bg-slate-700 rounded overflow-hidden mt-1">
-                              <div className="h-full bg-green-500" style={{ width: `${streaks[m.user_id] ? Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100) : 0}%` }} />
-                            </div>
-                            <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id]?.display || '0/5 +0%'}</div>
-                          </div>
-                          {/* チャレンジボーナス倍率 */}
-                          <div className="text-xs text-green-400 whitespace-nowrap">×{(1 + (streaks[m.user_id]?.tierPercent || 0)).toFixed(2)}</div>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
+              {isMember && (
               <div className="bg-slate-800 border border-slate-700 rounded p-4">
                 <h3 className="font-semibold mb-3">メンバーリスト ({members.length}/5)</h3>
                 {members.length === 0 ? (
@@ -229,7 +198,7 @@ const GuildPage: React.FC = () => {
                               <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
                                 <div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
                               </div>
-                              <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
+                          <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
                             </div>
                           )}
                         </div>
@@ -245,6 +214,7 @@ const GuildPage: React.FC = () => {
                   </ul>
                 )}
               </div>
+              )}
             </>
           )}
         </div>

--- a/src/platform/supabaseGuilds.ts
+++ b/src/platform/supabaseGuilds.ts
@@ -153,9 +153,9 @@ export async function fetchGuildDailyStreaks(
     const nextLevelDays = (level + 1) * 5;
     const tierMaxDays = level < 6 ? 5 : days; // レベル6の場合は現在の日数を表示
     
-    const display = level < 6 
-      ? `Lv.${level} (${days % 5}/5日) +${Math.round(tierPercent * 100)}%`
-      : `Lv.${level} (${days}日) +${Math.round(tierPercent * 100)}%`;
+    const display = level < 6
+      ? `ストリークLv.${level} (${days % 5}/5日) +${Math.round(tierPercent * 100)}%`
+      : `ストリークLv.${level} (${days}日) +${Math.round(tierPercent * 100)}%`;
       
     result[uid] = { 
       daysCurrentStreak: days, 


### PR DESCRIPTION
## Summary
- ギルド情報ページのストリークボーナス説明を更新
- メンバー一覧のストリーク表記を「ストリークLv.」へ変更
- 他人のギルドページではギルドボーナス説明・ギルドクエスト・メンバーリストを非表示にし、ギルドカードへメンバー数を追加
- ギルド検索結果のカードにメンバー数を表示

## Testing
- `npm test` (missing script)
- `npm run lint` (fails: numerous lint errors)
- `npm run type-check` (fails: type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4441adf64832899f7fac57a46011b