### PR TITLE
Improve fantasy game screen visuals

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -960,20 +960,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     return hearts;
   }, [heartFlash]);
   
-  // 敵のゲージ表示（黄色系）
-  const renderEnemyGauge = useCallback(() => {
-    return (
-      <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
-        <div 
-          className="h-full bg-gradient-to-r from-yellow-500 to-orange-400 rounded-full transition-all duration-200 ease-out"
-          style={{ 
-            width: `${Math.min(gameState.enemyGauge, 100)}%`,
-            boxShadow: gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
-          }}
-        />
-      </div>
-    );
-  }, [gameState.enemyGauge]);
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
@@ -1120,11 +1106,10 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           >
             {/* 魔法名表示 - モンスターカード内に移動 */}
             <FantasyPIXIRenderer
-              width={Math.max(monsterAreaWidth, 1)}   // 0 を渡さない
+              width={Math.max(monsterAreaWidth, 1)}
               height={monsterAreaHeight}
               monsterIcon={currentEnemy.icon}
-    
-              enemyGauge={gameState.enemyGauge}
+              enemyGauge={0}
               onReady={handleFantasyPixiReady}
               onMonsterDefeated={handleMonsterDefeated}
               onShowMagicName={handleShowMagicName}


### PR DESCRIPTION
Improve Fantasy Mode game screen visuals and user experience by updating UI elements and adding new effects after Canvas 2D migration.

This PR addresses several design inconsistencies and missing features that arose from the migration from PIXI to Canvas 2D. Specifically, it removes the unnecessary enemy gauge in quiz mode, significantly enlarges rhythm game lanes and notes for better readability, and enhances monster interactions by removing their background/frame, increasing their size, and adding visual feedback for damage (bubble icon, floating text) and enemy attacks (monster enlargement, anger icon).

---
<a href="https://cursor.com/background-agent?bcId=bc-2573996f-41c1-46a9-8f53-021577dc5ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2573996f-41c1-46a9-8f53-021577dc5ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

