### PR TITLE
Improve legend and stage mode playback

### DIFF
--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -604,9 +604,10 @@ export const useGameStore = createWithEqualityFn<GameStoreState>()(
             // エンジンの更新コールバック設定
             engine.setUpdateCallback((data: any) => {
               const storeSnapshot = useGameStore.getState();
-              const { abRepeat } = storeSnapshot;
+              const { abRepeat, mode } = storeSnapshot;
               
-              if (abRepeat.enabled && abRepeat.startTime !== null && abRepeat.endTime !== null) {
+              // ステージモードではABループを無効化
+              if (mode !== 'performance' && abRepeat.enabled && abRepeat.startTime !== null && abRepeat.endTime !== null) {
                 if (data.currentTime >= abRepeat.endTime) {
                   const seekTime = abRepeat.startTime;
                   console.log(`🔄 ABリピート(Store): ${data.currentTime.toFixed(2)}s → ${seekTime.toFixed(2)}s`);


### PR DESCRIPTION
Fix OSMD playhead position on pause, disable AB loop in Stage mode, and add draggable visual AB loop markers to both the seekbar and OSMD sheet music for improved usability.

The playhead position on pause was inaccurate, particularly in later sections, due to scroll margin interactions, which has been a recurring issue. This PR addresses it by adjusting the calculation to find the closest note. Additionally, AB loop functionality is now disabled in Stage mode as per requirements, and comprehensive visual and interactive controls for AB loop points have been added to enhance the user experience in practice mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2a9e2a4-fe43-424e-b6e0-6268a4d11b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2a9e2a4-fe43-424e-b6e0-6268a4d11b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

