### PR TITLE
Adjust scrolling and control bar for game modes

### DIFF
--- a/src/components/game/ControlBar.tsx
+++ b/src/components/game/ControlBar.tsx
@@ -230,19 +230,21 @@ const ControlBar: React.FC = () => {
         <div className="flex justify-center items-center space-x-3 overflow-x-auto whitespace-nowrap">
           {isPracticeMode ? (
             // 練習モード: 5秒戻る、再生/一時停止、5秒進む、ループ、移調
-            <>
-              <button
-                onClick={handleSkipBackward}
-
-                className="control-btn control-btn-xxs control-btn-secondary"
-                title="5秒戻る"
-              >
+              <>
+                <button
+                  type="button"
+                  onClick={handleSkipBackward}
+                  aria-label="5秒戻る"
+                  className="control-btn control-btn-xxs control-btn-secondary"
+                  title="5秒戻る"
+                >
                 <FaBackward />
               </button>
 
               <button
+                  type="button"
                 onClick={() => isPlaying ? pauseAction() : play()}
-
+                  aria-label={isPlaying ? '一時停止' : '再生'}
                 className="control-btn control-btn-xxs control-btn-primary"
 
                 disabled={!currentSong}
@@ -252,8 +254,9 @@ const ControlBar: React.FC = () => {
               </button>
 
               <button
+                  type="button"
                 onClick={handleSkipForward}
-
+                  aria-label="5秒進む"
                 className="control-btn control-btn-xxs control-btn-secondary"
 
                 title="5秒進む"

--- a/src/index.css
+++ b/src/index.css
@@ -351,6 +351,28 @@
            active:scale-95 overflow-hidden
            flex items-center justify-center leading-none;
   }
+
+  .control-btn-xxs {
+    min-width: 3.75rem;
+    min-height: 3.75rem;
+    font-size: 1.35rem;
+    line-height: 1.2;
+  }
+
+  @media (max-width: 640px) {
+    .control-btn-xxs {
+      min-width: 4rem;
+      min-height: 4rem;
+      font-size: 1.45rem;
+    }
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .control-btn-xxs {
+      min-width: 4.1rem;
+      min-height: 4.1rem;
+    }
+  }
   
   .control-btn:before {
     content: '';


### PR DESCRIPTION
Enable horizontal scrolling on touch swipe for keyboard and note drop areas in Legend/Fantasy modes, and fix invisible control bar buttons on iPhone.

The keyboard and note drop areas now use `touch-action: pan-x` and detect significant horizontal touch movement to prevent glissando and allow scrolling. The control bar buttons were given a new `control-btn-xxs` class to increase their size and tap area, with specific adjustments for iPhone/Safari, and `type="button"` and `aria-label` attributes were added for accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-f35cbf29-63a9-418c-be25-d9e5563ead07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f35cbf29-63a9-418c-be25-d9e5563ead07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

