### PR TITLE
Optimize legend mode note descent synchronization

### DIFF
--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -360,11 +360,11 @@ export class PIXINotesRendererInstance {
     log.info(`🎹 White key width: ${whiteKeyWidth.toFixed(2)}px, Note width: ${this.settings.noteWidth.toFixed(2)}px`);
     
     // PIXI.js アプリケーション初期化（統合レンダリングループ版）
-    this.app = new PIXI.Application({
+      this.app = new PIXI.Application({
       width,
       height: adjustedHeight, // ★ 最小高さを保証した高さを使用
       // 🎯 統合フレーム制御を使用して競合ループを回避
-      autoStart: false, // 自動開始を無効化
+        autoStart: true, // 共有Tickerに委譲し自動レンダリング
       backgroundColor: 0x0A0A0F, // より暗い宇宙的な背景
       antialias: true,
       resolution: 1, // 解像度を固定して一貫性を保つ
@@ -417,8 +417,9 @@ export class PIXINotesRendererInstance {
       log.error('❌ PIXI setup failed:', error);
     }
     
-    // ===== 新設計: Ticker管理を一元化 =====
-    this.setupTickerSystem();
+      // ===== 新設計: Ticker管理を一元化 =====
+      this.setupTickerSystem();
+      this.app.start();
     
     // グローバルpointerupイベントで保険を掛ける（音が伸び続けるバグの最終防止）
     this.app.stage.on('globalpointerup', () => {
@@ -428,9 +429,6 @@ export class PIXINotesRendererInstance {
       }
       this.activeKeyPresses.clear();
     });
-    
-    // 🎯 統合フレーム制御でPIXIアプリケーションを開始
-    this.startUnifiedRendering();
     
     log.info('✅ PIXI.js renderer initialized successfully');
   }
@@ -501,54 +499,6 @@ export class PIXINotesRendererInstance {
     log.debug('✅ Ticker system setup completed');
   }
 
-  /**
-   * 🎯 統合フレーム制御でPIXIアプリケーションを開始
-   */
-  // GameEngineと同じunifiedFrameControllerを利用して描画ループを統合
-  private startUnifiedRendering(): void {
-    if (!window.unifiedFrameController) {
-      log.warn('⚠️ unifiedFrameController not available, using default PIXI ticker');
-      this.app.start();
-      return;
-    }
-    
-    // 統合フレーム制御を使用してPIXIアプリケーションを制御
-    const renderFrame = () => {
-      const currentTime = performance.now();
-      
-      // 統合フレーム制御でフレームスキップ判定
-      if (window.unifiedFrameController.shouldSkipFrame(currentTime)) {
-        // フレームをスキップ
-        requestAnimationFrame(renderFrame);
-        return;
-      }
-      
-      // PIXIアプリケーションを手動でレンダリング（安全ガード付き）
-      if (this.isDestroyed) {
-        // 破棄済みの場合はレンダリングループを停止
-        return;
-      }
-      
-      try {
-        if (this.app && this.app.renderer) {
-          this.app.render();
-        }
-      } catch (error) {
-        log.warn('⚠️ PIXI render error (likely destroyed):', error);
-        // レンダリングループを停止
-        return;
-      }
-      
-      // 次のフレームをスケジュール
-      requestAnimationFrame(renderFrame);
-    };
-    
-    // レンダリングループを開始
-    renderFrame();
-    
-    log.info('🎯 PIXI.js unified frame control started');
-  }
-  
   /**
    * ノーツテクスチャを事前生成
    */

--- a/src/utils/sharedAnimationLoop.ts
+++ b/src/utils/sharedAnimationLoop.ts
@@ -1,0 +1,73 @@
+import { unifiedFrameController } from './performanceOptimizer';
+
+interface FramePayload {
+  timestamp: number;
+  deltaMs: number;
+}
+
+type FrameCallback = (payload: FramePayload) => void;
+
+class SharedAnimationLoop {
+  private callbacks = new Set<FrameCallback>();
+  private rafId: number | null = null;
+  private lastTimestamp = 0;
+  private running = false;
+
+  add(callback: FrameCallback): () => void {
+    this.callbacks.add(callback);
+    this.start();
+    return () => {
+      this.callbacks.delete(callback);
+      if (this.callbacks.size === 0) {
+        this.stop();
+      }
+    };
+  }
+
+  private start(): void {
+    if (this.running) return;
+    if (typeof window === 'undefined') return;
+    this.running = true;
+    this.lastTimestamp = 0;
+    this.rafId = window.requestAnimationFrame(this.handleFrame);
+  }
+
+  private stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    if (typeof window !== 'undefined' && this.rafId !== null) {
+      window.cancelAnimationFrame(this.rafId);
+    }
+    this.rafId = null;
+    this.lastTimestamp = 0;
+  }
+
+  private handleFrame = (timestamp: number): void => {
+    if (!this.running) return;
+
+    if (unifiedFrameController.shouldSkipFrame(timestamp)) {
+      this.queueNextFrame();
+      return;
+    }
+
+    const deltaMs = this.lastTimestamp === 0 ? 0 : timestamp - this.lastTimestamp;
+    this.lastTimestamp = timestamp;
+
+    for (const callback of this.callbacks) {
+      callback({ timestamp, deltaMs });
+    }
+
+    unifiedFrameController.markEffectUpdate(timestamp);
+    this.queueNextFrame();
+  };
+
+  private queueNextFrame(): void {
+    if (typeof window === 'undefined') {
+      this.stop();
+      return;
+    }
+    this.rafId = window.requestAnimationFrame(this.handleFrame);
+  }
+}
+
+export const sharedAnimationLoop = new SharedAnimationLoop();


### PR DESCRIPTION
Consolidate PIXI rendering loop to `PIXI.Ticker.shared` to resolve jerky note descent in Legend Mode caused by duplicate frame synchronization.

The previous setup used a custom `requestAnimationFrame`-based loop (`startUnifiedRendering`) to control PIXI rendering, while also having `PIXI.Application` initialized with `autoStart: false`. This created a potential conflict with the game's `unifiedFrameController` and PIXI's internal `Ticker`, leading to inconsistent frame updates and a "jerky" visual experience for notes. By enabling `autoStart: true` and removing the custom loop, PIXI's rendering is now solely managed by its shared Ticker, ensuring a single, consistent frame control source.

---
<a href="https://cursor.com/background-agent?bcId=bc-e17a8676-9948-49b5-9837-dcfe254e2c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e17a8676-9948-49b5-9837-dcfe254e2c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

