### PR TITLE
Fix legend mode playhead jump on pause

### DIFF
--- a/src/utils/musicXmlMapper.ts
+++ b/src/utils/musicXmlMapper.ts
@@ -244,7 +244,7 @@ function extractChordPositions(doc: Document): MusicXmlChordPosition[] {
 /**
  * 小節の時間情報
  */
-interface MeasureTimeInfo {
+export interface MeasureTimeInfo {
   measureNumber: number;
   startTime: number;
   duration: number;
@@ -340,6 +340,27 @@ function estimateMeasureTimeInfo(notePositions: MusicXmlNotePosition[], jsonNote
   }
   
   return measures;
+}
+
+/**
+ * MusicXMLとJSONノーツから小節時間情報を組み立てる
+ */
+export function buildMeasureTimeMap(doc: Document, jsonNotes: NoteData[]): MeasureTimeInfo[] {
+  if (!doc || jsonNotes.length === 0) {
+    return [];
+  }
+
+  const notePositions = extractNotePositions(doc);
+  if (notePositions.length === 0) {
+    console.warn('⚠️ MusicXMLからノート位置を取得できませんでした。');
+    return [];
+  }
+
+  if (notePositions.length !== jsonNotes.length) {
+    console.warn(`⚠️ ノート数不一致のまま小節時間を計算: MusicXML=${notePositions.length}, JSON=${jsonNotes.length}`);
+  }
+
+  return estimateMeasureTimeInfo(notePositions, jsonNotes);
 }
 
 /**
@@ -1009,4 +1030,4 @@ function getAccidentalText(alter: number): string | null {
 }
 
 // 小節時間情報推定関数を公開（他でも使用可能に）
-export { estimateMeasureTimeInfo }; 
+export { estimateMeasureTimeInfo };


### PR DESCRIPTION
Implement measure-based sheet music scrolling to prevent playhead jumps on pause in Legend mode.

The previous note-based mapping caused the playhead to jump to an incorrect, often much earlier, position when pausing, especially in later sections of the music. This PR introduces a new system that calculates playhead position and scroll based on measure timings and layouts, ensuring smoother and more accurate positioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-c251928e-6984-4c1f-bffc-5c3ca5dc2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c251928e-6984-4c1f-bffc-5c3ca5dc2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

