### PR TITLE
Fix piano key tap lag on iphone

### DIFF
--- a/src/components/fantasy/OnScreenPiano.tsx
+++ b/src/components/fantasy/OnScreenPiano.tsx
@@ -76,20 +76,21 @@ const OnScreenPiano: React.FC<OnScreenPianoProps> = ({
   };
 
   const handlePointerDown = (note: number) => (e: React.PointerEvent) => {
+    // 音を最優先で鳴らす (Reactの状態更新による遅延を回避)
+    playNote(note, 64);
+
     try { (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId); } catch {}
     isPointerDownRef.current = true;
     pointerIdToNoteRef.current.set(e.pointerId, note);
     setNoteActive(note, true);
-    // velocityは固定（やや強め）
-    playNote(note, 64);
   };
 
   const handlePointerUpOrCancel = (e: React.PointerEvent) => {
     const map = pointerIdToNoteRef.current;
     const note = map.get(e.pointerId);
     if (note != null) {
+      stopNote(note); // 停止を先に
       setNoteActive(note, false);
-      stopNote(note);
       map.delete(e.pointerId);
     }
     if (map.size === 0) isPointerDownRef.current = false;
@@ -101,12 +102,13 @@ const OnScreenPiano: React.FC<OnScreenPianoProps> = ({
     const prev = map.get(e.pointerId);
     if (prev === note) return;
     if (prev != null) {
+      stopNote(prev); // 停止を先に
       setNoteActive(prev, false);
-      stopNote(prev);
     }
     map.set(e.pointerId, note);
+    
+    playNote(note, 64); // 再生を先に
     setNoteActive(note, true);
-    playNote(note, 64);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Optimizes audio playback timing for touch events to reduce perceived lag when playing piano on iPhone.

The `playNote` function was refactored to execute synchronously when the audio context is active, avoiding `async/await` overhead. Additionally, audio playback/stop calls in `OnScreenPiano` are now prioritized before React state updates to prevent rendering delays from affecting sound responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-259ae2c4-b69c-48c7-912a-11467ab19c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-259ae2c4-b69c-48c7-912a-11467ab19c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

