### PR TITLE
Restore legend mode voice input with WASM

### DIFF
--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -3,6 +3,8 @@ import { useGameSelector, useGameActions } from '@/stores/helpers';
 import GameEngineComponent from './GameEngine';
 import ControlBar from './ControlBar';
 import { MidiDeviceSelector } from '@/components/ui/MidiDeviceManager';
+import { AudioDeviceSelector, InputTypeSelector } from '@/components/ui/AudioDeviceManager';
+import type { InputType } from '@/types';
 import ResultModal from './ResultModal';
 import SheetMusicDisplay from './SheetMusicDisplay';
 import ResizeHandle from '@/components/ui/ResizeHandle';
@@ -1406,17 +1408,39 @@ const SettingsPanel: React.FC = () => {
                     入力デバイス
                   </label>
                   <p className="text-xs text-gray-400">
-                    レジェンドモードは超低遅延のためMIDI入力専用に最適化されています。
+                    MIDI入力で超低遅延プレイ、または音声入力（マイク）で楽器やボーカルを認識
                   </p>
                 </div>
 
-                <div className="bg-blue-900 bg-opacity-20 p-4 rounded-lg border border-blue-700 border-opacity-30">
-                  <h4 className="text-sm font-medium text-blue-200 mb-3">🎹 MIDI デバイス設定</h4>
-                  <MidiDeviceSelector
-                    value={settings.selectedMidiDevice}
-                    onChange={(deviceId: string | null) => gameActions.updateSettings({ selectedMidiDevice: deviceId })}
+                {/* 入力方式選択 */}
+                <div className="bg-gray-800 bg-opacity-50 p-4 rounded-lg border border-gray-600 border-opacity-30 mb-4">
+                  <InputTypeSelector
+                    value={settings.inputType}
+                    onChange={(type: InputType) => gameActions.updateSettings({ inputType: type })}
                   />
                 </div>
+
+                {/* MIDI入力モード */}
+                {settings.inputType === 'midi' && (
+                  <div className="bg-blue-900 bg-opacity-20 p-4 rounded-lg border border-blue-700 border-opacity-30">
+                    <h4 className="text-sm font-medium text-blue-200 mb-3">🎹 MIDI デバイス設定</h4>
+                    <MidiDeviceSelector
+                      value={settings.selectedMidiDevice}
+                      onChange={(deviceId: string | null) => gameActions.updateSettings({ selectedMidiDevice: deviceId })}
+                    />
+                  </div>
+                )}
+
+                {/* 音声入力モード */}
+                {settings.inputType === 'audio' && (
+                  <div className="bg-green-900 bg-opacity-20 p-4 rounded-lg border border-green-700 border-opacity-30">
+                    <h4 className="text-sm font-medium text-green-200 mb-3">🎤 音声入力設定</h4>
+                    <AudioDeviceSelector
+                      value={settings.selectedAudioDevice}
+                      onChange={(deviceId: string | null) => gameActions.updateSettings({ selectedAudioDevice: deviceId })}
+                    />
+                  </div>
+                )}
               </div>
 
             {/* 音量設定 */}

--- a/src/components/ui/AudioDeviceManager.tsx
+++ b/src/components/ui/AudioDeviceManager.tsx
@@ -1,0 +1,238 @@
+/**
+ * 音声入力デバイス管理コンポーネントとカスタムフック
+ * マイク入力によるピッチ検出用
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import type { AudioDevice } from '@/utils/AudioController';
+
+// 音声デバイス管理用カスタムフック
+export const useAudioDevices = () => {
+  const [devices, setDevices] = useState<AudioDevice[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [currentDeviceId, setCurrentDeviceId] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+
+  // 音声デバイス一覧を取得
+  const refreshDevices = useCallback(async () => {
+    setIsRefreshing(true);
+    setError(null);
+    
+    try {
+      // mediaDevices API の存在確認
+      if (!navigator.mediaDevices || typeof navigator.mediaDevices.enumerateDevices !== 'function') {
+        throw new Error('このブラウザではマイク入力がサポートされていません');
+      }
+
+      // まずマイク許可を取得
+      if (typeof navigator.mediaDevices.getUserMedia === 'function') {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          stream.getTracks().forEach(track => track.stop());
+          setHasPermission(true);
+        } catch (permError) {
+          if (permError instanceof Error && permError.name === 'NotAllowedError') {
+            setHasPermission(false);
+            throw new Error('マイクの使用許可が必要です');
+          }
+          throw permError;
+        }
+      }
+
+      // デバイス一覧を取得
+      const allDevices = await navigator.mediaDevices.enumerateDevices();
+      const audioInputs = allDevices.filter(device => device.kind === 'audioinput');
+      
+      // 重複排除
+      const uniqueDevices = new Map<string, AudioDevice>();
+      audioInputs.forEach(device => {
+        if (device.deviceId) {
+          const key = device.label || device.deviceId;
+          if (!uniqueDevices.has(key)) {
+            uniqueDevices.set(key, {
+              id: device.deviceId,
+              name: device.label || `マイク ${device.deviceId.slice(0, 4)}`,
+              isDefault: device.deviceId === 'default'
+            });
+          }
+        }
+      });
+
+      setDevices(Array.from(uniqueDevices.values()));
+      
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '音声デバイスの取得に失敗しました';
+      setError(errorMessage);
+      setDevices([]);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  // 初回ロード時にデバイス一覧を取得
+  useEffect(() => {
+    refreshDevices();
+  }, [refreshDevices]);
+
+  // デバイス状態変更の監視
+  useEffect(() => {
+    if (navigator.mediaDevices && typeof navigator.mediaDevices.addEventListener === 'function') {
+      navigator.mediaDevices.addEventListener('devicechange', refreshDevices);
+      return () => {
+        navigator.mediaDevices.removeEventListener('devicechange', refreshDevices);
+      };
+    }
+    return undefined;
+  }, [refreshDevices]);
+
+  return {
+    devices,
+    isConnected,
+    currentDeviceId,
+    isRefreshing,
+    error,
+    hasPermission,
+    refreshDevices,
+    setCurrentDeviceId,
+    setIsConnected
+  };
+};
+
+// 音声デバイス選択コンポーネント
+interface AudioDeviceSelectorProps {
+  value: string | null;
+  onChange: (deviceId: string | null) => void;
+  className?: string;
+}
+
+export const AudioDeviceSelector: React.FC<AudioDeviceSelectorProps> = ({
+  value,
+  onChange,
+  className = ''
+}) => {
+  const { devices, isRefreshing, error, hasPermission, refreshDevices } = useAudioDevices();
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {/* デバイス選択ドロップダウン */}
+      <div>
+        <label htmlFor="audio-device-select" className="block text-xs text-blue-200 mb-1">
+          使用マイク
+        </label>
+        <div className="flex gap-2">
+          <select
+            id="audio-device-select"
+            value={value || ''}
+            onChange={(e) => onChange(e.target.value || null)}
+            className="select select-bordered select-sm flex-1 bg-gray-800 text-white border-blue-600 lp-mobile-select"
+            disabled={isRefreshing || hasPermission === false}
+          >
+            <option value="">なし</option>
+            {devices.map((device) => (
+              <option key={device.id} value={device.id}>
+                {`🎤 ${device.name}${device.isDefault ? ' (デフォルト)' : ''}`}
+              </option>
+            ))}
+          </select>
+          
+          <button 
+            className="btn btn-xs btn-outline btn-blue"
+            onClick={refreshDevices}
+            disabled={isRefreshing}
+            aria-label="マイクを再検出"
+          >
+            🔄 再検出
+          </button>
+        </div>
+      </div>
+
+      {/* デバイス情報表示 */}
+      <div className="text-xs text-blue-200 space-y-1">
+        <div className="flex justify-between">
+          <span>検出マイク数:</span>
+          <span className="font-mono">{devices.length} 個</span>
+        </div>
+        
+        <div className="flex justify-between">
+          <span>接続状態:</span>
+          {value ? (
+            <span className="text-green-400">✅ 選択済み</span>
+          ) : (
+            <span className="text-gray-400">なし</span>
+          )}
+        </div>
+        
+        {hasPermission === false && (
+          <div className="text-amber-400 text-xs mt-2 p-2 bg-amber-900 bg-opacity-30 rounded">
+            ⚠️ マイクの使用許可が必要です。ブラウザの設定でマイクへのアクセスを許可してください。
+          </div>
+        )}
+        
+        {error && hasPermission !== false && (
+          <div className="text-red-400 text-xs mt-2 p-2 bg-red-900 bg-opacity-30 rounded">
+            ❌ {error}
+          </div>
+        )}
+      </div>
+
+      {/* 使い方ヒント */}
+      <div className="text-xs text-gray-400 mt-2">
+        💡 ヒント: 楽器やボーカルの単音を認識します。静かな環境で使用してください。
+      </div>
+    </div>
+  );
+};
+
+// 入力タイプ選択コンポーネント（MIDI/Audio切り替え）
+interface InputTypeSelectorProps {
+  value: 'midi' | 'audio';
+  onChange: (type: 'midi' | 'audio') => void;
+  className?: string;
+}
+
+export const InputTypeSelector: React.FC<InputTypeSelectorProps> = ({
+  value,
+  onChange,
+  className = ''
+}) => {
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <span className="block text-sm font-medium text-gray-300">
+        入力方式
+      </span>
+      <div className="flex items-center space-x-4" role="radiogroup" aria-label="入力方式">
+        <label className="flex items-center space-x-2 cursor-pointer">
+          <input
+            type="radio"
+            name="input-type"
+            value="midi"
+            checked={value === 'midi'}
+            onChange={() => onChange('midi')}
+            className="radio radio-sm radio-primary"
+          />
+          <span className="text-sm text-gray-300">🎹 MIDI入力</span>
+        </label>
+        <label className="flex items-center space-x-2 cursor-pointer">
+          <input
+            type="radio"
+            name="input-type"
+            value="audio"
+            checked={value === 'audio'}
+            onChange={() => onChange('audio')}
+            className="radio radio-sm radio-primary"
+          />
+          <span className="text-sm text-gray-300">🎤 音声入力</span>
+        </label>
+      </div>
+      <div className="text-xs text-gray-400">
+        {value === 'midi' ? (
+          'MIDIキーボードやMIDIコントローラーで入力'
+        ) : (
+          'マイクで楽器やボーカルの音を認識（単音のみ）'
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -134,7 +134,9 @@ const defaultSettings: GameSettings = {
   pianoHeight: 80,  // ピアノの高さをさらに調整（100から80に減少）
   
   // 入力デバイス
+  inputType: 'midi',
   selectedMidiDevice: null,
+  selectedAudioDevice: null,
   
   // キー設定
   transpose: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@
 
 export type GameMode = 'practice' | 'performance';
 export type InstrumentMode = 'piano' | 'guitar';
+export type InputType = 'midi' | 'audio';
 // 移調楽器タイプ
 export type TransposingInstrument = 
   | 'concert_pitch'      // コンサートピッチ（移調なし）
@@ -172,7 +173,9 @@ export interface GameSettings {
   pianoHeight: number;
   
   // 入力デバイス
+  inputType: InputType;
   selectedMidiDevice: string | null;
+  selectedAudioDevice: string | null;
   
   // キー設定
   transpose: number;           // -6 to +6 (半音)

--- a/src/utils/AudioController.ts
+++ b/src/utils/AudioController.ts
@@ -1,0 +1,563 @@
+/**
+ * AudioController - WASMピッチ検出による音声入力コントローラー
+ * 
+ * 特徴:
+ * - 軽量・低レイテンシ
+ * - 単音検出（モノフォニック）
+ * - iOS対応
+ */
+
+// WASMモジュールの型定義
+interface WasmModule {
+  analyze_pitch: (ptr: number, length: number, sampleRate: number, yinThreshold: number) => number;
+  init_pitch_detector: (sampleRate: number) => void;
+  get_ring_buffer_ptr: () => number;
+  get_ring_buffer_size: () => number;
+  process_audio_block: (newWriteIndex: number) => number;
+  alloc: (size: number) => number;
+  free: (ptr: number, size: number) => void;
+  get_memory: () => WebAssembly.Memory;
+}
+
+// Audio Worklet用のメッセージ型
+interface WorkletMessage {
+  type: 'samples' | 'init';
+  samples?: Float32Array;
+  ptr?: number;
+  ringSize?: number;
+}
+
+// デバイス情報
+export interface AudioDevice {
+  id: string;
+  name: string;
+  isDefault?: boolean;
+}
+
+// コールバック型
+type NoteOnCallback = (note: number) => void;
+type NoteOffCallback = (note: number) => void;
+type ConnectionChangeCallback = (connected: boolean) => void;
+
+// iOS検出ユーティリティ
+const isIOS = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return /iPad|iPhone|iPod/.test(ua) || 
+    (/Macintosh/.test(ua) && 'ontouchend' in document);
+};
+
+/**
+ * AudioController クラス
+ * マイク入力からピッチを検出し、MIDIノートに変換する
+ */
+export class AudioController {
+  // コールバック
+  private onNoteOn: NoteOnCallback | null = null;
+  private onNoteOff: NoteOffCallback | null = null;
+  private onConnectionChange: ConnectionChangeCallback | null = null;
+
+  // Audio Context
+  private audioContext: AudioContext | null = null;
+  private mediaStream: MediaStream | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  private scriptNode: ScriptProcessorNode | null = null;
+  
+  // WASM関連
+  private wasmModule: WasmModule | null = null;
+  private wasmMemory: WebAssembly.Memory | null = null;
+  private ringBufferPtr = 0;
+  private ringSize = 0;
+  private writeIndex = 0;
+  
+  // 状態
+  private isProcessing = false;
+  private currentDeviceId: string | null = null;
+  private isIOSDevice = isIOS();
+  
+  // ピッチ検出パラメータ
+  private readonly bufferSize = 512;
+  private readonly minFrequency = 27.5;  // A0
+  private readonly maxFrequency = 4186.01; // C8
+  private readonly yinThreshold = 0.1;
+  private readonly noteOnThreshold = 0.05;
+  private readonly noteOffThreshold = 0.03;
+  private sampleRate = 44100;
+  
+  // ピッチ履歴とノート状態
+  private pitchHistory: number[] = [];
+  private readonly pitchHistorySize = 3;
+  private currentNote = -1;
+  private isNoteOn = false;
+  private lastDetectedFrequency = 0;
+  
+  // 周波数テーブル（MIDIノート -> 周波数）
+  private noteFrequencies: Map<number, number> = new Map();
+  
+  constructor(onNoteOn?: NoteOnCallback, onNoteOff?: NoteOffCallback) {
+    this.onNoteOn = onNoteOn || null;
+    this.onNoteOff = onNoteOff || null;
+    this.initializeNoteFrequencies();
+  }
+
+  /**
+   * 周波数テーブル初期化（A0からC8まで）
+   */
+  private initializeNoteFrequencies(): void {
+    for (let i = 21; i <= 108; i++) {
+      const frequency = 440 * Math.pow(2, (i - 69) / 12);
+      this.noteFrequencies.set(i, frequency);
+    }
+  }
+
+  /**
+   * WASMモジュールを初期化
+   */
+  async initWasm(): Promise<void> {
+    if (this.wasmModule) return;
+    
+    try {
+      const wasmUrl = new URL('/wasm/pitch_detector_bg.wasm', window.location.origin);
+      const response = await fetch(wasmUrl);
+      const wasmBytes = await response.arrayBuffer();
+      
+      const imports = {
+        wbg: {
+          __wbg_log_c222819a41e063d3: () => { /* Debug log disabled */ },
+          __wbindgen_init_externref_table: () => {
+            // Required by WASM bindgen
+          },
+          __wbindgen_memory: () => this.wasmMemory,
+          __wbindgen_string_new: () => '',
+          __wbindgen_throw: (ptr: number, len: number) => {
+            throw new Error(`WASM error at ${ptr}:${len}`);
+          }
+        }
+      };
+
+      const { instance } = await WebAssembly.instantiate(wasmBytes, imports);
+      this.wasmModule = instance.exports as unknown as WasmModule;
+      this.wasmMemory = this.wasmModule.get_memory();
+      
+    } catch (error) {
+      // WASM初期化失敗時はフォールバックモードで動作
+      this.wasmModule = null;
+    }
+  }
+
+  /**
+   * コールバック設定
+   */
+  setCallbacks(
+    onNoteOn: NoteOnCallback,
+    onNoteOff: NoteOffCallback,
+    onConnectionChange?: ConnectionChangeCallback
+  ): void {
+    this.onNoteOn = onNoteOn;
+    this.onNoteOff = onNoteOff;
+    if (onConnectionChange) {
+      this.onConnectionChange = onConnectionChange;
+    }
+  }
+
+  /**
+   * オーディオデバイス一覧を取得
+   */
+  async getDevices(): Promise<AudioDevice[]> {
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.enumerateDevices !== 'function') {
+      return [];
+    }
+
+    try {
+      // まずマイク許可を取得（ラベル取得のため）
+      const tempStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      tempStream.getTracks().forEach(track => track.stop());
+
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const audioInputs = devices.filter(device => device.kind === 'audioinput');
+      
+      return audioInputs.map(device => ({
+        id: device.deviceId,
+        name: device.label || `マイク ${device.deviceId.slice(0, 4)}`,
+        isDefault: device.deviceId === 'default'
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * デバイスに接続
+   */
+  async connectDevice(deviceId?: string): Promise<boolean> {
+    try {
+      // 既存接続を切断
+      if (this.mediaStream) {
+        this.mediaStream.getTracks().forEach(track => track.stop());
+        this.mediaStream = null;
+      }
+
+      // getUserMedia の存在確認
+      if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+        this.notifyConnectionChange(false);
+        return false;
+      }
+
+      // マイク許可を取得
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          deviceId: deviceId ? { exact: deviceId } : undefined,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true
+        },
+        video: false
+      });
+
+      // AudioContext作成
+      if (!this.audioContext || this.audioContext.state === 'closed') {
+        const AudioContextClass = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+        this.audioContext = new AudioContextClass();
+      }
+      
+      if (this.audioContext.state === 'suspended') {
+        await this.audioContext.resume();
+      }
+      
+      this.sampleRate = this.audioContext.sampleRate;
+
+      // WASM初期化
+      await this.initWasm();
+      if (this.wasmModule) {
+        this.wasmModule.init_pitch_detector(this.sampleRate);
+        this.ringBufferPtr = this.wasmModule.get_ring_buffer_ptr();
+        this.ringSize = this.wasmModule.get_ring_buffer_size();
+        this.writeIndex = 0;
+      }
+
+      // オーディオソース作成
+      const source = this.audioContext.createMediaStreamSource(this.mediaStream);
+
+      // AudioWorkletまたはScriptProcessor
+      if (window.AudioWorkletNode) {
+        await this.setupAudioWorklet(source);
+      } else {
+        this.setupScriptProcessor(source);
+      }
+
+      this.currentDeviceId = deviceId || null;
+      this.isProcessing = true;
+      this.notifyConnectionChange(true);
+      
+      return true;
+    } catch {
+      this.notifyConnectionChange(false);
+      return false;
+    }
+  }
+
+  /**
+   * AudioWorkletセットアップ
+   */
+  private async setupAudioWorklet(source: MediaStreamAudioSourceNode): Promise<void> {
+    if (!this.audioContext) return;
+
+    try {
+      // Workletモジュール登録
+      await this.audioContext.audioWorklet.addModule('/js/audio/audio-worklet-processor.js');
+      this.workletNode = new AudioWorkletNode(this.audioContext, 'audio-processor');
+
+      // メッセージハンドラ
+      this.workletNode.port.onmessage = (e: MessageEvent<WorkletMessage>) => {
+        if (e.data.type === 'samples' && e.data.samples) {
+          this.processAudioSamples(e.data.samples);
+        }
+      };
+
+      // 初期化メッセージ
+      this.workletNode.port.postMessage({
+        type: 'init',
+        ptr: this.ringBufferPtr,
+        ringSize: this.ringSize
+      });
+
+      source.connect(this.workletNode);
+      this.workletNode.connect(this.audioContext.destination);
+    } catch {
+      // フォールバック
+      this.setupScriptProcessor(source);
+    }
+  }
+
+  /**
+   * ScriptProcessor フォールバック
+   */
+  private setupScriptProcessor(source: MediaStreamAudioSourceNode): void {
+    if (!this.audioContext) return;
+
+    this.scriptNode = this.audioContext.createScriptProcessor(this.bufferSize, 1, 1);
+    this.scriptNode.onaudioprocess = (e: AudioProcessingEvent) => {
+      const inputData = e.inputBuffer.getChannelData(0);
+      this.processAudioSamples(inputData);
+    };
+    
+    source.connect(this.scriptNode);
+    this.scriptNode.connect(this.audioContext.destination);
+  }
+
+  /**
+   * オーディオサンプルを処理
+   */
+  private processAudioSamples(samples: Float32Array): void {
+    if (!this.isProcessing) return;
+
+    // 振幅チェック
+    let maxAmplitude = 0;
+    for (let i = 0; i < samples.length; i++) {
+      maxAmplitude = Math.max(maxAmplitude, Math.abs(samples[i]));
+    }
+
+    // ノートオン/オフ状態更新
+    if (!this.isNoteOn && maxAmplitude > this.noteOnThreshold) {
+      this.isNoteOn = true;
+    } else if (this.isNoteOn && maxAmplitude < this.noteOffThreshold) {
+      this.isNoteOn = false;
+      this.handleNoPitch();
+      return;
+    }
+
+    if (!this.isNoteOn) return;
+
+    // WASMピッチ検出
+    let frequency = 0;
+    if (this.wasmModule && this.wasmMemory) {
+      frequency = this.detectPitchWithWasm(samples);
+    } else {
+      // フォールバック: 自己相関法
+      frequency = this.detectPitchFallback(samples);
+    }
+
+    if (frequency > 0 && frequency >= this.minFrequency && frequency <= this.maxFrequency) {
+      this.handleDetectedPitch(frequency);
+    } else {
+      this.handleNoPitch();
+    }
+  }
+
+  /**
+   * WASMでピッチ検出
+   */
+  private detectPitchWithWasm(samples: Float32Array): number {
+    if (!this.wasmModule || !this.wasmMemory) return 0;
+
+    try {
+      const byteLength = samples.length * Float32Array.BYTES_PER_ELEMENT;
+      const ptr = this.wasmModule.alloc(byteLength);
+      const wasmArray = new Float32Array(this.wasmMemory.buffer, ptr, samples.length);
+      wasmArray.set(samples);
+      
+      const frequency = this.wasmModule.analyze_pitch(
+        ptr, 
+        byteLength, 
+        this.sampleRate, 
+        this.yinThreshold
+      );
+      
+      this.wasmModule.free(ptr, byteLength);
+      return frequency;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * フォールバック: 自己相関法によるピッチ検出
+   */
+  private detectPitchFallback(samples: Float32Array): number {
+    const n = samples.length;
+    const maxLag = Math.floor(this.sampleRate / this.minFrequency);
+    const minLag = Math.floor(this.sampleRate / this.maxFrequency);
+    
+    let bestCorrelation = 0;
+    let bestLag = 0;
+
+    for (let lag = minLag; lag <= maxLag && lag < n; lag++) {
+      let correlation = 0;
+      for (let i = 0; i < n - lag; i++) {
+        correlation += samples[i] * samples[i + lag];
+      }
+      
+      if (correlation > bestCorrelation) {
+        bestCorrelation = correlation;
+        bestLag = lag;
+      }
+    }
+
+    return bestLag > 0 ? this.sampleRate / bestLag : 0;
+  }
+
+  /**
+   * 検出されたピッチを処理
+   */
+  private handleDetectedPitch(frequency: number): void {
+    const midiNote = this.getClosestNote(frequency);
+    
+    // ピッチ履歴を更新
+    this.pitchHistory.push(midiNote);
+    if (this.pitchHistory.length > this.pitchHistorySize) {
+      this.pitchHistory.shift();
+    }
+
+    // 安定したノートを取得
+    const stableNote = this.getStableNote();
+    if (stableNote !== -1 && stableNote !== this.currentNote) {
+      if (this.currentNote !== -1) {
+        this.onNoteOff?.(this.currentNote);
+      }
+      this.currentNote = stableNote;
+      this.onNoteOn?.(stableNote);
+    }
+
+    this.lastDetectedFrequency = frequency;
+  }
+
+  /**
+   * ピッチが検出されなかった場合
+   */
+  private handleNoPitch(): void {
+    this.pitchHistory.push(-1);
+    if (this.pitchHistory.length > this.pitchHistorySize) {
+      this.pitchHistory.shift();
+    }
+
+    const silentFrames = this.pitchHistory.filter(p => p === -1).length;
+    if (silentFrames >= 2 && this.currentNote !== -1) {
+      this.onNoteOff?.(this.currentNote);
+      this.currentNote = -1;
+    }
+
+    this.lastDetectedFrequency = 0;
+  }
+
+  /**
+   * 周波数から最も近いMIDIノートを取得
+   */
+  private getClosestNote(frequency: number): number {
+    let closestNote = 48; // C2
+    let minDifference = Infinity;
+
+    for (const [note, noteFreq] of this.noteFrequencies) {
+      const difference = Math.abs(frequency - noteFreq);
+      if (difference < minDifference) {
+        minDifference = difference;
+        closestNote = note;
+      }
+    }
+
+    return closestNote;
+  }
+
+  /**
+   * 安定したノートを取得
+   */
+  private getStableNote(): number {
+    if (this.pitchHistory.length < 2) return -1;
+
+    const recentHistory = this.pitchHistory.slice(-3);
+    const noteCounts = new Map<number, number>();
+
+    for (const note of recentHistory) {
+      if (note !== -1) {
+        noteCounts.set(note, (noteCounts.get(note) || 0) + 1);
+      }
+    }
+
+    let mostCommonNote = -1;
+    let maxCount = 0;
+    const minRequiredCount = Math.ceil(recentHistory.length * 0.5);
+
+    for (const [note, count] of noteCounts) {
+      if (count > maxCount && count >= minRequiredCount) {
+        mostCommonNote = note;
+        maxCount = count;
+      }
+    }
+
+    return mostCommonNote;
+  }
+
+  /**
+   * 接続変更を通知
+   */
+  private notifyConnectionChange(connected: boolean): void {
+    this.onConnectionChange?.(connected);
+  }
+
+  /**
+   * デバイスから切断
+   */
+  async disconnect(): Promise<void> {
+    this.isProcessing = false;
+
+    if (this.workletNode) {
+      this.workletNode.disconnect();
+      this.workletNode.port.close();
+      this.workletNode = null;
+    }
+
+    if (this.scriptNode) {
+      this.scriptNode.disconnect();
+      this.scriptNode = null;
+    }
+
+    if (this.mediaStream) {
+      this.mediaStream.getTracks().forEach(track => track.stop());
+      this.mediaStream = null;
+    }
+
+    if (this.audioContext) {
+      if (this.isIOSDevice) {
+        // iOSではsuspend
+        await this.audioContext.suspend();
+      } else {
+        await this.audioContext.close();
+        this.audioContext = null;
+      }
+    }
+
+    if (this.currentNote !== -1) {
+      this.onNoteOff?.(this.currentNote);
+      this.currentNote = -1;
+    }
+
+    this.currentDeviceId = null;
+    this.pitchHistory = [];
+    this.notifyConnectionChange(false);
+  }
+
+  /**
+   * 現在接続中かどうか
+   */
+  isConnected(): boolean {
+    return this.isProcessing && this.mediaStream !== null;
+  }
+
+  /**
+   * 現在のデバイスIDを取得
+   */
+  getCurrentDeviceId(): string | null {
+    return this.currentDeviceId;
+  }
+
+  /**
+   * リソースを破棄
+   */
+  async dispose(): Promise<void> {
+    await this.disconnect();
+    this.wasmModule = null;
+    this.wasmMemory = null;
+    this.onNoteOn = null;
+    this.onNoteOff = null;
+    this.onConnectionChange = null;
+  }
+}


### PR DESCRIPTION
レジェンドモードでの音声入力オプションを復活させ、WASMベースの軽量・低レイテンシ単音ピッチ検出をiOS対応で実現します。

この変更により、ユーザーはマイクを使用して楽器やボーカルの単音をゲームに入力できるようになります。WASMを活用した新しいピッチ検出器は、パフォーマンスとiOS互換性を考慮して設計されています。

---
<a href="https://cursor.com/background-agent?bcId=bc-86ebb550-5af0-466a-8297-0fe40887a04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86ebb550-5af0-466a-8297-0fe40887a04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

