### PR TITLE
Enforce premium plan for course and block release

### DIFF
--- a/src/platform/supabaseCourses.ts
+++ b/src/platform/supabaseCourses.ts
@@ -254,7 +254,7 @@ export function canAccessCourse(
     return { canAccess: false, reason: 'このコースは現在ロックされています。前提コースを完了すると自動で解放されます。' };
   }
 
-  // ランク制限は premium_only のみをトリガーとする
+  // ランク制限（premium_only）
   if (course.premium_only) {
     const hasRankAccess = userRank === 'premium' || userRank === 'platinum';
     if (!hasRankAccess) {
@@ -262,11 +262,18 @@ export function canAccessCourse(
     }
   }
 
-  // 前提条件をチェック
-  const prerequisitesMet = checkCoursePrerequisites(course, completedCourseIds);
-  if (!prerequisitesMet) {
-    const prerequisiteNames = course.prerequisites?.map(p => p.prerequisite_course.title).join(', ') || '';
-    return { canAccess: false, reason: `前提コース（${prerequisiteNames}）を完了してください` };
+  // 管理者によるアンロックの取り扱い：
+  // - プラチナ会員のみ、adminによるアンロック（is_unlocked === true）で前提条件を無視可能
+  // - プラチナ以外は前提条件に必ず従う
+  const isAdminUnlockEffective = userRank === 'platinum' && isUnlocked === true;
+
+  if (!isAdminUnlockEffective) {
+    // 前提条件をチェック（通常ルール）
+    const prerequisitesMet = checkCoursePrerequisites(course, completedCourseIds);
+    if (!prerequisitesMet) {
+      const prerequisiteNames = course.prerequisites?.map(p => p.prerequisite_course.title).join(', ') || '';
+      return { canAccess: false, reason: `前提コース（${prerequisiteNames}）を完了してください` };
+    }
   }
 
   return { canAccess: true };


### PR DESCRIPTION
Update course and block unlock logic to restrict administrator-forced unlocks to Platinum plan users.

This ensures that administrator-set unlocks are only effective for Platinum subscribers, and reverts to standard progression rules (prerequisites for courses, previous block completion for lessons/blocks) for all other plans.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a41a5a2-0339-4d3f-b780-7bc155b27264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a41a5a2-0339-4d3f-b780-7bc155b27264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

