### PR TITLE
ギルドページからチャレンジ要素を削除

### DIFF
--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -1,23 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild, fetchGuildDailyStreaks } from '@/platform/supabaseGuilds';
+import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild } from '@/platform/supabaseGuilds';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
 import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from 'react-icons/fa';
-import { computeGuildBonus, formatMultiplier } from '@/utils/guildBonus';
 
 const GuildPage: React.FC = () => {
   const [open, setOpen] = useState(window.location.hash.startsWith('#guild'));
   const [guildId, setGuildId] = useState<string | null>(null);
   const [guild, setGuild] = useState<Guild | null>(null);
-  const [members, setMembers] = useState<Array<{ user_id: string; nickname: string; avatar_url?: string; level: number; rank: string; role: 'leader' | 'member' }>>([]);
+  const [members, setMembers] = useState<Array<{ user_id: string; nickname: string; avatar_url?: string; level: number; rank: string; role: 'leader' | 'member'; selected_title?: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [memberMonthly, setMemberMonthly] = useState<Array<{ user_id: string; monthly_xp: number }>>([]);
   const [seasonXp, setSeasonXp] = useState<number>(0);
   const [rank, setRank] = useState<number | null>(null);
   const [isMember, setIsMember] = useState<boolean>(false);
   const [busy, setBusy] = useState<boolean>(false);
-  const [streaks, setStreaks] = useState<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>>({});
 
   useEffect(() => {
     const handler = () => setOpen(window.location.hash.startsWith('#guild'));
@@ -48,8 +46,6 @@ const GuildPage: React.FC = () => {
           ]);
           setMembers(m);
           setMemberMonthly(per);
-          const st = await fetchGuildDailyStreaks(g.id).catch(()=>({} as Record<string, any>));
-          setStreaks(st);
           // 今シーズン（当月）合計XPと順位
           const now = new Date();
           const currentMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0,10);
@@ -68,12 +64,6 @@ const GuildPage: React.FC = () => {
 
   if (!open) return null;
 
-  const contributors = memberMonthly.filter(x => Number(x.monthly_xp || 0) >= 1).length;
-  const streakBonus = guild?.guild_type === 'challenge' ? Object.values(streaks).reduce((sum, s) => sum + (s.tierPercent || 0), 0) : 0;
-  const bonus = computeGuildBonus(guild?.level || 1, contributors, streakBonus);
-  const mvpUserId = memberMonthly.sort((a,b)=>b.monthly_xp-a.monthly_xp)[0]?.user_id;
-  const mvp = mvpUserId ? members.find(x => x.user_id === mvpUserId) : undefined;
-  const mvpXp = memberMonthly.find(x => x.user_id === mvpUserId)?.monthly_xp || 0;
 
   const getTitleType = (title: string): 'level' | 'mission' | 'lesson' | 'wizard' => {
     if (TITLES.includes(title as any)) return 'level';
@@ -100,11 +90,6 @@ const GuildPage: React.FC = () => {
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="max-w-4xl mx-auto space-y-4">
           <h2 className="text-xl font-bold">ギルドページ</h2>
-          {/* 説明カード（ミッションページ風） */}
-          <div className="bg-slate-800 rounded-lg border border-slate-700 p-6">
-            <h3 className="text-lg font-semibold mb-2">ギルドボーナス</h3>
-            <p className="text-gray-300 text-sm">ギルドに所属していると、XP獲得にボーナスが加算されます。レベル倍率（レベル1ごとに+0.1%）と、当月にXPを1以上獲得したメンバー人数×10%（最大+50%）のメンバー倍率の合算を、1に足した倍率が適用されます。</p>
-          </div>
           {loading ? (
             <p className="text-gray-400">読み込み中...</p>
           ) : !guild ? (
@@ -121,7 +106,6 @@ const GuildPage: React.FC = () => {
                       </span>
                     </div>
                     <div className="text-sm text-gray-300 mt-1">Lv.{guild.level}</div>
-                    <div className="text-sm text-green-400 mt-1">ギルドボーナス: {formatMultiplier(1 + bonus.levelBonus + bonus.memberBonus + (guild.guild_type==='challenge'?bonus.streakBonus:0))} <span className="text-xs text-gray-400 ml-1">（レベル +{(bonus.levelBonus*100).toFixed(1)}% / メンバー +{(bonus.memberBonus*100).toFixed(1)}%{guild.guild_type==='challenge' ? ` / ストリーク +${(bonus.streakBonus*100).toFixed(1)}%` : ''}）</span></div>
                     <div className="grid grid-cols-2 gap-3 mt-3 text-sm">
                       <div className="bg-slate-900 rounded p-3 border border-slate-700">
                         <div className="text-gray-400">今シーズン合計XP</div>
@@ -144,55 +128,6 @@ const GuildPage: React.FC = () => {
                   <div className="mt-3 text-sm text-gray-200 whitespace-pre-wrap">{guild.description}</div>
                 )}
               </div>
-
-              {guild.guild_type === 'challenge' && (
-                <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                  <h3 className="font-semibold mb-2">ギルドクエスト</h3>
-                  <p className="text-sm text-gray-300">今月の獲得経験値が1,000,000に達しないと、月末にギルドは解散（メンバー0人）となります。</p>
-                  <div className="mt-2">
-                    <div className="text-gray-400 text-sm">今月の進捗</div>
-                    <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
-                      <div className="h-full bg-pink-500" style={{ width: `${Math.min(100, (seasonXp/1000000)*100)}%` }} />
-                    </div>
-                    <div className="text-[10px] text-gray-400 mt-1">{seasonXp.toLocaleString()} / 1,000,000</div>
-                  </div>
-                </div>
-              )}
-
-              {/* チャレンジギルド: チャレンジ見出し */}
-              {guild.guild_type === 'challenge' && (
-                <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                  <h3 className="font-semibold mb-3">チャレンジ</h3>
-                  <ul className="space-y-2">
-                    {members.map(m => (
-                      <li key={m.user_id} className="bg-slate-900 p-2 rounded">
-                        <div className="flex items-center gap-3">
-                          <img src={m.avatar_url || DEFAULT_AVATAR_URL} className="w-8 h-8 rounded-full" />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <button className="hover:text-blue-400 truncate" onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }}>{m.nickname}</button>
-                              {/* レベル（チャレンジレベル=連続日数ティア） */}
-                              <span className="text-xs text-yellow-400">
-                                {(() => {
-                                  const s = streaks[m.user_id];
-                                  if (!s) return 'Lv.0 (+0%)';
-                                  return `Lv.${Math.min(s.daysCurrentStreak, s.tierMaxDays)} (+${Math.round(s.tierPercent*100)}%)`;
-                                })()}
-                              </span>
-                            </div>
-                            <div className="h-1.5 bg-slate-700 rounded overflow-hidden mt-1">
-                              <div className="h-full bg-green-500" style={{ width: `${streaks[m.user_id] ? Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100) : 0}%` }} />
-                            </div>
-                            <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id]?.display || '0/5 +0%'}</div>
-                          </div>
-                          {/* チャレンジボーナス倍率 */}
-                          <div className="text-xs text-green-400 whitespace-nowrap">×{(1 + (streaks[m.user_id]?.tierPercent || 0)).toFixed(2)}</div>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
 
               <div className="bg-slate-800 border border-slate-700 rounded p-4">
                 <h3 className="font-semibold mb-3">メンバーリスト ({members.length}/5)</h3>
@@ -223,15 +158,6 @@ const GuildPage: React.FC = () => {
                             )}
                           </div>
                           <div className="text-xs text-gray-400">Lv.{m.level} / {m.rank}</div>
-                          {/* チャレンジギルド: 連続達成進捗 */}
-                          {guild.guild_type === 'challenge' && streaks[m.user_id] && (
-                            <div className="mt-1">
-                              <div className="h-1.5 bg-slate-700 rounded overflow-hidden">
-                                <div className="h-full bg-green-500" style={{ width: `${Math.min(100, (Math.min(streaks[m.user_id].daysCurrentStreak, streaks[m.user_id].tierMaxDays) / streaks[m.user_id].tierMaxDays) * 100)}%` }} />
-                              </div>
-                              <div className="text-[10px] text-gray-400 mt-1">{streaks[m.user_id].display}</div>
-                            </div>
-                          )}
                         </div>
                         {m.role === 'leader' && (
                           <span className="text-[10px] px-2 py-0.5 rounded_full bg-yellow-500 text-black font-bold">Leader</span>


### PR DESCRIPTION
## 概要
- ギルドボーナス説明カード、ギルドクエスト、チャレンジ関連UIを削除
- ボーナス計算やストリーク取得など不要な処理とインポートを整理
- メンバー型に `selected_title` を追加

## テスト
- `npm test` : スクリプト未定義で失敗
- `npm run lint` : 1306件の問題を検出
- `npm run type-check` : 複数の型エラーを検出

------
https://chatgpt.com/codex/tasks/task_e_68a4582b8c5c832889c073aa3ccd3344