### PR TITLE
Update sheet music scrolling and ab loop controls

### DIFF
--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1209,6 +1209,8 @@ export const useGameStore = createWithEqualityFn<GameStoreState>()(
             }
             // 本番モードでは練習モードガイドを無効化
             state.settings.practiceGuide = 'off';
+            // ステージ（本番）モードではABループを強制的に無効化
+            state.abRepeat.enabled = false;
             
             // 🆕 レッスンモード時：本番モードで課題条件を強制適用
             if (state.lessonContext) {


### PR DESCRIPTION
Enhance sheet music scrolling at song end, disable AB loop in performance mode, and improve AB loop UI with draggable markers and visual feedback.

These changes address user feedback to provide a more intuitive and robust experience. The improved sheet music scrolling ensures the playhead remains visible even past the last note. Disabling AB loop in performance mode prevents accidental looping during live play. The new draggable markers and visual cues for AB loop make setting and understanding loop ranges much easier in practice mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c90c9ca-3621-4a0b-8788-108be4e00460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c90c9ca-3621-4a0b-8788-108be4e00460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

