### PR TITLE
Fix legend mode audio and seek issues

### DIFF
--- a/src/components/game/ControlBar.tsx
+++ b/src/components/game/ControlBar.tsx
@@ -142,16 +142,20 @@ const ControlBar: React.FC = () => {
     transpose(1);
   }, [transpose]);
 
-  // ヘッダー表示/非表示の切り替え
-  const toggleHeader = useCallback(() => {
-    updateSettings({ showHeader: !settings.showHeader });
-  }, [updateSettings, settings.showHeader]);
+    // ヘッダー表示/非表示の切り替え
+    const toggleHeader = useCallback(() => {
+      updateSettings({ showHeader: !settings.showHeader });
+    }, [updateSettings, settings.showHeader]);
+
+    const handleStop = useCallback(() => {
+      stop({ preservePosition: true });
+    }, [stop]);
 
 
-  // 楽譜表示の切り替え
-  const toggleSheetMusic = useCallback(() => {
-    updateSettings({ showSheetMusic: !settings.showSheetMusic });
-  }, [updateSettings, settings.showSheetMusic]);
+    // 楽譜表示の切り替え
+    const toggleSheetMusic = useCallback(() => {
+      updateSettings({ showSheetMusic: !settings.showSheetMusic });
+    }, [updateSettings, settings.showSheetMusic]);
 
   return (
     <div className="w-full">
@@ -345,31 +349,28 @@ const ControlBar: React.FC = () => {
             </>
           ) : (
             // 本番モード: 再生/最初に戻るボタン（状況に応じて動作変化）
-            <>
-                <button
-                  onClick={handlePlayOrRestart}
-
-                  className="control-btn control-btn-xxs control-btn-primary control-btn-transport"
-
-                disabled={!currentSong}
-                title={
-                  currentTime > 0
-                    ? '最初に戻って再生'
-                    : '再生'
-                }
-              >
-                {currentTime > 0 ? <MdReplay /> : <FaPlay />}
-              </button>
-
-                <button
-                  onClick={() => stop()}
-                  className="control-btn control-btn-xxs control-btn-secondary control-btn-transport"
-
-                disabled={!currentSong}
-                title="停止"
-              >
-                <FaStop />
-              </button>
+              <>
+                  <button
+                    onClick={handlePlayOrRestart}
+                    className="control-btn control-btn-xxs control-btn-primary control-btn-transport"
+                    disabled={!currentSong}
+                    title={
+                      currentTime > 0
+                        ? '最初に戻って再生'
+                        : '再生'
+                    }
+                  >
+                    {currentTime > 0 ? <MdReplay /> : <FaPlay />}
+                  </button>
+  
+                  <button
+                    onClick={handleStop}
+                    className="control-btn control-btn-xxs control-btn-secondary control-btn-transport"
+                    disabled={!currentSong}
+                    title="停止"
+                  >
+                    <FaStop />
+                  </button>
 
               {/* 移調コントロール（レッスンモード・ミッションモードでは非表示） */}
               {!lessonContext && !missionContext && (


### PR DESCRIPTION
Fix Legend mode playback issues including playhead reset on stop, broken seek/AB repeat, and inaccurate song end detection.

The core problem stemmed from inconsistent synchronization between the audio source (HTML audio element or AudioContext) and the game engine's internal time, especially during active playback and seeking. Additionally, the stop action was hardcoded to reset the playhead. This PR refactors the time synchronization logic in `GameEngine` and updates the `stop` action to optionally preserve the current position, ensuring a more robust and user-friendly playback experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb15168e-0747-490c-8b5c-38b4c05bb836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb15168e-0747-490c-8b5c-38b4c05bb836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

