### PR TITLE
feat: レッスン解放ロジックの会員ランク連動と管理画面の楽観的更新を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "preview:prod": "vite build --mode production && vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
+    "test": "vitest run --coverage",
     "clean": "rm -rf dist node_modules/.vite",
     "clean:all": "rm -rf dist node_modules/.vite node_modules && npm install"
   },
@@ -68,7 +69,8 @@
     "tailwindcss": "^3.4.0",
     "ts-prune": "^0.10.3",
     "typescript": "^5.9.2",
-    "vite": "^5.0.8"
+    "vite": "^5.0.8",
+    "vitest": "^2.0.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/components/lesson/LessonDetailPage.tsx
+++ b/src/components/lesson/LessonDetailPage.tsx
@@ -37,6 +37,7 @@ import {
   clearNavigationCacheForCourse,
   LessonNavigationInfo 
 } from '@/utils/lessonNavigation';
+import { type MembershipRank } from '@/utils/lessonAccess';
 
 /**
  * レッスン詳細画面
@@ -58,6 +59,7 @@ const LessonDetailPage: React.FC = () => {
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   const { profile } = useAuthStore();
+  const userRank = (profile?.rank ?? 'free') as MembershipRank;
   const toast = useToast();
   const { fetchStats } = useUserStatsStore();
 
@@ -98,7 +100,7 @@ const LessonDetailPage: React.FC = () => {
     if (open && lessonId) {
       loadLessonData(lessonId);
     }
-  }, [open, lessonId]);
+  }, [open, lessonId, userRank]);
 
   const loadLessonData = async (targetLessonId: string) => {
     setLoading(true);
@@ -150,7 +152,7 @@ const LessonDetailPage: React.FC = () => {
         ]);
         if (course) {
           const unlockFlag = unlockMap[course.id] !== undefined ? unlockMap[course.id] : null;
-          const access = canAccessCourse(course, profile.rank, completedCourses, unlockFlag);
+          const access = canAccessCourse(course, userRank, completedCourses, unlockFlag);
           if (!access.canAccess) {
             toast.warning(access.reason || 'このコースにはアクセスできません');
             window.location.hash = '#lessons';
@@ -168,7 +170,11 @@ const LessonDetailPage: React.FC = () => {
       // ナビゲーション情報を取得
       if (lessonData?.course_id) {
         try {
-          const navInfo = await getLessonNavigationInfo(targetLessonId, lessonData.course_id);
+          const navInfo = await getLessonNavigationInfo(
+            targetLessonId,
+            lessonData.course_id,
+            userRank,
+          );
           setNavigationInfo(navInfo);
         } catch (navError) {
           console.error('Navigation info loading error:', navError);

--- a/src/platform/supabaseCourses.ts
+++ b/src/platform/supabaseCourses.ts
@@ -1,5 +1,10 @@
 import { getSupabaseClient, fetchWithCache, clearCacheByPattern, clearCacheByKey } from './supabaseClient';
 import { Course } from '@/types';
+import {
+  evaluateCourseAccess,
+  type CourseAccessResult,
+  type MembershipRank,
+} from '@/utils/lessonAccess';
 
 // コースキャッシュキー生成関数
 export const COURSES_CACHE_KEY = () => 'courses';
@@ -218,58 +223,20 @@ export async function fetchUserCompletedCourses(userId: string): Promise<string[
 }
 
 /**
- * コースの前提条件が満たされているかチェックします
- * @param {Course} course
- * @param {string[]} completedCourseIds ユーザーが完了したコースIDの配列
- * @returns {boolean}
- */
-export function checkCoursePrerequisites(course: Course, completedCourseIds: string[]): boolean {
-  // 前提条件がない場合は満たされている
-  if (!course.prerequisites || course.prerequisites.length === 0) {
-    return true;
-  }
-
-  // すべての前提条件が完了しているかチェック
-  return course.prerequisites.every(prereq => 
-    completedCourseIds.includes(prereq.prerequisite_course_id)
-  );
-}
-
-/**
- * ユーザーがコースにアクセス可能かどうかを判定します（前提条件とランク制限、管理者アンロックを含む）
- * @param {Course} course
- * @param {string} userRank
- * @param {string[]} completedCourseIds
- * @param {boolean} isUnlocked user_course_progressのis_unlockedフラグ
- * @returns {object} { canAccess: boolean, reason?: string }
+ * ユーザーがコースにアクセス可能かどうかを判定します
  */
 export function canAccessCourse(
-  course: Course, 
-  userRank: string, 
+  course: Course,
+  userRank: MembershipRank,
   completedCourseIds: string[] = [],
-  isUnlocked: boolean | null = null
-): { canAccess: boolean; reason?: string } {
-  // user_course_progressでアンロック状態が明示的にロックの場合のみブロック
-  if (isUnlocked === false) {
-    return { canAccess: false, reason: 'このコースは現在ロックされています。前提コースを完了すると自動で解放されます。' };
-  }
-
-  // ランク制限は premium_only のみをトリガーとする
-  if (course.premium_only) {
-    const hasRankAccess = userRank === 'premium' || userRank === 'platinum' || userRank === 'black';
-    if (!hasRankAccess) {
-      return { canAccess: false, reason: 'プレミアムプラン以上が必要です' };
-    }
-  }
-
-  // 前提条件をチェック
-  const prerequisitesMet = checkCoursePrerequisites(course, completedCourseIds);
-  if (!prerequisitesMet) {
-    const prerequisiteNames = course.prerequisites?.map(p => p.prerequisite_course.title).join(', ') || '';
-    return { canAccess: false, reason: `前提コース（${prerequisiteNames}）を完了してください` };
-  }
-
-  return { canAccess: true };
+  isUnlocked: boolean | null = null,
+): CourseAccessResult {
+  return evaluateCourseAccess({
+    course,
+    userRank,
+    completedCourseIds,
+    adminOverride: isUnlocked,
+  });
 }
 
 /**

--- a/src/utils/__tests__/lessonAccess.test.ts
+++ b/src/utils/__tests__/lessonAccess.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import type { Course, Lesson } from '@/types';
+import type { LessonProgress } from '@/platform/supabaseLessonProgress';
+import {
+  ADMIN_LOCK_REASON,
+  PREMIUM_ONLY_REASON,
+  buildProgressMap,
+  evaluateBlockAccess,
+  evaluateCourseAccess,
+  evaluateLessonAccess,
+  getBlockLessons,
+  getPreviousBlockNumbers,
+  isPremiumRank,
+  isRankAtLeast,
+} from '@/utils/lessonAccess';
+
+const iso = () => new Date('2024-01-01T00:00:00.000Z').toISOString();
+
+const makeLesson = (overrides: Partial<Lesson>): Lesson => ({
+  id: 'lesson-default',
+  course_id: 'course-main',
+  title: 'Lesson',
+  description: 'desc',
+  assignment_description: undefined,
+  order_index: 0,
+  block_number: 1,
+  created_at: iso(),
+  updated_at: iso(),
+  ...overrides,
+});
+
+const sampleLessons: Lesson[] = [
+  makeLesson({ id: 'l1', order_index: 0, block_number: 1, title: 'Intro' }),
+  makeLesson({ id: 'l2', order_index: 1, block_number: 1, title: 'Basics' }),
+  makeLesson({ id: 'l3', order_index: 2, block_number: 2, title: 'Intermediate' }),
+  makeLesson({ id: 'l4', order_index: 3, block_number: 3, title: 'Advanced' }),
+];
+
+const makeCourse = (overrides: Partial<Course>): Course => ({
+  id: 'course-main',
+  title: 'Main Course',
+  description: 'Course description',
+  created_at: iso(),
+  updated_at: iso(),
+  order_index: 0,
+  lessons: sampleLessons,
+  prerequisites: [],
+  ...overrides,
+});
+
+const makeProgress = (
+  lessonId: string,
+  overrides: Partial<LessonProgress> = {},
+): LessonProgress => ({
+  id: `${lessonId}-progress`,
+  user_id: 'user-1',
+  lesson_id: lessonId,
+  course_id: 'course-main',
+  completed: false,
+  created_at: iso(),
+  updated_at: iso(),
+  ...overrides,
+});
+
+describe('lessonAccess helper', () => {
+  describe('evaluateCourseAccess', () => {
+    it('applies admin unlock for premium ranks and exposes badge', () => {
+      const course = makeCourse({});
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'premium',
+        completedCourseIds: [],
+        adminOverride: true,
+      });
+
+      expect(result.canAccess).toBe(true);
+      expect(result.overrideApplied).toBe('admin_unlock');
+      expect(result.showAdminBadge).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('blocks access when admin lock is present for premium ranks', () => {
+      const course = makeCourse({});
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'platinum',
+        completedCourseIds: [],
+        adminOverride: false,
+      });
+
+      expect(result.canAccess).toBe(false);
+      expect(result.overrideApplied).toBe('admin_lock');
+      expect(result.reason).toBe(ADMIN_LOCK_REASON);
+    });
+
+    it('ignores admin override for standard ranks while keeping access', () => {
+      const course = makeCourse({});
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'standard',
+        completedCourseIds: [],
+        adminOverride: true,
+      });
+
+      expect(result.canAccess).toBe(true);
+      expect(result.overrideApplied).toBe('none');
+      expect(result.showAdminBadge).toBe(false);
+    });
+
+    it('requires premium rank for premium-only courses', () => {
+      const course = makeCourse({ premium_only: true });
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'standard',
+        completedCourseIds: [],
+      });
+
+      expect(result.canAccess).toBe(false);
+      expect(result.reason).toBe(PREMIUM_ONLY_REASON);
+    });
+
+    it('respects min_rank threshold when present', () => {
+      const course = makeCourse({ min_rank: 'platinum' });
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'premium',
+        completedCourseIds: [],
+      });
+
+      expect(result.canAccess).toBe(false);
+      expect(result.reason).toBe('このコースはPLATINUMプラン以上が必要です');
+    });
+
+    it('enforces course prerequisites when not completed', () => {
+      const prerequisiteCourse: Course = {
+        ...makeCourse({ id: 'course-pre', title: 'Prerequisite', lessons: [] }),
+      };
+      const course = makeCourse({
+        prerequisites: [
+          {
+            prerequisite_course_id: prerequisiteCourse.id,
+            prerequisite_course: prerequisiteCourse,
+          },
+        ],
+      });
+
+      const result = evaluateCourseAccess({
+        course,
+        userRank: 'premium',
+        completedCourseIds: [],
+      });
+
+      expect(result.canAccess).toBe(false);
+      expect(result.reason).toBe('前提コース（Prerequisite）を完了してください');
+
+      const satisfied = evaluateCourseAccess({
+        course,
+        userRank: 'premium',
+        completedCourseIds: [prerequisiteCourse.id],
+      });
+
+      expect(satisfied.canAccess).toBe(true);
+      expect(satisfied.reason).toBeUndefined();
+    });
+  });
+
+  describe('block and lesson evaluation', () => {
+    it('evaluates block access with natural unlocks and completions', () => {
+      const course = makeCourse({});
+      const emptyMap = buildProgressMap([]);
+      const block1State = evaluateBlockAccess({
+        course,
+        progressMap: emptyMap,
+        blockNumber: 1,
+      });
+
+      expect(block1State.blockNumber).toBe(1);
+      expect(block1State.naturallyUnlocked).toBe(true);
+      expect(block1State.completed).toBe(false);
+
+      const block2State = evaluateBlockAccess({
+        course,
+        progressMap: emptyMap,
+        blockNumber: 2,
+      });
+
+      expect(block2State.naturallyUnlocked).toBe(false);
+
+      const completedProgress = buildProgressMap([
+        makeProgress('l1', { completed: true }),
+        makeProgress('l2', { completed: true }),
+      ]);
+
+      const block2AfterCompletion = evaluateBlockAccess({
+        course,
+        progressMap: completedProgress,
+        blockNumber: 2,
+      });
+
+      expect(block2AfterCompletion.naturallyUnlocked).toBe(true);
+      expect(block2AfterCompletion.completed).toBe(false);
+    });
+
+    it('identifies manual lesson unlocks and completions', () => {
+      const course = makeCourse({});
+      const progress = buildProgressMap([
+        makeProgress('l1', { completed: true }),
+        makeProgress('l2', { completed: true }),
+        makeProgress('l3', { is_unlocked: true }),
+      ]);
+
+      const block2State = evaluateBlockAccess({
+        course,
+        progressMap: progress,
+        blockNumber: 2,
+      });
+
+      const lessonAccess = evaluateLessonAccess(
+        sampleLessons[2],
+        block2State,
+        progress,
+      );
+
+      expect(lessonAccess.naturallyUnlocked).toBe(true);
+      expect(lessonAccess.manuallyUnlocked).toBe(true);
+      expect(lessonAccess.completed).toBe(false);
+
+      const block3State = evaluateBlockAccess({
+        course,
+        progressMap: progress,
+        blockNumber: 3,
+      });
+
+      const lockedLesson = evaluateLessonAccess(
+        sampleLessons[3],
+        block3State,
+        progress,
+      );
+
+      expect(lockedLesson.naturallyUnlocked).toBe(false);
+      expect(lockedLesson.manuallyUnlocked).toBe(false);
+    });
+  });
+
+  describe('utility helpers', () => {
+    it('builds lesson progress map keyed by lesson id', () => {
+      const progress = [
+        makeProgress('l1'),
+        makeProgress('l2', { is_unlocked: true }),
+      ];
+
+      const map = buildProgressMap(progress);
+      expect(map.get('l1')).toMatchObject({ lesson_id: 'l1' });
+      expect(map.get('l2')?.is_unlocked).toBe(true);
+    });
+
+    it('returns lessons and previous block numbers correctly', () => {
+      const course = makeCourse({});
+      expect(getBlockLessons(course, 1).length).toBe(2);
+      expect(getBlockLessons(course, 3).length).toBe(1);
+      expect(getPreviousBlockNumbers(course, 1)).toEqual([]);
+      expect(getPreviousBlockNumbers(course, 3)).toEqual([1, 2]);
+    });
+
+    it('checks rank relationships and premium statuses', () => {
+      expect(isRankAtLeast('platinum', 'standard')).toBe(true);
+      expect(isRankAtLeast('standard', 'platinum')).toBe(false);
+      expect(isPremiumRank('premium')).toBe(true);
+      expect(isPremiumRank('standard')).toBe(false);
+    });
+  });
+});
+

--- a/src/utils/lessonAccess.ts
+++ b/src/utils/lessonAccess.ts
@@ -1,0 +1,234 @@
+import type { Course, Lesson } from '@/types';
+import type { LessonProgress } from '@/platform/supabaseLessonProgress';
+
+export const rankOrder = [
+  'free',
+  'standard',
+  'standard_global',
+  'premium',
+  'platinum',
+  'black',
+] as const;
+
+export type MembershipRank = typeof rankOrder[number];
+
+const premiumRanks: ReadonlySet<MembershipRank> = new Set([
+  'premium',
+  'platinum',
+  'black',
+]);
+
+export const ADMIN_LOCK_REASON =
+  '管理者によりロックされています。前提コースを完了すると自動で解放されます。';
+
+export const PREMIUM_ONLY_REASON = 'プレミアムプラン以上が必要です';
+
+export type CourseAccessOverride = 'admin_unlock' | 'admin_lock' | 'none';
+
+export interface CourseAccessParams {
+  course: Course;
+  userRank: MembershipRank;
+  completedCourseIds?: readonly string[];
+  adminOverride?: boolean | null;
+}
+
+export interface CourseAccessResult {
+  canAccess: boolean;
+  reason?: string;
+  overrideApplied: CourseAccessOverride;
+  showAdminBadge: boolean;
+}
+
+export function isRankAtLeast(
+  userRank: MembershipRank,
+  requiredRank: MembershipRank,
+): boolean {
+  return rankOrder.indexOf(userRank) >= rankOrder.indexOf(requiredRank);
+}
+
+export function isPremiumRank(rank: MembershipRank): boolean {
+  return premiumRanks.has(rank);
+}
+
+export function checkCoursePrerequisites(
+  course: Course,
+  completedCourseIds: readonly string[] = [],
+): boolean {
+  if (!course.prerequisites || course.prerequisites.length === 0) {
+    return true;
+  }
+
+  return course.prerequisites.every((prereq) =>
+    completedCourseIds.includes(prereq.prerequisite_course_id),
+  );
+}
+
+function buildPrerequisiteReason(course: Course): string | undefined {
+  if (!course.prerequisites || course.prerequisites.length === 0) {
+    return undefined;
+  }
+
+  const prerequisiteNames = course.prerequisites
+    .map((prereq) => prereq.prerequisite_course.title)
+    .join(', ');
+
+  return prerequisiteNames
+    ? `前提コース（${prerequisiteNames}）を完了してください`
+    : undefined;
+}
+
+export function evaluateCourseAccess({
+  course,
+  userRank,
+  completedCourseIds = [],
+  adminOverride,
+}: CourseAccessParams): CourseAccessResult {
+  const overrideAllowed = isPremiumRank(userRank);
+  const effectiveOverride = overrideAllowed ? adminOverride ?? null : null;
+  const showAdminBadge = effectiveOverride === true && overrideAllowed;
+
+  if (effectiveOverride === false) {
+    return {
+      canAccess: false,
+      reason: ADMIN_LOCK_REASON,
+      overrideApplied: 'admin_lock',
+      showAdminBadge: false,
+    };
+  }
+
+  if (effectiveOverride === true) {
+    return {
+      canAccess: true,
+      overrideApplied: 'admin_unlock',
+      showAdminBadge,
+    };
+  }
+
+  if (course.min_rank && !isRankAtLeast(userRank, course.min_rank)) {
+    return {
+      canAccess: false,
+      reason: `このコースは${course.min_rank.toUpperCase()}プラン以上が必要です`,
+      overrideApplied: 'none',
+      showAdminBadge: false,
+    };
+  }
+
+  if (course.premium_only && !isPremiumRank(userRank)) {
+    return {
+      canAccess: false,
+      reason: PREMIUM_ONLY_REASON,
+      overrideApplied: 'none',
+      showAdminBadge: false,
+    };
+  }
+
+  const prerequisitesMet = checkCoursePrerequisites(course, completedCourseIds);
+
+  if (!prerequisitesMet) {
+    return {
+      canAccess: false,
+      reason: buildPrerequisiteReason(course),
+      overrideApplied: 'none',
+      showAdminBadge: false,
+    };
+  }
+
+  return {
+    canAccess: true,
+    overrideApplied: 'none',
+    showAdminBadge: false,
+  };
+}
+
+export interface BlockAccessContext {
+  course: Course;
+  progressMap: Map<string, LessonProgress>;
+  blockNumber: number;
+}
+
+export interface BlockAccessState {
+  blockNumber: number;
+  naturallyUnlocked: boolean;
+  completed: boolean;
+}
+
+export function getBlockLessons(course: Course, blockNumber: number): Lesson[] {
+  return course.lessons.filter(
+    (lesson) => (lesson.block_number || 1) === blockNumber,
+  );
+}
+
+export function buildProgressMap(progress: readonly LessonProgress[]): Map<string, LessonProgress> {
+  return new Map(progress.map((entry) => [entry.lesson_id, entry]));
+}
+
+export function getPreviousBlockNumbers(course: Course, blockNumber: number): number[] {
+  if (blockNumber <= 1) {
+    return [];
+  }
+
+  const allBlocks = new Set<number>();
+  course.lessons.forEach((lesson) => {
+    const currentBlock = lesson.block_number || 1;
+    if (currentBlock < blockNumber) {
+      allBlocks.add(currentBlock);
+    }
+  });
+
+  return Array.from(allBlocks.values()).sort((a, b) => a - b);
+}
+
+export function evaluateBlockAccess({
+  course,
+  progressMap,
+  blockNumber,
+}: BlockAccessContext): BlockAccessState {
+  const lessonsInBlock = getBlockLessons(course, blockNumber);
+  const previousBlocks = getPreviousBlockNumbers(course, blockNumber);
+
+  const previousBlocksCompleted = previousBlocks.every((prevBlockNumber) => {
+    const lessons = getBlockLessons(course, prevBlockNumber);
+    if (lessons.length === 0) {
+      return true;
+    }
+
+    return lessons.every((lesson) => progressMap.get(lesson.id)?.completed === true);
+  });
+
+  const naturallyUnlocked = blockNumber === 1 || previousBlocksCompleted;
+  const completed =
+    lessonsInBlock.length > 0 &&
+    lessonsInBlock.every((lesson) => progressMap.get(lesson.id)?.completed === true);
+
+  return {
+    blockNumber,
+    naturallyUnlocked,
+    completed,
+  };
+}
+
+export interface LessonAccessState {
+  lessonId: string;
+  naturallyUnlocked: boolean;
+  manuallyUnlocked: boolean;
+  completed: boolean;
+}
+
+export function evaluateLessonAccess(
+  lesson: Lesson,
+  blockState: BlockAccessState,
+  progressMap: Map<string, LessonProgress>,
+): LessonAccessState {
+  const progress = progressMap.get(lesson.id);
+  const manuallyUnlocked =
+    progress?.is_unlocked === true && !blockState.naturallyUnlocked;
+  const completed = progress?.completed === true;
+
+  return {
+    lessonId: lesson.id,
+    naturallyUnlocked: blockState.naturallyUnlocked,
+    manuallyUnlocked,
+    completed,
+  };
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,35 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/utils/lessonAccess.ts'],
+      lines: 100,
+      statements: 100,
+      functions: 100,
+      branches: 100,
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+      '@/components': resolve(__dirname, './src/components'),
+      '@/stores': resolve(__dirname, './src/stores'),
+      '@/engines': resolve(__dirname, './src/engines'),
+      '@/systems': resolve(__dirname, './src/systems'),
+      '@/platform': resolve(__dirname, './src/platform'),
+      '@/data': resolve(__dirname, './src/data'),
+      '@/types': resolve(__dirname, './src/types'),
+      '@/utils': resolve(__dirname, './src/utils'),
+    },
+  },
+});
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 


### PR DESCRIPTION
- 新規: lessonAccess ヘルパーを追加し、コース・ブロック・レッスンのアクセス判定を統一
- 変更: プレミア未満では管理者解放を無効化し、通常条件のみ有効に
- 変更: 管理画面のコース/ブロック操作を「解放/通常条件に戻す」に統一
- 変更: 楽観的更新を強化し、即時反映を実現
- 追加: vitest によるユニットテストとカバレッジ設定を追加

主要変更点:
- src/utils/lessonAccess.ts: アクセス判定ロジックの共通化
- src/platform/supabaseCourses.ts: canAccessCourse を新ヘルパー経由に移行
- src/components/lesson/*: 新判定ロジックでバッジ表示とアクセス制御を更新
- src/components/admin/UserManager.tsx: 操作UIを新仕様に合わせて改修
- src/platform/supabaseLessonProgress.ts: resetBlockOverride 関数を追加