### PR TITLE
Fix legend mode music playback issues

### DIFF
--- a/src/components/game/SheetMusicDisplay.tsx
+++ b/src/components/game/SheetMusicDisplay.tsx
@@ -14,6 +14,9 @@ interface TimeMappingEntry {
   xPosition: number;
 }
 
+const PLAYHEAD_OFFSET_PX = 120;
+const PRE_START_MARGIN_MS = 10;
+
 /**
  * 楽譜表示コンポーネント
  * OSMDを使用して横スクロール形式の楽譜を表示
@@ -289,7 +292,20 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
         return;
       }
 
-      const currentTimeMs = currentTime * 1000;
+        const currentTimeMs = currentTime * 1000;
+        const firstEntry = mapping[0];
+        if (firstEntry) {
+          const beforeFirstPlayableNote = currentTimeMs + PRE_START_MARGIN_MS < firstEntry.timeMs;
+          if (beforeFirstPlayableNote) {
+            if (scoreWrapperRef.current) {
+              scoreWrapperRef.current.style.transform = 'translateX(0px)';
+            }
+            mappingCursorRef.current = -1;
+            lastRenderedIndexRef.current = -1;
+            lastScrollXRef.current = 0;
+            return;
+          }
+        }
 
       const findNextIndex = () => {
         let low = 0;
@@ -310,8 +326,7 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
       mappingCursorRef.current = activeIndex;
 
       const targetEntry = mapping[activeIndex] ?? mapping[mapping.length - 1];
-      const playheadPosition = 120;
-      const scrollX = Math.max(0, targetEntry.xPosition - playheadPosition);
+        const scrollX = Math.max(0, targetEntry.xPosition - PLAYHEAD_OFFSET_PX);
 
       const needsIndexUpdate = activeIndex !== lastRenderedIndexRef.current;
       const needsScrollUpdate = Math.abs(scrollX - lastScrollXRef.current) > 0.5;


### PR DESCRIPTION
Fixes iOS playback speed reset during pitch changes, ensures practice mode UI stops correctly at song end, and prevents OSMD playhead from jumping prematurely.

iOS devices sometimes reset the playback rate when pitch shifting is active; the `enforcePlaybackSpeed` function with delayed re-application addresses this. The practice mode fix ensures the UI accurately reflects the stopped state after a song ends, allowing for correct re-playback. The OSMD playhead now remains at the start until the first note is about to play, improving the visual experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-f53c5abb-ec09-4cff-b79e-0e6171b7cbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f53c5abb-ec09-4cff-b79e-0e6171b7cbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

