### PR TITLE
ギルド勧誘一覧追加と参加リクエスト重複対応

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import {
-	getMyGuild,
-	getGuildMembers,
-	searchGuilds,
-	requestJoin,
-	createGuild,
+        getMyGuild,
+        getGuildMembers,
+        createGuild,
 	fetchMyGuildRank,
 	fetchGuildMemberMonthlyXp,
 	fetchJoinRequestsForMyGuild,
@@ -51,9 +49,8 @@ const GuildDashboard: React.FC = () => {
 	const [loading, setLoading] = useState(true);
 	const [myGuild, setMyGuild] = useState<Guild | null>(null);
 	const [members, setMembers] = useState<GuildMember[]>([]);
-	const [keyword, setKeyword] = useState('');
-	const [results, setResults] = useState<Guild[]>([]);
-	const [busy, setBusy] = useState(false);
+        const [guildName, setGuildName] = useState('');
+        const [busy, setBusy] = useState(false);
 	const [myRank, setMyRank] = useState<number | null>(null);
 	const [thisMonthXp, setThisMonthXp] = useState<number>(0);
 	const [memberMonthly, setMemberMonthly] = useState<Array<{ user_id: string; monthly_xp: number }>>([]);
@@ -150,36 +147,52 @@ const GuildDashboard: React.FC = () => {
 		})();
 	}, []);
 
-	const handleSearch = async () => {
-		if (!keyword) return;
-		try {
-			setLoading(true);
-			const r = await searchGuilds(keyword);
-			setResults(r);
-		} catch (e: any) {
-			alert(e?.message || 'ギルド検索に失敗しました');
-		} finally {
-			setLoading(false);
-		}
-	};
+        const handleCreateGuild = async () => {
+                if (!user || !guildName.trim()) return;
+                try {
+                        setBusy(true);
+                        const gId = await createGuild(guildName.trim(), newGuildType);
+                        if (gId) {
+                                alert('ギルドが作成されました！');
+                                // 再読み込み
+                                window.location.hash = '#guild-dashboard';
+                                window.location.reload();
+                        }
+                } catch (e) {
+                        const msg = (e as { message?: string }).message;
+                        alert(msg || 'ギルド作成に失敗しました');
+                } finally {
+                        setBusy(false);
+                }
+        };
 
-	const handleCreateGuild = async () => {
-		if (!user || !keyword.trim()) return;
-		try {
-			setBusy(true);
-			const gId = await createGuild(keyword.trim(), newGuildType);
-			if (gId) {
-				alert('ギルドが作成されました！');
-				// 再読み込み
-				window.location.hash = '#guild-dashboard';
-				window.location.reload();
-			}
-		} catch (e: any) {
-			alert(e?.message || 'ギルド作成に失敗しました');
-		} finally {
-			setBusy(false);
-		}
-	};
+        const handleAcceptInvitation = async (invitationId: string) => {
+                try {
+                        setBusy(true);
+                        await acceptInvitation(invitationId);
+                        alert('ギルドに参加しました');
+                        window.location.reload();
+                } catch (e) {
+                        const msg = (e as { message?: string }).message;
+                        alert(msg || '勧誘の承認に失敗しました');
+                } finally {
+                        setBusy(false);
+                }
+        };
+
+        const handleRejectInvitation = async (invitationId: string) => {
+                try {
+                        setBusy(true);
+                        await rejectInvitation(invitationId);
+                        setPendingInvitations(prev => prev.filter(i => i.id !== invitationId));
+                        alert('勧誘を拒否しました');
+                } catch (e) {
+                        const msg = (e as { message?: string }).message;
+                        alert(msg || '勧誘の拒否に失敗しました');
+                } finally {
+                        setBusy(false);
+                }
+        };
 
 	const handleLeaveGuild = async () => {
 		if (!myGuild || !user) return;
@@ -385,7 +398,7 @@ const GuildDashboard: React.FC = () => {
                                                         </div>
                                                 )}
                                                 <div className="mt-4">
-                                                        <input type="text" placeholder="ギルド名/検索キーワード" value={keyword} onChange={(e)=>setKeyword(e.target.value)} className="input input-bordered w-full max-w-xs" />
+                                                        <input type="text" placeholder="新しいギルド名" value={guildName} onChange={(e)=>setGuildName(e.target.value)} className="input input-bordered w-full max-w-xs" />
                                                         <div className="mt-2 flex gap-2 justify-center items-center">
                                                                 <label className="text-sm">タイプ:</label>
                                                                 <select className="select select-bordered select-sm" value={newGuildType} onChange={e=>setNewGuildType(e.target.value as any)}>
@@ -393,22 +406,29 @@ const GuildDashboard: React.FC = () => {
                                                                         <option value="challenge">チャレンジギルド</option>
                                                                 </select>
                                                                 <button onClick={handleCreateGuild} className="btn btn-primary" disabled={busy}>ギルドを作成</button>
-                                                                <button onClick={handleSearch} className="btn btn-secondary" disabled={busy}>検索</button>
                                                         </div>
                                                 </div>
-                                                {results.length > 0 && (
-                                                        <div className="mt-4">
-                                                                <h3>検索結果</h3>
-                                                                <ul>
-                                                                        {results.map(g => (
-                                                                                <li key={g.id} onClick={() => requestJoin(g.id)} className="cursor-pointer hover:bg-slate-800 p-2 rounded flex items-center gap-2">
-                                                                                        <span className="font-medium">{g.name}</span>
-                                                                                        <span className={`text-sm px-2 py-0.5 rounded-full ${g.guild_type === 'challenge' ? 'bg-pink-500 text-white' : 'bg-slate-600 text-white'}`}>{g.guild_type === 'challenge' ? 'チャレンジ' : 'カジュアル'}</span>
+                                                <div className="mt-4">
+                                                        <h3 className="font-semibold">勧誘一覧</h3>
+                                                        {pendingInvitations.length === 0 ? (
+                                                                <p className="text-sm text-gray-300">現在、勧誘はありません</p>
+                                                        ) : (
+                                                                <ul className="space-y-2">
+                                                                        {pendingInvitations.map(inv => (
+                                                                                <li key={inv.id} className="bg-slate-800 border border-slate-700 rounded p-2 flex items-center justify-between">
+                                                                                        <div>
+                                                                                                <div className="font-medium">{inv.guild_name}</div>
+                                                                                                <div className="text-sm text-gray-300">招待者: {inv.inviter_nickname}</div>
+                                                                                        </div>
+                                                                                        <div className="flex gap-2">
+                                                                                                <button className="btn btn-sm btn-primary" onClick={() => handleAcceptInvitation(inv.id)} disabled={busy}>参加</button>
+                                                                                                <button className="btn btn-sm btn-outline" onClick={() => handleRejectInvitation(inv.id)} disabled={busy}>拒否</button>
+                                                                                        </div>
                                                                                 </li>
                                                                         ))}
                                                                 </ul>
-                                                        </div>
-                                                )}
+                                                        )}
+                                                </div>
                                         </div>
                                 </div>
                         </div>

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -120,7 +120,24 @@ const GuildPage: React.FC = () => {
                   <div className="flex flex-col items-end gap-2">
                     <button className="btn btn-sm btn-outline" onClick={() => { const p = new URLSearchParams(); p.set('id', guild.id); window.location.hash = `#guild-history?${p.toString()}`; }}>ギルドヒストリーを見る</button>
                     {!isMember && guild.members_count < 5 && (
-                      <button className="btn btn-sm btn-primary" disabled={busy} onClick={async()=>{ try{ setBusy(true); await requestJoin(guild.id); alert('参加リクエストを送信しました'); } catch(e:any){ alert(e?.message||'リクエスト送信に失敗しました'); } finally{ setBusy(false); } }}>参加リクエスト</button>
+                      <button
+                        className="btn btn-sm btn-primary"
+                        disabled={busy}
+                        onClick={async () => {
+                          try {
+                            setBusy(true);
+                            const r = await requestJoin(guild.id);
+                            alert(r === null ? '既に参加リクエストがあります' : '参加リクエストを送信しました');
+                          } catch (e) {
+                            const msg = (e as { message?: string }).message;
+                            alert(msg || 'リクエスト送信に失敗しました');
+                          } finally {
+                            setBusy(false);
+                          }
+                        }}
+                      >
+                        参加リクエスト
+                      </button>
                     )}
                   </div>
                 </div>

--- a/src/platform/supabaseGuilds.ts
+++ b/src/platform/supabaseGuilds.ts
@@ -223,11 +223,19 @@ export async function rejectInvitation(invitationId: string): Promise<void> {
   if (error) throw error;
 }
 
-export async function requestJoin(guildId: string): Promise<string> {
-  const { data, error } = await getSupabaseClient()
-    .rpc('rpc_guild_request_join', { p_gid: guildId });
-  if (error) throw error;
-  return data as string;
+export async function requestJoin(guildId: string): Promise<string | null> {
+  try {
+    const { data, error } = await getSupabaseClient()
+      .rpc('rpc_guild_request_join', { p_gid: guildId });
+    if (error) throw error;
+    return data as string;
+  } catch (e) {
+    const message = (e as { message?: string }).message;
+    if (message && message.includes('guild_join_request_unique_pending')) {
+      return null;
+    }
+    throw e;
+  }
 }
 
 export async function approveJoinRequest(requestId: string): Promise<void> {
@@ -432,40 +440,6 @@ export async function fetchJoinRequestsForMyGuild(): Promise<GuildJoinRequest[]>
     status: row.status,
     requester_nickname: row.requester?.nickname,
   }));
-}
-
-export async function searchGuilds(keyword: string): Promise<Guild[]> {
-  const supabase = getSupabaseClient();
-  let query = supabase
-    .from('guilds')
-    .select('*');
-  if (keyword && keyword.trim().length > 0) {
-    query = query.ilike('name', `%${keyword.trim()}%`);
-  }
-  query = query.order('level', { ascending: false }).limit(50);
-
-  const { data, error } = await query;
-  if (error) throw error;
-
-  const result: Guild[] = [];
-  for (const g of data || []) {
-    const { count } = await supabase
-      .from('guild_members')
-      .select('*', { count: 'exact', head: true })
-      .eq('guild_id', (g as any).id);
-    result.push({
-      id: (g as any).id,
-      name: (g as any).name,
-      leader_id: (g as any).leader_id,
-      level: Number((g as any).level || 1),
-      total_xp: Number((g as any).total_xp || 0),
-      members_count: count || 0,
-      description: (g as any).description ?? null,
-      disbanded: !!(g as any).disbanded,
-      guild_type: ((g as any).guild_type as GuildType) || 'casual',
-    });
-  }
-  return result;
 }
 
 export async function getGuildIdOfUser(userId: string): Promise<string | null> {


### PR DESCRIPTION
## Summary
- ギルドページに受信した勧誘一覧を追加
- 参加リクエスト重複時にエラーを無視してメッセージ表示
- ギルド検索機能を削除

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: many errors)
- `npm run type-check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68a463541bdc832894624160080d92e1