### PR TITLE
Fix legend mode music playback issues

### DIFF
--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -354,6 +354,10 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
         };
         const handleEnded = () => {
           setHasPlaybackFinished(true);
+          const declaredDuration = currentSongDuration ?? audio.duration ?? currentTimeRef.current;
+          const safeDuration = Number.isFinite(declaredDuration) ? declaredDuration : currentTimeRef.current;
+          updateTime(safeDuration);
+          pause();
         };
         const handlePlayEvent = () => {
           setHasPlaybackFinished(false);
@@ -415,7 +419,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
     } else {
       setAudioLoaded(false);
     }
-      }, [hasAudioTrack, currentSongAudioFile, currentSongTitle, currentSongId, settings.musicVolume, audioElementKey]);
+        }, [hasAudioTrack, currentSongAudioFile, currentSongTitle, currentSongId, settings.musicVolume, audioElementKey, currentSongDuration, pause, updateTime]);
 
     useEffect(() => {
       setHasPlaybackFinished(false);
@@ -676,7 +680,7 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       if (gameEngine) {
         updateEngineSettings();
       }
-  }, [settings.playbackSpeed, gameEngine, updateEngineSettings, isPlaying, audioElementKey]);
+  }, [settings.playbackSpeed, gameEngine, updateEngineSettings, isPlaying, audioElementKey, settings.transpose]);
   
   // シーク機能（音声ありと音声なし両方対応）
   useEffect(() => {


### PR DESCRIPTION
Fixes legend mode issues: iOS pitch change resetting playback speed, practice mode not stopping playback display at end, and OSMD playhead jumping prematurely.

-   **iOS Pitch/Speed Conflict:** The playback speed `useEffect` now reacts to `transpose` changes, ensuring `playbackRate` and `preservesPitch` are reapplied when the `HTMLAudioElement` is reconfigured due to pitch changes on iOS, preventing the speed from resetting to 1.0x.
-   **Practice Mode Playback End:** The `handleEnded` function now explicitly calls `updateTime` to the audio's end duration and `pause()`, ensuring the playback display stops correctly after completion and allowing re-seeking.
-   **OSMD Playhead Behavior:** The OSMD playhead is now fixed at the beginning measure until the first note starts, and it returns to this position when seeking back to the start (near 0 seconds), preventing immediate jumps.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3e83e87-369a-4bf2-8ae4-e5a53d005d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3e83e87-369a-4bf2-8ae4-e5a53d005d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

