### PR TITLE
ギルドシステム改善と参加申請管理の更新

### DIFF
--- a/src/components/guild/GuildDashboard.tsx
+++ b/src/components/guild/GuildDashboard.tsx
@@ -61,10 +61,8 @@ const GuildDashboard: React.FC = () => {
 	const [isLeader, setIsLeader] = useState<boolean>(false);
 	const [streaks, setStreaks] = useState<Record<string, { daysCurrentStreak: number; tierPercent: number; tierMaxDays: number; display: string }>>({});
 	const [newGuildType, setNewGuildType] = useState<'casual'|'challenge'>('casual');
-	const [lastGuildInfo, setLastGuildInfo] = useState<{ id: string; name: string } | null>(null);
+        const [lastGuildInfo, setLastGuildInfo] = useState<{ id: string; name: string } | null>(null);
         const [lastGuildEvent, setLastGuildEvent] = useState<'left'|'kicked'|'disband'|null>(null);
-        const [leaveReason, setLeaveReason] = useState<string>('');
-        const [reasonSubmitting, setReasonSubmitting] = useState<boolean>(false);
         const [pendingInvitations, setPendingInvitations] = useState<GuildInvitation[]>([]);
 
 	useEffect(() => {
@@ -338,32 +336,13 @@ const GuildDashboard: React.FC = () => {
                                                 {lastGuildInfo && (
                                                         <div className="mt-6 max-w-xl mx-auto text-left bg-slate-800 border border-slate-700 rounded p-4">
                                                                 <div className="font-semibold mb-2">脱退のご報告</div>
-                                                                <p className="text-sm text-gray-300 mb-2">ギルド名「{lastGuildInfo.name}」から{lastGuildEvent === 'disband' ? '解散' : lastGuildEvent === 'kicked' ? '除名' : '脱退'}のため、脱退しました。よろしければ理由をご記入ください。</p>
-                                                                <textarea className="textarea textarea-bordered w-full text-sm" rows={3} placeholder="脱退理由（任意）" value={leaveReason} onChange={(e)=>setLeaveReason(e.target.value)} />
+                                                                <p className="text-sm text-gray-300 mb-2">ギルド名「{lastGuildInfo.name}」から{lastGuildEvent === 'disband' ? '解散' : lastGuildEvent === 'kicked' ? '除名' : '脱退'}のため、脱退しました。</p>
                                                                 <div className="mt-2 flex gap-2">
-                                                                        <button className="btn btn-sm btn-primary" disabled={reasonSubmitting || leaveReason.trim().length===0} onClick={async()=>{
-                                                                                try {
-                                                                                        setReasonSubmitting(true);
-                                                                                        const { submitGuildLeaveFeedback } = await import('@/platform/supabaseGuilds');
-                                                                                        await submitGuildLeaveFeedback(lastGuildInfo.id, lastGuildInfo.name, (lastGuildEvent||'left'), leaveReason.trim());
-                                                                                        alert('ご協力ありがとうございます。');
-                                                                                        localStorage.removeItem('lastGuildInfo');
-                                                                                        localStorage.removeItem('lastGuildEvent');
-                                                                                        setLastGuildInfo(null);
-                                                                                        setLastGuildEvent(null);
-                                                                                        setLeaveReason('');
-                                                                                } catch (e:any) {
-                                                                                        alert(e?.message || '送信に失敗しました');
-                                                                                } finally {
-                                                                                        setReasonSubmitting(false);
-                                                                                }
-                                                                        }}>送信</button>
-                                                                        <button className="btn btn-sm btn-ghost" onClick={()=>{
+                                                                        <button className="btn btn-sm btn-primary" onClick={()=>{
                                                                                 localStorage.removeItem('lastGuildInfo');
                                                                                 localStorage.removeItem('lastGuildEvent');
                                                                                 setLastGuildInfo(null);
                                                                                 setLastGuildEvent(null);
-                                                                                setLeaveReason('');
                                                                         }}>閉じる</button>
                                                                 </div>
                                                         </div>

--- a/src/components/guild/GuildPage.tsx
+++ b/src/components/guild/GuildPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import GameHeader from '@/components/ui/GameHeader';
 import { DEFAULT_AVATAR_URL } from '@/utils/constants';
-import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild } from '@/platform/supabaseGuilds';
+import { Guild, getGuildById, getGuildMembers, fetchGuildMemberMonthlyXp, fetchGuildRankForMonth, fetchGuildMonthlyXpSingle, requestJoin, getMyGuild, getMyPendingJoinRequest, cancelJoinRequest } from '@/platform/supabaseGuilds';
 import { DEFAULT_TITLE, type Title, TITLES, MISSION_TITLES, LESSON_TITLES, WIZARD_TITLES, getTitleRequirement } from '@/utils/titleConstants';
 import { FaCrown, FaTrophy, FaGraduationCap, FaHatWizard, FaCheckCircle } from 'react-icons/fa';
 
@@ -15,6 +15,7 @@ const GuildPage: React.FC = () => {
   const [seasonXp, setSeasonXp] = useState<number>(0);
   const [rank, setRank] = useState<number | null>(null);
   const [isMember, setIsMember] = useState<boolean>(false);
+  const [joinReqId, setJoinReqId] = useState<string | null>(null);
   const [busy, setBusy] = useState<boolean>(false);
 
   useEffect(() => {
@@ -30,37 +31,44 @@ const GuildPage: React.FC = () => {
     setGuildId(id);
   }, [open]);
 
-  useEffect(() => {
-    (async () => {
-      if (!guildId) return;
-      setLoading(true);
-      try {
-        const g = await getGuildById(guildId);
-        setGuild(g);
-        const mine = await getMyGuild();
-        setIsMember(!!(mine && mine.id === guildId));
-        if (g) {
-          const [m, per] = await Promise.all([
-            getGuildMembers(g.id),
-            fetchGuildMemberMonthlyXp(g.id),
-          ]);
-          setMembers(m);
-          setMemberMonthly(per);
-          // 今シーズン（当月）合計XPと順位
-          const now = new Date();
-          const currentMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0,10);
-          const [xp, r] = await Promise.all([
-            fetchGuildMonthlyXpSingle(g.id, currentMonth),
-            fetchGuildRankForMonth(g.id, currentMonth),
-          ]);
-          setSeasonXp(xp);
-          setRank(r);
+    useEffect(() => {
+      (async () => {
+        if (!guildId) return;
+        setLoading(true);
+        try {
+          const g = await getGuildById(guildId);
+          setGuild(g);
+          const mine = await getMyGuild();
+          const member = !!(mine && mine.id === guildId);
+          setIsMember(member);
+          if (g) {
+            if (member) {
+              const [m, per] = await Promise.all([
+                getGuildMembers(g.id),
+                fetchGuildMemberMonthlyXp(g.id),
+              ]);
+              setMembers(m);
+              setMemberMonthly(per);
+            } else {
+              setMembers([]);
+              setMemberMonthly([]);
+              const pending = await getMyPendingJoinRequest(g.id);
+              setJoinReqId(pending?.id || null);
+            }
+            const now = new Date();
+            const currentMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0,10);
+            const [xp, r] = await Promise.all([
+              fetchGuildMonthlyXpSingle(g.id, currentMonth),
+              fetchGuildRankForMonth(g.id, currentMonth),
+            ]);
+            setSeasonXp(xp);
+            setRank(r);
+          }
+        } finally {
+          setLoading(false);
         }
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [guildId]);
+      })();
+    }, [guildId]);
 
   if (!open) return null;
 
@@ -120,7 +128,7 @@ const GuildPage: React.FC = () => {
                   <div className="flex flex-col items-end gap-2">
                     <button className="btn btn-sm btn-outline" onClick={() => { const p = new URLSearchParams(); p.set('id', guild.id); window.location.hash = `#guild-history?${p.toString()}`; }}>ギルドヒストリーを見る</button>
                     {!isMember && guild.members_count < 5 && (
-                      <button className="btn btn-sm btn-primary" disabled={busy} onClick={async()=>{ try{ setBusy(true); await requestJoin(guild.id); alert('参加リクエストを送信しました'); } catch(e:any){ alert(e?.message||'リクエスト送信に失敗しました'); } finally{ setBusy(false); } }}>参加リクエスト</button>
+                      <button className="btn btn-sm btn-primary" disabled={busy} onClick={async()=>{ try{ setBusy(true); if(joinReqId){ await cancelJoinRequest(joinReqId); setJoinReqId(null); } else { const id = await requestJoin(guild.id); setJoinReqId(id); } } catch(e:any){ alert(e?.message||'操作に失敗しました'); } finally{ setBusy(false); } }}>{joinReqId ? 'リクエスト取消' : '参加リクエスト'}</button>
                     )}
                   </div>
                 </div>
@@ -130,8 +138,10 @@ const GuildPage: React.FC = () => {
               </div>
 
               <div className="bg-slate-800 border border-slate-700 rounded p-4">
-                <h3 className="font-semibold mb-3">メンバーリスト ({members.length}/5)</h3>
-                {members.length === 0 ? (
+                <h3 className="font-semibold mb-3">メンバーリスト ({guild.members_count}/5)</h3>
+                {!isMember ? (
+                  <p className="text-gray-400 text-sm">メンバー情報は非公開です</p>
+                ) : members.length === 0 ? (
                   <p className="text-gray-400 text-sm">メンバーがいません</p>
                 ) : (
                   <ul className="space-y-2 text-base">
@@ -143,7 +153,6 @@ const GuildPage: React.FC = () => {
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-2">
                             <button className="hover:text-blue-400 truncate" onClick={()=>{ window.location.hash = `#diary-user?id=${m.user_id}`; }}>{m.nickname}</button>
-                            {/* 称号（ホバー/タップで条件表示） */}
                             {m.selected_title && (
                               <div className="relative group">
                                 <div className="flex items-center gap-1 text-yellow-400 cursor-help">
@@ -160,9 +169,8 @@ const GuildPage: React.FC = () => {
                           <div className="text-xs text-gray-400">Lv.{m.level} / {m.rank}</div>
                         </div>
                         {m.role === 'leader' && (
-                          <span className="text-[10px] px-2 py-0.5 rounded_full bg-yellow-500 text-black font-bold">Leader</span>
+                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-yellow-500 text-black font-bold">Leader</span>
                         )}
-                        {/* 当月貢献ありメンバー: Success!! アイコン */}
                         {memberMonthly.some(x=>x.user_id===m.user_id && Number(x.monthly_xp||0)>=1) && (
                           <FaCheckCircle className="text-green-400 text-sm" title="今月のギルド貢献にカウント済み" />
                         )}

--- a/supabase/migrations/20250905120000_guild_system_updates.sql
+++ b/supabase/migrations/20250905120000_guild_system_updates.sql
@@ -1,0 +1,105 @@
+-- Guild system updates: visibility, cancellation, disbanded column, feedback optional
+
+-- Add disbanded column if missing
+alter table public.guilds
+  add column if not exists disbanded boolean not null default false;
+
+-- Allow all guild members to view other members
+drop policy if exists guild_members_select_visible on public.guild_members;
+create policy guild_members_select_visible on public.guild_members
+  for select using (
+    exists(select 1 from public.guild_members gm where gm.guild_id = guild_members.guild_id and gm.user_id = auth.uid())
+  );
+
+-- Allow leader to transfer leadership
+drop policy if exists guilds_update_leader on public.guilds;
+create policy guilds_update_leader on public.guilds
+  for update using (auth.uid() = leader_id)
+  with check (true);
+
+-- Make leave feedback reason optional
+alter table public.guild_leave_feedback
+  alter column reason drop not null;
+
+drop function if exists public.rpc_submit_guild_leave_feedback(uuid, text, text, text);
+create or replace function public.rpc_submit_guild_leave_feedback(
+  p_prev_guild_id uuid,
+  p_prev_guild_name text,
+  p_leave_type text,
+  p_reason text default null
+)
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+begin
+  if _uid is null then raise exception 'Auth required'; end if;
+  if p_prev_guild_name is null or length(trim(p_prev_guild_name)) = 0 then raise exception 'previous guild name required'; end if;
+  if p_leave_type is null or p_leave_type not in ('left','kicked','disband') then raise exception 'invalid leave_type'; end if;
+  insert into public.guild_leave_feedback(user_id, previous_guild_id, previous_guild_name, leave_type, reason)
+  values(_uid, p_prev_guild_id, p_prev_guild_name, p_leave_type, p_reason);
+end;
+$$;
+grant execute on function public.rpc_submit_guild_leave_feedback(uuid, text, text, text) to anon, authenticated;
+
+-- Cancel a specific join request by requester
+create or replace function public.rpc_guild_cancel_request(p_request_id uuid)
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+begin
+  if _uid is null then raise exception 'Auth required'; end if;
+  update public.guild_join_requests
+    set status = 'cancelled', updated_at = now()
+    where id = p_request_id and requester_id = _uid and status = 'pending';
+  if not found then raise exception 'Request not found or not pending'; end if;
+end;
+$$;
+grant execute on function public.rpc_guild_cancel_request(uuid) to anon, authenticated;
+
+-- Cancel all pending join requests of current user
+create or replace function public.rpc_guild_cancel_my_requests()
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+begin
+  if _uid is null then raise exception 'Auth required'; end if;
+  update public.guild_join_requests
+    set status = 'cancelled', updated_at = now()
+    where requester_id = _uid and status = 'pending';
+end;
+$$;
+grant execute on function public.rpc_guild_cancel_my_requests() to anon, authenticated;
+
+-- Replace approve request RPC to cancel others and handle full guild
+create or replace function public.rpc_guild_approve_request(p_request_id uuid)
+returns void
+language plpgsql security definer as $$
+declare
+  _uid uuid := auth.uid();
+  _row record;
+  _member_count integer;
+begin
+  select * into _row from public.guild_join_requests where id = p_request_id and status = 'pending';
+  if not found then raise exception 'Request not found or not pending'; end if;
+  if not exists(select 1 from public.guilds g where g.id = _row.guild_id and g.leader_id = _uid) then
+    raise exception 'Only leader can approve';
+  end if;
+  select count(*) into _member_count from public.guild_members where guild_id = _row.guild_id;
+  if _member_count >= 5 then raise exception 'Guild is full'; end if;
+  update public.guild_join_requests set status = 'approved', updated_at = now() where id = p_request_id;
+  insert into public.guild_members(guild_id, user_id, role) values(_row.guild_id, _row.requester_id, 'member');
+  -- cancel other requests by this user
+  update public.guild_join_requests set status = 'cancelled', updated_at = now()
+    where requester_id = _row.requester_id and status = 'pending';
+  -- cancel remaining requests if guild now full
+  select count(*) into _member_count from public.guild_members where guild_id = _row.guild_id;
+  if _member_count >= 5 then
+    update public.guild_join_requests set status = 'cancelled', updated_at = now()
+      where guild_id = _row.guild_id and status = 'pending';
+  end if;
+end;
+$$;
+grant execute on function public.rpc_guild_approve_request(uuid) to anon, authenticated;

--- a/supabase/migrations/20250905120000_guild_system_updates.sql
+++ b/supabase/migrations/20250905120000_guild_system_updates.sql
@@ -8,7 +8,10 @@ alter table public.guilds
 drop policy if exists guild_members_select_visible on public.guild_members;
 create policy guild_members_select_visible on public.guild_members
   for select using (
-    exists(select 1 from public.guild_members gm where gm.guild_id = guild_members.guild_id and gm.user_id = auth.uid())
+    user_id = auth.uid()
+    or guild_id in (
+      select gm.guild_id from public.guild_members gm where gm.user_id = auth.uid()
+    )
   );
 
 -- Allow leader to transfer leadership


### PR DESCRIPTION
## 概要
- ギルドメンバー可視化ポリシーとリーダー更新ポリシーの調整
- 参加申請のキャンセル/一括取消RPCとギルド解散列の追加
- ギルドページの参加申請キャンセル対応とメンバー非公開表示

## テスト
- `npm run lint` 失敗 (既存のlintエラー)
- `npm run type-check` 失敗 (既存の型エラー)
- `npm test` スクリプト未定義


------
https://chatgpt.com/codex/tasks/task_e_68a49414ad508328be4523df5ee44a74