### PR TITLE
Fix guild bonus experience calculation

### DIFF
--- a/src/components/fantasy/FantasyMain.tsx
+++ b/src/components/fantasy/FantasyMain.tsx
@@ -365,8 +365,13 @@ const FantasyMain: React.FC = () => {
                   streakSum = Object.values(st).reduce((acc: number, s: any) => acc + (s?.tierPercent || 0), 0);
                 } catch {}
               }
-              const b = computeGuildBonus(myGuild.level || 1, contributors, streakSum);
-              guildMultiplier = 1 + b.levelBonus + b.memberBonus + (myGuild.guild_type === 'challenge' ? b.streakBonus : 0);
+              // チャレンジ以外ではストリークは0として計算
+              const bonus = computeGuildBonus(
+                myGuild.level || 1,
+                contributors,
+                myGuild.guild_type === 'challenge' ? streakSum : 0,
+              );
+              guildMultiplier = bonus.totalMultiplier;
             }
           } catch {}
 

--- a/src/components/game/ResultModal.tsx
+++ b/src/components/game/ResultModal.tsx
@@ -82,8 +82,12 @@ const ResultModal: React.FC = () => {
                   streakSum = Object.values(st).reduce((acc, s: any) => acc + (s?.tierPercent || 0), 0);
                 } catch {}
               }
-              const b = computeGuildBonus(myGuild.level || 1, contributors, streakSum);
-              guildMultiplier = 1 + b.levelBonus + b.memberBonus + (myGuild.guild_type === 'challenge' ? b.streakBonus : 0);
+              const bonus = computeGuildBonus(
+                myGuild.level || 1,
+                contributors,
+                myGuild.guild_type === 'challenge' ? streakSum : 0,
+              );
+              guildMultiplier = bonus.totalMultiplier;
             }
           } catch (e) {
             // 失敗しても続行


### PR DESCRIPTION
Unify guild bonus calculation to correctly apply all components (level, member, streak) to gained XP.

The previous implementation in some areas might have incorrectly applied only parts of the guild bonus, leading to discrepancies between displayed and actual XP gain. This PR ensures that the `totalMultiplier` from `computeGuildBonus` is consistently used across fantasy mode, regular game results, and mission rewards, with streak bonus correctly applied only for challenge guilds.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c9c832-d834-41de-9b47-7f49a4c30d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45c9c832-d834-41de-9b47-7f49a4c30d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

