### PR TITLE
Optimize fantasy mode performance and audio transitions

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -2123,42 +2123,28 @@ export class FantasyPIXIInstance {
 
     noteContainer.x = x;
     noteContainer.y = this.app.screen.height / 2;
+    noteContainer.visible = false;
 
     return noteContainer;
   }
   
   // ノーツを更新（太鼓の達人風）
-  updateTaikoNotes(notes: Array<{id: string, chord: string, x: number}>): void {
-    // 既存のノーツをクリア
-    this.activeNotes.forEach((note, id) => {
-      if (!notes.find(n => n.id === id)) {
-        try {
-          if (note && !(note as any).destroyed) note.destroy({ children: true });
-        } catch {}
-        this.activeNotes.delete(id);
-      }
+  updateTaikoNotes(notes: Array<{id: string, chord: string, x: number, alpha?: number}>): void {
+    this.activeNotes.forEach((note) => {
+      note.visible = false;
     });
-    
-    // 新しいノーツを追加・更新
+
     notes.forEach(noteData => {
       let note = this.activeNotes.get(noteData.id);
-      
-      if (!note) {
-        // 新しいノーツを作成
+      if (!note || (note as any).destroyed || !(note as any).transform) {
         note = this.createTaikoNote(noteData.id, noteData.chord, noteData.x);
+        note.visible = false;
         this.notesContainer.addChild(note);
         this.activeNotes.set(noteData.id, note);
-      } else {
-        // 破棄済みなら作り直す
-        if ((note as any).destroyed || !(note as any).transform) {
-          note = this.createTaikoNote(noteData.id, noteData.chord, noteData.x);
-          this.notesContainer.addChild(note);
-          this.activeNotes.set(noteData.id, note);
-        } else {
-          // 既存のノーツの位置を更新
-          note.x = noteData.x;
-        }
       }
+      note.visible = true;
+      note.x = noteData.x;
+      note.alpha = typeof noteData.alpha === 'number' ? noteData.alpha : 0.95;
     });
   }
 

--- a/src/components/fantasy/LPPIXIPiano.tsx
+++ b/src/components/fantasy/LPPIXIPiano.tsx
@@ -115,16 +115,14 @@ const LPPIXIPiano: React.FC<LPPIXIPianoProps> = ({
 
   // MIDIの初期化とキーのハイライト連携
   useEffect(() => {
-    const controller = new MIDIController({
+      const controller = new MIDIController({
       onNoteOn: (note: number) => {
         if (rendererReady) rendererReady.highlightKey?.(note, true);
       },
       onNoteOff: (note: number) => {
         if (rendererReady) rendererReady.highlightKey?.(note, false);
       },
-      playMidiSound: true,
-      // LPデモ用: 軽量音源モードを有効化
-      ...( { lightAudio: true } as any )
+        playMidiSound: true
     });
     midiControllerRef.current = controller;
 
@@ -158,7 +156,7 @@ const LPPIXIPiano: React.FC<LPPIXIPianoProps> = ({
     (async () => {
       try {
         const { initializeAudioSystem } = await import('@/utils/MidiController');
-        await initializeAudioSystem({ light: true });
+        await initializeAudioSystem();
         if (!cancelled) setAudioReady(true);
       } catch {
         if (!cancelled) setAudioReady(false);
@@ -171,8 +169,8 @@ const LPPIXIPiano: React.FC<LPPIXIPianoProps> = ({
   const handleUserActivate = useCallback(async () => {
     try { await (window as any).Tone?.start?.(); } catch {}
     try {
-      const { initializeAudioSystem } = await import('@/utils/MidiController');
-      await initializeAudioSystem({ light: true });
+        const { initializeAudioSystem } = await import('@/utils/MidiController');
+        await initializeAudioSystem();
     } catch {}
     setShowPrompt(false);
     setAudioReady(true);

--- a/src/components/fantasy/OnScreenPiano.tsx
+++ b/src/components/fantasy/OnScreenPiano.tsx
@@ -118,8 +118,7 @@ const OnScreenPiano: React.FC<OnScreenPianoProps> = ({
       onNoteOff: (note: number) => {
         setNoteActive(note, false);
       },
-      playMidiSound: true,
-      ...( { lightAudio: true } as any )
+      playMidiSound: true
     });
 
     midiControllerRef.current = controller;

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -597,6 +597,20 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
 
     useEffect(() => {
       let isMounted = true;
+      ensureMidiModule()
+        .then(async (module) => {
+          if (!isMounted) return;
+          const mode = settings.pianoSoundQuality === 'piano' ? 'piano' : 'light';
+          await module.setAudioQualityMode?.(mode);
+        })
+        .catch(() => {});
+      return () => {
+        isMounted = false;
+      };
+    }, [settings.pianoSoundQuality, ensureMidiModule]);
+
+    useEffect(() => {
+      let isMounted = true;
       void ensureMidiModule()
         .then(async (module) => {
           if (!isMounted) return;

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -515,7 +515,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       try {
         const midiModule = await ensureMidiModule();
         const { initializeAudioSystem, default: MIDIController } = midiModule;
-        await initializeAudioSystem({ light: true });
+        await initializeAudioSystem();
         log.info('✅ 共通音声システム初期化完了');
         
         // MIDIController インスタンスを作成
@@ -597,25 +597,11 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
 
     useEffect(() => {
       let isMounted = true;
-      ensureMidiModule()
-        .then(async (module) => {
-          if (!isMounted) return;
-          const mode = settings.pianoSoundQuality === 'piano' ? 'piano' : 'light';
-          await module.setAudioQualityMode?.(mode);
-        })
-        .catch(() => {});
-      return () => {
-        isMounted = false;
-      };
-    }, [settings.pianoSoundQuality, ensureMidiModule]);
-
-    useEffect(() => {
-      let isMounted = true;
       void ensureMidiModule()
         .then(async (module) => {
           if (!isMounted) return;
           try {
-            await module.initializeAudioSystem({ light: true });
+            await module.initializeAudioSystem();
           } catch (warmupError) {
             log.warn('⚠️ Audio system warmup failed:', warmupError);
           }

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -847,7 +847,7 @@ const GamePlayScreen: React.FC = () => {
                 onClick={async () => {
                   try {
                     const { initializeAudioSystem } = await import('@/utils/MidiController');
-                    await initializeAudioSystem({ light: true });
+                    await initializeAudioSystem();
                   } catch (error) {
                     console.error('❌ Manual audio system initialization failed:', error);
                     alert('音声システムの初期化に失敗しました。ページを再読み込みしてください。');
@@ -1539,39 +1539,6 @@ const SettingsPanel: React.FC = () => {
                   className="slider w-full accent-amber-400"
                 />
               </div>
-                
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
-                    ピアノ音源の品質
-                  </label>
-                  <div className="flex flex-wrap gap-4">
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="piano-sound-quality"
-                        value="light"
-                        checked={settings.pianoSoundQuality !== 'piano'}
-                        onChange={() => gameActions.updateSettings({ pianoSoundQuality: 'light' })}
-                        className="radio radio-xs"
-                      />
-                      <span className="text-sm text-gray-300">軽量モード（低負荷）</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="piano-sound-quality"
-                        value="piano"
-                        checked={settings.pianoSoundQuality === 'piano'}
-                        onChange={() => gameActions.updateSettings({ pianoSoundQuality: 'piano' })}
-                        className="radio radio-xs"
-                      />
-                      <span className="text-sm text-gray-300">高音質ピアノ</span>
-                    </label>
-                  </div>
-                  <p className="text-xs text-gray-400 mt-1">
-                    軽量モードは起動が速く端末負荷が小さい設定です。高音質ピアノは@tonejs/piano音源を利用し、より自然なサウンドになります。
-                  </p>
-                </div>
             </div>
 
             {/* ノーツスピード */}

--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -1539,6 +1539,39 @@ const SettingsPanel: React.FC = () => {
                   className="slider w-full accent-amber-400"
                 />
               </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    ピアノ音源の品質
+                  </label>
+                  <div className="flex flex-wrap gap-4">
+                    <label className="flex items-center space-x-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="piano-sound-quality"
+                        value="light"
+                        checked={settings.pianoSoundQuality !== 'piano'}
+                        onChange={() => gameActions.updateSettings({ pianoSoundQuality: 'light' })}
+                        className="radio radio-xs"
+                      />
+                      <span className="text-sm text-gray-300">軽量モード（低負荷）</span>
+                    </label>
+                    <label className="flex items-center space-x-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="piano-sound-quality"
+                        value="piano"
+                        checked={settings.pianoSoundQuality === 'piano'}
+                        onChange={() => gameActions.updateSettings({ pianoSoundQuality: 'piano' })}
+                        className="radio radio-xs"
+                      />
+                      <span className="text-sm text-gray-300">高音質ピアノ</span>
+                    </label>
+                  </div>
+                  <p className="text-xs text-gray-400 mt-1">
+                    軽量モードは起動が速く端末負荷が小さい設定です。高音質ピアノは@tonejs/piano音源を利用し、より自然なサウンドになります。
+                  </p>
+                </div>
             </div>
 
             {/* ノーツスピード */}

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -110,8 +110,7 @@ const defaultSettings: GameSettings = {
   notesSpeed: 1.0,
   playbackSpeed: 1.0,
   instrumentMode: 'piano',
-  inputMode: 'midi',
-  pianoSoundQuality: 'light',
+    inputMode: 'midi',
   
   // 判定設定
   allowOctaveError: false,
@@ -320,11 +319,6 @@ const validateSettings = (settings: Partial<GameSettings>): { valid: boolean; er
     normalized.midiVolume = Math.max(0, Math.min(1, normalized.midiVolume));
   }
     
-    if (normalized.pianoSoundQuality !== 'light' && normalized.pianoSoundQuality !== 'piano') {
-      errors.push('ピアノ音源品質は「軽量」または「高音質」から選択してください');
-      normalized.pianoSoundQuality = 'light';
-    }
-  
   if (normalized.bgmVolume < 0 || normalized.bgmVolume > 1) {
     errors.push('BGM音量は0-1の範囲で設定してください');
     normalized.bgmVolume = Math.max(0, Math.min(1, normalized.bgmVolume));

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -111,6 +111,7 @@ const defaultSettings: GameSettings = {
   playbackSpeed: 1.0,
   instrumentMode: 'piano',
   inputMode: 'midi',
+  pianoSoundQuality: 'light',
   
   // 判定設定
   allowOctaveError: false,
@@ -318,6 +319,11 @@ const validateSettings = (settings: Partial<GameSettings>): { valid: boolean; er
     errors.push('MIDI音量は0-1の範囲で設定してください');
     normalized.midiVolume = Math.max(0, Math.min(1, normalized.midiVolume));
   }
+    
+    if (normalized.pianoSoundQuality !== 'light' && normalized.pianoSoundQuality !== 'piano') {
+      errors.push('ピアノ音源品質は「軽量」または「高音質」から選択してください');
+      normalized.pianoSoundQuality = 'light';
+    }
   
   if (normalized.bgmVolume < 0 || normalized.bgmVolume > 1) {
     errors.push('BGM音量は0-1の範囲で設定してください');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@
 export type GameMode = 'practice' | 'performance';
 export type InstrumentMode = 'piano' | 'guitar';
 export type InputMode = 'midi' | 'audio' | 'both';
+export type PianoSoundQuality = 'light' | 'piano';
 
 // 移調楽器タイプ
 export type TransposingInstrument = 
@@ -143,6 +144,7 @@ export interface GameSettings {
   playbackSpeed: number;       // 0.25-2.0
   instrumentMode: InstrumentMode;
   inputMode: InputMode;
+  pianoSoundQuality: PianoSoundQuality;
   
   // 判定設定
   allowOctaveError: boolean;   // オクターブ違いを正解にする

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,6 @@
 export type GameMode = 'practice' | 'performance';
 export type InstrumentMode = 'piano' | 'guitar';
 export type InputMode = 'midi' | 'audio' | 'both';
-export type PianoSoundQuality = 'light' | 'piano';
 
 // 移調楽器タイプ
 export type TransposingInstrument = 
@@ -144,7 +143,6 @@ export interface GameSettings {
   playbackSpeed: number;       // 0.25-2.0
   instrumentMode: InstrumentMode;
   inputMode: InputMode;
-  pianoSoundQuality: PianoSoundQuality;
   
   // 判定設定
   allowOctaveError: boolean;   // オクターブ違いを正解にする


### PR DESCRIPTION
Allows direct selection of piano sound quality in all modes and smooths Taiko note rendering in Fantasy mode to improve performance and user experience.

The `pianoSoundQuality` setting is introduced, enabling users to explicitly choose between a lightweight sampler and the high-quality `@tonejs/piano` instrument. This eliminates the previous implicit loading of the high-quality piano in Fantasy mode, which caused performance issues, and allows direct selection in Legend mode without needing to first enter Fantasy mode. The `MidiController` has been refactored to handle these audio quality switches efficiently and to improve initial audio system responsiveness. Additionally, Taiko notes in Fantasy mode now use a smoothed time calculation, synchronizing better with the BGM and preventing choppy animations, especially at loop boundaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-55a96784-6159-40dd-8702-fbc5989b9f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55a96784-6159-40dd-8702-fbc5989b9f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

