### PR TITLE
Fix legend mode playhead jump on pause

### DIFF
--- a/src/components/game/GameEngine.tsx
+++ b/src/components/game/GameEngine.tsx
@@ -720,21 +720,24 @@ const playFromOffset = useCallback(
     }, [hasAudioTrack, currentSongDuration, isPlaying]);
   
 // 再生状態同期
-useEffect(() => {
-  if (!gameEngine) {
-    return;
-  }
+  useEffect(() => {
+    if (!gameEngine) {
+      return;
+    }
 
-  if (isPlaying) {
-    void playFromOffset(currentTimeRef.current);
-  } else {
+    if (isPlaying) {
+      void playFromOffset(currentTimeRef.current);
+      return;
+    }
+
     stopCurrentBufferSource();
+    const engineSnapshot = gameEngine.getState();
     gameEngine.pause();
     log.info('🎮 GameEngine paused');
-    const timelineTime = getTimelineTime();
-    updateTime(timelineTime);
-  }
-}, [gameEngine, getTimelineTime, isPlaying, playFromOffset, stopCurrentBufferSource, updateTime]);
+    const pauseTime = engineSnapshot?.currentTime ?? getTimelineTime();
+    currentTimeRef.current = pauseTime;
+    updateTime(pauseTime);
+  }, [gameEngine, getTimelineTime, isPlaying, playFromOffset, stopCurrentBufferSource, updateTime]);
 
 useEffect(() => {
   return () => {


### PR DESCRIPTION
Prioritize the game engine's current time on pause in Legend mode to prevent the OSMD playhead from jumping to an incorrect position.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f3a5e2e-7c67-4517-ac91-65fb944e3641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f3a5e2e-7c67-4517-ac91-65fb944e3641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

