### PR TITLE
Legend mode playback and display fixes

### DIFF
--- a/src/utils/gameEngine.ts
+++ b/src/utils/gameEngine.ts
@@ -357,13 +357,15 @@ export class GameEngine {
   
   clearABRepeat(): void {}
   
-  updateSettings(settings: GameSettings): void {
-    const prevSpeed = this.settings.playbackSpeed ?? 1;
+    updateSettings(settings: GameSettings): void {
+      const prevSpeed = this.settings.playbackSpeed ?? 1;
+      const prevTimingAdjustment = this.settings.timingAdjustment ?? 0;
     // 現在の論理時間を保持（旧スピードで計算）
     const currentLogicalTime = this.getCurrentTime();
 
     // 設定更新
     this.settings = settings;
+      const timingChanged = (this.settings.timingAdjustment ?? 0) !== prevTimingAdjustment;
 
     // 本番モードでは練習モードガイドを無効化
     if (this.settings.practiceGuide !== 'off') {
@@ -385,14 +387,18 @@ export class GameEngine {
       // devLog.debug(`🔧 GameEngine.updateSettings: 速度変更 ${prevSpeed}x → ${newSpeed}x`);
     }
 
-    // notesSpeed が変化した場合、未処理ノートの appearTime を更新
-    const dynamicLookahead = this.getLookaheadTime();
-    this.notes.forEach((note) => {
-      // まだ appearTime を計算済みでも更新（タイミング調整を含める）
-      note.appearTime = note.time + this.getTimingAdjSec() - dynamicLookahead;
-    });
-    const lookBehind = Math.max(0, this.getCurrentTime() - dynamicLookahead);
-    this.nextNoteIndex = this.findNextNoteIndex(lookBehind);
+      if (timingChanged) {
+        // timingAdjustment変更時は処理済みフラグをリセットして完全に再計算
+        this.resetNoteProcessing(this.getCurrentTime());
+      } else {
+        // notesSpeed 等が変化した場合、未処理ノートの appearTime を更新
+        const dynamicLookahead = this.getLookaheadTime();
+        this.notes.forEach((note) => {
+          note.appearTime = note.time + this.getTimingAdjSec() - dynamicLookahead;
+        });
+        const lookBehind = Math.max(0, this.getCurrentTime() - dynamicLookahead);
+        this.nextNoteIndex = this.findNextNoteIndex(lookBehind);
+      }
   }
   
   destroy(): void {


### PR DESCRIPTION
Implements `Tone.GrainPlayer` for iOS to enable pitch-preserving audio speed changes, adjusts result modal timing to audio completion, and replaces OSMD playhead with custom note highlighting and native scrolling for improved sheet music synchronization and visibility.

The previous audio playback mechanism on iOS did not support changing playback speed without altering pitch. The result modal was triggering prematurely based on note completion rather than audio completion. Furthermore, the OSMD playhead caused issues with sheet music scrolling and visibility, which is now resolved by a custom highlighting and scrolling solution that also correctly incorporates timing adjustments from the start of playback.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb80f1fb-7f3a-4a3a-aa38-ef8bad7c1b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb80f1fb-7f3a-4a3a-aa38-ef8bad7c1b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

