### PR TITLE
Legend mode playback and display fixes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -218,7 +218,20 @@
   
   /* Removed DotGothic16 import and utility; use Tailwind font-sans (Kaisei Opti) */
   
-  /* 楽譜エリア: 再生中はスクロールバーを非表示 */
+    .sheet-note path,
+    .sheet-note ellipse,
+    .sheet-note circle {
+      transition: fill 120ms ease, stroke 120ms ease;
+    }
+
+    .sheet-note.sheet-note-active path,
+    .sheet-note.sheet-note-active ellipse,
+    .sheet-note.sheet-note-active circle {
+      fill: #ef4444 !important;
+      stroke: #ef4444 !important;
+    }
+
+    /* 楽譜エリア: 再生中はスクロールバーを非表示 */
   .overflow-hidden.custom-sheet-scrollbar::-webkit-scrollbar {
     display: none;
   }

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1090,10 +1090,13 @@ export const useGameStore = createWithEqualityFn<GameStoreState>()(
           });
             
             // set の外側で最新の設定値を取得し、GameEngine へ反映
-            const { gameEngine, settings, currentSong, rawNotes } = get();
+            const { gameEngine, settings, currentSong, rawNotes, currentTime } = get();
             if (gameEngine) {
               // Proxy（Immer Draft）が revoke されるのを防ぐため、プレーンオブジェクトを渡す
               gameEngine.updateSettings({ ...settings });
+              if (Object.prototype.hasOwnProperty.call(filteredSettings, 'timingAdjustment')) {
+                gameEngine.seek(currentTime);
+              }
             }
           
           // 移調楽器の設定が変更された場合、楽譜を再処理

--- a/src/types/osmd.d.ts
+++ b/src/types/osmd.d.ts
@@ -38,6 +38,7 @@ declare module 'opensheetmusicdisplay' {
         y: number;
       };
     };
+    getSVGElement?: () => SVGGraphicsElement | null;
   }
 
   export interface GraphicalVoiceEntry {


### PR DESCRIPTION
Fixes Legend Mode issues including iOS audio speed, result modal timing, sheet music display, and timing adjustment application.

The audio playback logic was refactored to allow pitch-preserved speed changes on iOS by conditionally using `MediaElementAudioSourceNode` only when transposing. The result modal now waits for the audio to fully complete before appearing. Sheet music display was overhauled to use custom SVG class-based note highlighting instead of OSMD's playhead, enabling full scrollability, an auto-follow toggle, and precise synchronization with timing adjustments. Timing adjustments now apply immediately by seeking the audio engine upon change.

---
<a href="https://cursor.com/background-agent?bcId=bc-4356618d-4e35-4a55-9de7-52513828dde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4356618d-4e35-4a55-9de7-52513828dde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

