### PR TITLE
Fix legend mode score scroll pause bug

### DIFF
--- a/src/components/game/SheetMusicDisplay.tsx
+++ b/src/components/game/SheetMusicDisplay.tsx
@@ -306,6 +306,39 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
     }
   }, [shouldRenderSheet]);
 
+  // 現在の時刻から正確なスクロール位置を計算する関数
+  const calculateScrollXFromCurrentTime = useCallback(() => {
+    const mapping = timeMappingRef.current;
+    if (mapping.length === 0) {
+      return 0;
+    }
+
+    const currentTimeMs = currentTime * 1000;
+    const playheadPosition = 120;
+
+    // 現在時刻に最も近い音符のインデックスを検索
+    let low = 0;
+    let high = mapping.length - 1;
+    
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      if (mapping[mid].timeMs <= currentTimeMs) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    
+    const activeIndex = Math.max(0, Math.min(low - 1, mapping.length - 1));
+    const targetEntry = mapping[activeIndex];
+    
+    if (!targetEntry) {
+      return 0;
+    }
+
+    return Math.max(0, targetEntry.xPosition - playheadPosition);
+  }, [currentTime]);
+
   // 再生状態に応じてtransform/scrollLeft方式を切り替え
   useEffect(() => {
     if (!shouldRenderSheet) {
@@ -320,10 +353,13 @@ const SheetMusicDisplay: React.FC<SheetMusicDisplayProps> = ({ className = '' })
       scrollContainer.scrollLeft = 0;
       wrapper.style.transform = `translateX(-${lastScrollXRef.current}px)`;
     } else {
+      // 一時停止時は現在の時刻から正確なスクロール位置を計算
+      const accurateScrollX = calculateScrollXFromCurrentTime();
+      lastScrollXRef.current = accurateScrollX;
       wrapper.style.transform = 'translateX(0px)';
-      scrollContainer.scrollLeft = lastScrollXRef.current;
+      scrollContainer.scrollLeft = accurateScrollX;
     }
-  }, [isPlaying, shouldRenderSheet]);
+  }, [isPlaying, shouldRenderSheet, calculateScrollXFromCurrentTime]);
 
   // 音符の時刻とX座標のマッピングを作成
     // 注: 以下のコードは transform 方式のスクロールでは効果が薄く、意図しないジャンプの原因になるためコメントアウト


### PR DESCRIPTION
Fixes playhead jumping to an incorrect position when pausing in Legend mode.

Previously, when pausing, the scroll position was not accurately recalculated based on the current time, leading to the playhead jumping to an incorrect position, particularly noticeable in the latter half of the song. This change introduces a function to calculate the precise scroll position from the current time and applies it upon pausing.

---
<a href="https://cursor.com/background-agent?bcId=bc-0448f19a-0828-47e0-b663-b8ae356a866c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0448f19a-0828-47e0-b663-b8ae356a866c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

