### PR TITLE
Optimize legend mode scrolling and performance

### DIFF
--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -140,6 +140,7 @@ export class PIXINotesRendererInstance {
   private onKeyRelease?: (note: number) => void;
   private backgroundCanvas: HTMLCanvasElement | null = null;
   private backgroundNeedsUpdate = true;
+  private currentChord = '';
 
   constructor(canvas: HTMLCanvasElement, width: number, height: number) {
     this.canvas = canvas;
@@ -257,6 +258,7 @@ export class PIXINotesRendererInstance {
     this.guideHighlightedKeys.clear();
       this.pointerStates.clear();
     this.backgroundCanvas = null;
+    this.currentChord = '';
   }
 
   get view(): HTMLCanvasElement {
@@ -518,6 +520,7 @@ export class PIXINotesRendererInstance {
     }
     this.drawNotes(ctx);
     this.drawKeyHighlights(ctx);
+    this.drawChord(ctx);
     if (token) {
       controller.endFrame(token);
     }
@@ -720,6 +723,45 @@ export class PIXINotesRendererInstance {
     };
     this.guideHighlightedKeys.forEach((midi) => drawHighlight(midi, this.colors.guideKey));
     this.highlightedKeys.forEach((midi) => drawHighlight(midi, this.colors.activeKey));
+    ctx.restore();
+  }
+
+  updateChord(chord: string): void {
+    if (this.destroyed) return;
+    if (this.currentChord !== chord) {
+      this.currentChord = chord;
+      this.requestRender();
+    }
+  }
+
+  private drawChord(ctx: CanvasRenderingContext2D): void {
+    if (!this.currentChord) return;
+    
+    ctx.save();
+    const centerX = this.width / 2;
+    const topY = this.height * 0.4; // 画面の40%の位置（元のChordOverlayと同じ）
+    
+    // 背景（半透明の黒）
+    const fontSize = Math.max(32, this.width * 0.04);
+    ctx.font = `bold ${fontSize}px 'Inter', 'Noto Sans JP', sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    
+    const textMetrics = ctx.measureText(this.currentChord);
+    const padding = 16;
+    const bgWidth = textMetrics.width + padding * 2;
+    const bgHeight = fontSize + padding * 2;
+    const bgX = centerX - bgWidth / 2;
+    const bgY = topY - bgHeight / 2;
+    
+    // 背景を描画
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+    ctx.fillRect(bgX, bgY, bgWidth, bgHeight);
+    
+    // テキストを描画
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(this.currentChord, centerX, topY);
+    
     ctx.restore();
   }
 

--- a/src/components/game/ScoreOverlay.tsx
+++ b/src/components/game/ScoreOverlay.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useGameSelector } from '@/stores/helpers';
+
+/**
+ * スコア表示オーバーレイコンポーネント
+ * GameEngine から分離して、スコア更新時の再レンダリングを最小化
+ */
+const ScoreOverlay: React.FC = () => {
+  const { score, mode } = useGameSelector((state) => ({
+    score: state.score,
+    mode: state.mode
+  }));
+
+  // パフォーマンスモードでのみ表示
+  if (mode !== 'performance') {
+    return null;
+  }
+
+  return (
+    <div className="absolute top-3 left-3 z-20 text-lg font-bold bg-black bg-opacity-70 px-3 py-2 rounded-lg pointer-events-none">
+      <span className="text-green-400">✓ {score.goodCount}</span>
+      <span className="mx-3 text-gray-500">|</span>
+      <span className="text-red-400">× {score.missCount}</span>
+    </div>
+  );
+};
+
+export default ScoreOverlay;


### PR DESCRIPTION
Refactor Legend Mode rendering to fix scroll issues and significantly improve performance.

This PR addresses several performance bottlenecks and a UX issue in Legend Mode:
1.  **Stopping Scroll Fix:** When paused, sheet music now uses `scrollLeft` instead of `transform` to allow scrolling back to past notes.
2.  **Canvas Migration:** Sheet music display (OSMD) and chord overlays now use Canvas 2D, eliminating DOM overhead from SVG and frequent React re-renders.
3.  **Component Isolation:** Score display is moved to a separate component, and `currentTime` updates are handled via a `subscribe` pattern, preventing the main `GameEngineComponent` from re-rendering on every frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b5ff38c-68b2-4546-af21-679a89561980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b5ff38c-68b2-4546-af21-679a89561980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

