### PR TITLE
Fix legend mode audio and seek issues

### DIFF
--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -161,7 +161,7 @@ const GameScreen: React.FC = () => {
           
           // レッスン設定を先に適用（loadSongの前に実行）
           // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
-          gameActions.stop();
+        gameActions.stop({ resetToStart: true });
           gameActions.clearSong();
           
           await gameActions.updateSettings({
@@ -352,7 +352,7 @@ const GameScreen: React.FC = () => {
           
           // ミッション曲の条件を先に設定に適用（loadSongの前に実行）
           // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
-          gameActions.stop();
+            gameActions.stop({ resetToStart: true });
           gameActions.clearSong();
           
           await gameActions.updateSettings({
@@ -665,7 +665,7 @@ const SongSelectionScreen: React.FC = () => {
                   gameActions.clearMissionContext();
                   
                   // 明示的リセット: 前の曲の再生・状態を完全停止/初期化
-                  gameActions.stop();
+                    gameActions.stop({ resetToStart: true });
                   gameActions.clearSong();
                   
                   try {


### PR DESCRIPTION
Refactor Legend mode audio and playhead synchronization to fix seeking, stopping, and performance issues.

The previous implementation had issues where seeking and AB repeat were unreliable, the playhead reset on stop, and performance suffered due to frequent Immer updates. This PR introduces a unified `syncPlaybackPosition` callback for robust audio/game engine synchronization, modifies the `stop` action to preserve the current position by default, and optimizes `currentTime` updates to reduce re-renders and improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-6878bd81-d156-4338-bcaf-dd1228d48238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6878bd81-d156-4338-bcaf-dd1228d48238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

