### PR TITLE
Adjust scrolling and control bar for game modes

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1362,7 +1362,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                 width={pixiWidth}
                 height={120} // ★★★ 高さを120に固定 ★★★
                 onReady={handlePixiReady}
-                className="w-full h-full"
+                  className="w-full h-full"
+                  enableSwipeScroll={needsScroll}
               />
               </div>
             );
@@ -1374,7 +1375,8 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                 width={pixiWidth}
                 height={120} // ★★★ 高さを120に固定 ★★★
                 onReady={handlePixiReady}
-                className="w-full h-full"
+                  className="w-full h-full"
+                  enableSwipeScroll={needsScroll}
               />
               </div>
             );

--- a/src/components/game/ControlBar.tsx
+++ b/src/components/game/ControlBar.tsx
@@ -1,21 +1,21 @@
 import React, { useCallback } from 'react';
 import { useGameSelector, useGameActions } from '@/stores/helpers';
-import { 
-  FaPlay, 
-  FaPause, 
-  FaStop, 
-  FaBackward, 
-  FaForward, 
+import {
+  FaPlay,
+  FaPause,
+  FaStop,
+  FaBackward,
+  FaForward,
   FaTimes,
   FaCompressAlt,
   FaExpandAlt,
-  FaMusic
+  FaMusic,
 } from 'react-icons/fa';
-import { 
-  MdLoop,
-  MdReplay
-} from 'react-icons/md';
+import { MdLoop, MdReplay } from 'react-icons/md';
 
+const CONTROL_ICON_SIZE = 22;
+const SECONDARY_ICON_SIZE = 18;
+const TERTIARY_ICON_SIZE = 16;
 
 /**
  * ゲームコントロールバーコンポーネント
@@ -30,7 +30,7 @@ const ControlBar: React.FC = () => {
     settings,
     abRepeat,
     lessonContext,
-    missionContext
+    missionContext,
   } = useGameSelector((state) => ({
     mode: state.mode,
     isPlaying: state.isPlaying,
@@ -39,7 +39,7 @@ const ControlBar: React.FC = () => {
     settings: state.settings,
     abRepeat: state.abRepeat,
     lessonContext: state.lessonContext,
-    missionContext: state.missionContext
+    missionContext: state.missionContext,
   }));
 
   const {
@@ -56,7 +56,7 @@ const ControlBar: React.FC = () => {
     clearABRepeatEnd,
     transpose,
     updateSettings,
-    toggleSettings
+    toggleSettings,
   } = useGameActions();
 
   const isPracticeMode = mode === 'practice';
@@ -71,11 +71,14 @@ const ControlBar: React.FC = () => {
   }, []);
 
   // シークバーハンドラー
-  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!canInteract) return;
-    const newTime = parseFloat(e.target.value);
-    seek(newTime);
-  }, [canInteract, seek]);
+  const handleSeek = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!canInteract) return;
+      const newTime = parseFloat(e.target.value);
+      seek(newTime);
+    },
+    [canInteract, seek],
+  );
 
   // 5秒スキップハンドラー
   const handleSkipBackward = useCallback(() => {
@@ -109,7 +112,14 @@ const ControlBar: React.FC = () => {
       // 自動でループを有効化
       setTimeout(() => toggleABRepeat(), 50);
     }
-  }, [toggleABRepeat, setABRepeatStart, setABRepeatEnd, abRepeat, currentTime, songDuration]);
+  }, [
+    toggleABRepeat,
+    setABRepeatStart,
+    setABRepeatEnd,
+    abRepeat,
+    currentTime,
+    songDuration,
+  ]);
 
   // 本番モード用の再生/最初に戻るボタン（一時停止なし）
   const handlePlayOrRestart = useCallback(() => {
@@ -147,7 +157,6 @@ const ControlBar: React.FC = () => {
     updateSettings({ showHeader: !settings.showHeader });
   }, [updateSettings, settings.showHeader]);
 
-
   // 楽譜表示の切り替え
   const toggleSheetMusic = useCallback(() => {
     updateSettings({ showSheetMusic: !settings.showSheetMusic });
@@ -176,48 +185,50 @@ const ControlBar: React.FC = () => {
                   [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full 
                   [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:border-0`}
               />
-              
+
               {/* ループマーカー */}
-              {(abRepeat.startTime !== null || abRepeat.endTime !== null) && songDuration > 0 && (
-                <div className="absolute top-0 left-0 w-full h-2 pointer-events-none">
-                  {/* A地点マーカー */}
-                  {abRepeat.startTime !== null && (
-                    <div
-                      className="absolute top-0 w-1 h-2 bg-green-400 shadow-lg"
-                      style={{
-                        left: `${(abRepeat.startTime / songDuration) * 100}%`,
-                        transform: 'translateX(-50%)'
-                      }}
-                      title={`A地点: ${formatTime(abRepeat.startTime)}`}
-                    />
-                  )}
-                  
-                  {/* B地点マーカー */}
-                  {abRepeat.endTime !== null && (
-                    <div
-                      className="absolute top-0 w-1 h-2 bg-red-400 shadow-lg"
-                      style={{
-                        left: `${(abRepeat.endTime / songDuration) * 100}%`,
-                        transform: 'translateX(-50%)'
-                      }}
-                      title={`B地点: ${formatTime(abRepeat.endTime)}`}
-                    />
-                  )}
-                  
-                  {/* ループ範囲の背景 */}
-                  {abRepeat.startTime !== null && abRepeat.endTime !== null && (
-                    <div
-                      className={`absolute top-0 h-2 ${abRepeat.enabled ? 'bg-green-400' : 'bg-gray-400'} opacity-30 rounded`}
-                      style={{
-                        left: `${(abRepeat.startTime / songDuration) * 100}%`,
-                        width: `${((abRepeat.endTime - abRepeat.startTime) / songDuration) * 100}%`
-                      }}
-                    />
-                  )}
-                </div>
-              )}
+              {(abRepeat.startTime !== null || abRepeat.endTime !== null) &&
+                songDuration > 0 && (
+                  <div className="absolute top-0 left-0 w-full h-2 pointer-events-none">
+                    {/* A地点マーカー */}
+                    {abRepeat.startTime !== null && (
+                      <div
+                        className="absolute top-0 w-1 h-2 bg-green-400 shadow-lg"
+                        style={{
+                          left: `${(abRepeat.startTime / songDuration) * 100}%`,
+                          transform: 'translateX(-50%)',
+                        }}
+                        title={`A地点: ${formatTime(abRepeat.startTime)}`}
+                      />
+                    )}
+
+                    {/* B地点マーカー */}
+                    {abRepeat.endTime !== null && (
+                      <div
+                        className="absolute top-0 w-1 h-2 bg-red-400 shadow-lg"
+                        style={{
+                          left: `${(abRepeat.endTime / songDuration) * 100}%`,
+                          transform: 'translateX(-50%)',
+                        }}
+                        title={`B地点: ${formatTime(abRepeat.endTime)}`}
+                      />
+                    )}
+
+                    {/* ループ範囲の背景 */}
+                    {abRepeat.startTime !== null &&
+                      abRepeat.endTime !== null && (
+                        <div
+                          className={`absolute top-0 h-2 ${abRepeat.enabled ? 'bg-green-400' : 'bg-gray-400'} opacity-30 rounded`}
+                          style={{
+                            left: `${(abRepeat.startTime / songDuration) * 100}%`,
+                            width: `${((abRepeat.endTime - abRepeat.startTime) / songDuration) * 100}%`,
+                          }}
+                        />
+                      )}
+                  </div>
+                )}
             </div>
-            
+
             <div className="text-sm text-gray-300 min-w-[80px] text-right">
               {formatTime(currentTime)} / {formatTime(songDuration)}
             </div>
@@ -232,87 +243,114 @@ const ControlBar: React.FC = () => {
             // 練習モード: 5秒戻る、再生/一時停止、5秒進む、ループ、移調
             <>
               <button
+                type="button"
                 onClick={handleSkipBackward}
-
                 className="control-btn control-btn-xxs control-btn-secondary"
+                aria-label="5秒戻る"
                 title="5秒戻る"
               >
-                <FaBackward />
+                <FaBackward size={CONTROL_ICON_SIZE} />
               </button>
 
               <button
-                onClick={() => isPlaying ? pauseAction() : play()}
-
+                type="button"
+                onClick={() => (isPlaying ? pauseAction() : play())}
                 className="control-btn control-btn-xxs control-btn-primary"
-
                 disabled={!currentSong}
+                aria-label={isPlaying ? '一時停止' : '再生'}
                 title={isPlaying ? '一時停止' : '再生'}
               >
-                {isPlaying ? <FaPause /> : <FaPlay />}
+                {isPlaying ? (
+                  <FaPause size={CONTROL_ICON_SIZE} />
+                ) : (
+                  <FaPlay size={CONTROL_ICON_SIZE} />
+                )}
               </button>
 
               <button
+                type="button"
                 onClick={handleSkipForward}
-
                 className="control-btn control-btn-xxs control-btn-secondary"
-
+                aria-label="5秒進む"
                 title="5秒進む"
               >
-                <FaForward />
+                <FaForward size={CONTROL_ICON_SIZE} />
               </button>
 
               {/* ループコントロール */}
               <div className="flex items-center space-x-2 ml-4 flex-shrink-0">
                 <button
+                  type="button"
                   onClick={handleToggleLoop}
                   className={`control-btn control-btn-xxs ${abRepeat.enabled ? 'control-btn-loop-active' : 'control-btn-loop'}`}
+                  aria-label="ABリピートON/OFF"
+                  aria-pressed={abRepeat.enabled}
                   title="ABリピートON/OFF"
                 >
-                  <MdLoop />
+                  <MdLoop size={SECONDARY_ICON_SIZE} />
                 </button>
               </div>
 
               {/* A/B地点設定（コンパクト） */}
               <div className="flex items-center space-x-1 ml-2 text-xs flex-shrink-0">
                 <button
+                  type="button"
                   onClick={handleSetAStart}
                   className={`control-btn control-btn-xxs ${abRepeat.startTime !== null ? 'control-btn-primary' : 'control-btn-secondary'}`}
                   title="A地点設定"
+                  aria-label="A地点設定"
                 >
                   A
                 </button>
                 <span className="text-gray-400 w-8 text-center">
-                  {abRepeat.startTime !== null ? Math.floor(abRepeat.startTime / 60) + ':' + String(Math.floor(abRepeat.startTime % 60)).padStart(2, '0') : '--'}
+                  {abRepeat.startTime !== null
+                    ? Math.floor(abRepeat.startTime / 60) +
+                      ':' +
+                      String(Math.floor(abRepeat.startTime % 60)).padStart(
+                        2,
+                        '0',
+                      )
+                    : '--'}
                 </span>
                 {abRepeat.startTime !== null && (
                   <button
+                    type="button"
                     onClick={handleClearA}
                     className="control-btn control-btn-xxs control-btn-danger"
                     title="A地点クリア"
+                    aria-label="A地点クリア"
                   >
-                    <FaTimes size={10} />
+                    <FaTimes size={TERTIARY_ICON_SIZE} />
                   </button>
                 )}
-                
+
                 <span className="text-gray-500">~</span>
-                
+
                 <button
+                  type="button"
                   onClick={handleSetBEnd}
                   className={`control-btn control-btn-xxs ${abRepeat.endTime !== null ? 'control-btn-primary' : 'control-btn-secondary'}`}
                   title="B地点設定"
+                  aria-label="B地点設定"
                 >
                   B
                 </button>
                 <span className="text-gray-400 w-8 text-center">
-                  {abRepeat.endTime !== null ? Math.floor(abRepeat.endTime / 60) + ':' + String(Math.floor(abRepeat.endTime % 60)).padStart(2, '0') : '--'}
+                  {abRepeat.endTime !== null
+                    ? Math.floor(abRepeat.endTime / 60) +
+                      ':' +
+                      String(Math.floor(abRepeat.endTime % 60)).padStart(2, '0')
+                    : '--'}
                 </span>
                 {abRepeat.endTime !== null && (
                   <button
+                    type="button"
                     onClick={handleClearB}
                     className="control-btn control-btn-xxs control-btn-danger"
                     title="B地点クリア"
+                    aria-label="B地点クリア"
                   >
-                    <FaTimes size={10} />
+                    <FaTimes size={TERTIARY_ICON_SIZE} />
                   </button>
                 )}
               </div>
@@ -322,21 +360,27 @@ const ControlBar: React.FC = () => {
                 <div className="flex items-center space-x-1 ml-4 flex-shrink-0">
                   {/* 練習モードでは常に移調ボタンを表示 */}
                   <button
+                    type="button"
                     onClick={handleTransposeDown}
                     className="control-btn control-btn-xxs control-btn-secondary"
                     title="半音下げる"
                     disabled={settings.transpose <= -6}
+                    aria-label="半音下げる"
                   >
                     ♭
                   </button>
                   <span className="text-gray-300 min-w-[30px] text-center text-sm">
-                    {settings.transpose > 0 ? `+${settings.transpose}` : settings.transpose}
+                    {settings.transpose > 0
+                      ? `+${settings.transpose}`
+                      : settings.transpose}
                   </span>
                   <button
+                    type="button"
                     onClick={handleTransposeUp}
                     className="control-btn control-btn-xxs control-btn-secondary"
                     title="半音上げる"
                     disabled={settings.transpose >= 6}
+                    aria-label="半音上げる"
                   >
                     ♯
                   </button>
@@ -347,49 +391,56 @@ const ControlBar: React.FC = () => {
             // 本番モード: 再生/最初に戻るボタン（状況に応じて動作変化）
             <>
               <button
+                type="button"
                 onClick={handlePlayOrRestart}
-
                 className="control-btn control-btn-xxs control-btn-primary"
-
                 disabled={!currentSong}
-                title={
-                  currentTime > 0
-                    ? '最初に戻って再生'
-                    : '再生'
-                }
+                aria-label={currentTime > 0 ? '最初に戻って再生' : '再生'}
+                title={currentTime > 0 ? '最初に戻って再生' : '再生'}
               >
-                {currentTime > 0 ? <MdReplay /> : <FaPlay />}
+                {currentTime > 0 ? (
+                  <MdReplay size={CONTROL_ICON_SIZE} />
+                ) : (
+                  <FaPlay size={CONTROL_ICON_SIZE} />
+                )}
               </button>
 
               <button
+                type="button"
                 onClick={() => stop()}
                 className="control-btn control-btn-xxs control-btn-secondary"
-
                 disabled={!currentSong}
+                aria-label="停止"
                 title="停止"
               >
-                <FaStop />
+                <FaStop size={CONTROL_ICON_SIZE} />
               </button>
 
               {/* 移調コントロール（レッスンモード・ミッションモードでは非表示） */}
               {!lessonContext && !missionContext && (
                 <div className="flex items-center space-x-1 ml-4 flex-shrink-0">
                   <button
+                    type="button"
                     onClick={handleTransposeDown}
                     className="control-btn control-btn-xxs control-btn-secondary"
                     title="半音下げる"
                     disabled={settings.transpose <= -6}
+                    aria-label="半音下げる"
                   >
                     ♭
                   </button>
                   <span className="text-gray-300 min-w-[30px] text-center text-sm">
-                    {settings.transpose > 0 ? `+${settings.transpose}` : settings.transpose}
+                    {settings.transpose > 0
+                      ? `+${settings.transpose}`
+                      : settings.transpose}
                   </span>
                   <button
+                    type="button"
                     onClick={handleTransposeUp}
                     className="control-btn control-btn-xxs control-btn-secondary"
                     title="半音上げる"
                     disabled={settings.transpose >= 6}
+                    aria-label="半音上げる"
                   >
                     ♯
                   </button>
@@ -398,37 +449,46 @@ const ControlBar: React.FC = () => {
             </>
           )}
         </div>
-        
+
         {/* 右側: FPSモニター、設定、楽譜表示、シークバー切り替えボタン */}
         <div className="flex items-center space-x-2 flex-shrink-0 ml-4">
-
-          
           {/* 設定ボタン */}
           <button
+            type="button"
             onClick={toggleSettings}
             className="control-btn control-btn-xxs control-btn-secondary"
             title="設定"
+            aria-label="設定"
           >
             ⚙️
           </button>
-          
+
           {/* 楽譜表示切り替えボタン */}
           <button
+            type="button"
             onClick={toggleSheetMusic}
             className={`control-btn control-btn-xxs ${settings.showSheetMusic ? 'control-btn-primary' : 'control-btn-secondary'}`}
             title={settings.showSheetMusic ? '楽譜を隠す' : '楽譜を表示'}
+            aria-label={settings.showSheetMusic ? '楽譜を隠す' : '楽譜を表示'}
           >
-            <FaMusic />
+            <FaMusic size={SECONDARY_ICON_SIZE} />
           </button>
-          
+
           {/* ヘッダー表示/非表示ボタン */}
           <button
+            type="button"
             onClick={toggleHeader}
             className="control-btn control-btn-xxs control-btn-secondary"
             title={settings.showHeader ? 'ヘッダーを隠す' : 'ヘッダーを表示'}
+            aria-label={
+              settings.showHeader ? 'ヘッダーを隠す' : 'ヘッダーを表示'
+            }
           >
-            {settings.showHeader ? <FaCompressAlt /> : <FaExpandAlt />}
-
+            {settings.showHeader ? (
+              <FaCompressAlt size={SECONDARY_ICON_SIZE} />
+            ) : (
+              <FaExpandAlt size={SECONDARY_ICON_SIZE} />
+            )}
           </button>
         </div>
       </div>

--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -940,6 +940,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
             idealWidth = Math.ceil(TOTAL_WHITE_KEYS * whiteKeyWidth);
             displayMode = 'MOBILE_SCROLL';
           }
+            const enableSwipeScroll = displayMode === 'MOBILE_SCROLL';
           
           
           return (
@@ -968,6 +969,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
                     height={gameAreaSize.height}
                     onReady={handlePixiReady}
                     className="w-full h-full"
+                    enableSwipeScroll={enableSwipeScroll}
                   />
                 <ChordOverlay />
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -350,6 +350,22 @@
            focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-opacity-40
            active:scale-95 overflow-hidden
            flex items-center justify-center leading-none;
+    min-width: 56px;
+    min-height: 56px;
+  }
+  
+  .control-btn-xxs {
+    min-width: 56px;
+    min-height: 56px;
+    @apply px-4 py-3 text-xl;
+  }
+  
+  @media (max-width: 640px) {
+    .control-btn-xxs {
+      min-width: 48px;
+      min-height: 48px;
+      @apply px-3 py-2 text-lg;
+    }
   }
   
   .control-btn:before {
@@ -383,6 +399,17 @@
   .control-btn-secondary:hover {
     background: linear-gradient(135deg, #9ca3af 0%, #6b7280 50%, #4b5563 100%);
     box-shadow: 0 6px 20px rgba(107, 114, 128, 0.6);
+  }
+  
+  .control-btn-danger {
+    background: linear-gradient(135deg, #dc2626 0%, #b91c1c 50%, #7f1d1d 100%);
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.35);
+    @apply focus:ring-red-500;
+  }
+  
+  .control-btn-danger:hover {
+    background: linear-gradient(135deg, #f87171 0%, #ef4444 50%, #b91c1c 100%);
+    box-shadow: 0 6px 20px rgba(239, 68, 68, 0.5);
   }
   
   .control-btn-loop {


### PR DESCRIPTION
Implement horizontal swipe scrolling for piano keys and note areas in Legend/Fantasy modes and fix control bar button display on iPhone to improve mobile usability.

The previous implementation for Legend and Fantasy modes treated all horizontal swipes on the piano keys as glissandos, making it impossible to scroll the wide keyboard view on narrow screens. This PR introduces a dedicated swipe-scroll mode that distinguishes between short taps (for notes) and longer drags (for scrolling). Additionally, control bar icons were not rendering on iPhones due to insufficient button sizing, which is addressed by explicitly setting icon sizes and minimum button dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e05ba47-dfc9-4339-b2cc-8193a0d15455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e05ba47-dfc9-4339-b2cc-8193a0d15455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

