### PR TITLE
Implement and fix game engine seek and ab repeat

### DIFF
--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -65,7 +65,8 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       mode,
       lastKeyHighlight,
       isSettingsOpen,
-      resultModalOpen
+      resultModalOpen,
+      abRepeat // ストアからABリピート情報を取得
     } = useGameSelector((state) => ({
       gameEngine: state.gameEngine,
       isPlaying: state.isPlaying,
@@ -74,7 +75,8 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       mode: state.mode,
       lastKeyHighlight: state.lastKeyHighlight,
       isSettingsOpen: state.isSettingsOpen,
-      resultModalOpen: state.resultModalOpen
+      resultModalOpen: state.resultModalOpen,
+      abRepeat: state.abRepeat // 追加
     }));
     const currentSongId = currentSong?.id ?? null;
     const currentSongAudioFile = currentSong?.audioFile ?? '';
@@ -211,6 +213,19 @@ export const GameEngineComponent: React.FC<GameEngineComponentProps> = ({
       renderBridgeRef.current?.dispose();
     };
   }, []);
+
+  // ABリピートの設定をGameEngineに同期
+  useEffect(() => {
+    if (gameEngine) {
+      if (abRepeat.enabled) {
+        gameEngine.enableABRepeat();
+      } else {
+        gameEngine.disableABRepeat();
+      }
+      gameEngine.setABRepeatStart(abRepeat.start);
+      gameEngine.setABRepeatEnd(abRepeat.end);
+    }
+  }, [gameEngine, abRepeat]);
 
     useEffect(() => {
       pianoZoomRef.current = pianoZoom;


### PR DESCRIPTION
Implement AB repeat functionality and fix seek/pause logic in GameEngine to ensure correct playback and looping.

The `seek()` method incorrectly reset `pausedTime` to 0, causing playback to jump to the beginning after seeking while paused. Additionally, AB repeat functionality was incomplete, with empty methods for setting loop points and checking the loop condition. This PR corrects these issues by updating `pausedTime` to the seek target and implementing the full AB repeat logic, including UI synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-63becfa1-8a61-4a94-b727-74245c3ecd2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63becfa1-8a61-4a94-b727-74245c3ecd2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

