### PR TITLE
Refactor fantasy game screen visuals

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1239,6 +1239,16 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         </div>
                       )}
                       
+                      {/* 行動ゲージ (singleモードのみ、HPゲージの上) */}
+                      {stage.mode === 'single' && (
+                        <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden mb-1">
+                          <div
+                            className="h-full bg-gradient-to-r from-purple-500 to-purple-700"
+                            style={{ width: `${monster.gauge}%` }}
+                          />
+                        </div>
+                      )}
+                      
                       {/* HPゲージ */}
                       {(() => {
                         const isLandscape = window.innerWidth > window.innerHeight;
@@ -1260,7 +1270,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                             </div>
                           </div>
                         );
-                                             })()}
+                      })()}
                      </div>
                      );
                    })}

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -162,9 +162,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     return () => bgmManager.stop();
   }, [isReady, stage, settings.bgmVolume]);
   
-  // ★★★ 追加: 各モンスターのゲージDOM要素を保持するマップ ★★★
-  const gaugeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  
   // ノート入力のハンドリング用ref
   const handleNoteInputRef = useRef<(note: number, source?: 'mouse' | 'midi') => void>();
   
@@ -960,20 +957,6 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     return hearts;
   }, [heartFlash]);
   
-  // 敵のゲージ表示（黄色系）
-  const renderEnemyGauge = useCallback(() => {
-    return (
-      <div className="w-48 h-6 bg-gray-700 border-2 border-gray-600 rounded-full mt-2 overflow-hidden">
-        <div 
-          className="h-full bg-gradient-to-r from-yellow-500 to-orange-400 rounded-full transition-all duration-200 ease-out"
-          style={{ 
-            width: `${Math.min(gameState.enemyGauge, 100)}%`,
-            boxShadow: gameState.enemyGauge > 80 ? '0 0 10px rgba(245, 158, 11, 0.6)' : 'none'
-          }}
-        />
-      </div>
-    );
-  }, [gameState.enemyGauge]);
   
   // NEXTコード表示（コード進行モード用）
   const getNextChord = useCallback(() => {
@@ -1248,28 +1231,11 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                       {/* 魔法名表示 */}
                       {magicName && magicName.monsterId === monster.id && (
                         <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
-                          {/* ▼▼▼ 変更点 ▼▼▼ */}
                           <div className={`font-bold font-sans drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] opacity-75 text-sm ${
                             magicName.isSpecial ? 'text-yellow-300' : 'text-white'
                           }`}>
-                          {/* ▲▲▲ ここまで ▲▲▲ */}
                             {magicName.name}
                           </div>
-                        </div>
-                      )}
-                      
-                      {/* 行動ゲージ (singleモードのみ表示) */}
-                      {stage.mode === 'single' && (
-                        <div 
-                          ref={el => {
-                            if (el) gaugeRefs.current.set(monster.id, el);
-                          }}
-                          className="w-full h-2 bg-gray-700 border border-gray-600 rounded-full overflow-hidden relative mb-1"
-                        >
-                          <div
-                            className="h-full bg-gradient-to-r from-purple-500 to-purple-700 transition-all duration-100"
-                            style={{ width: `${monster.gauge}%` }}
-                          />
                         </div>
                       )}
                       

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -41,7 +41,6 @@ interface DamageTextEffect {
 interface SpecialAttackEffect {
   start: number;
   duration: number;
-  phase: 'flash' | 'text' | 'fadeout';
 }
 
 interface MonsterVisual {
@@ -59,12 +58,10 @@ interface MonsterVisual {
   showDamageIcon: boolean;
   damageIconUntil: number;
   damageText?: DamageTextEffect;
-  magicText?: {
-    value: string;
-    isSpecial: boolean;
-    until: number;
-  };
 }
+
+// 30fps = 約33ms間隔
+const FRAME_INTERVAL = 1000 / 30;
 
 export class FantasyPIXIInstance {
   private canvas: HTMLCanvasElement;
@@ -73,12 +70,12 @@ export class FantasyPIXIInstance {
   private height: number;
   private pixelRatio: number;
   private destroyed = false;
-  private renderHandle: number | ReturnType<typeof setTimeout> | null = null;
+  private renderHandle: number | null = null;
+  private lastFrameTime = 0;
   private monsters: MonsterVisual[] = [];
   private taikoMode = false;
   private taikoNotes: TaikoDisplayNote[] = [];
   private effects: ParticleEffect[] = [];
-  private damageTexts: DamageTextEffect[] = [];
   private specialAttackEffect: SpecialAttackEffect | null = null;
   private overlayText: { value: string; until: number } | null = null;
   private defaultMonsterIcon: string;
@@ -86,7 +83,6 @@ export class FantasyPIXIInstance {
   private imageCache = new Map<string, HTMLImageElement>();
   private loadingImages = new Set<string>();
   private onMonsterDefeated?: () => void;
-  private onShowMagicName?: (magicName: string, isSpecial: boolean, monsterId: string) => void;
   private angerIcon: HTMLImageElement | null = null;
   private attackIcon: HTMLImageElement | null = null;
 
@@ -95,33 +91,29 @@ export class FantasyPIXIInstance {
     width: number,
     height: number,
     onMonsterDefeated?: () => void,
-    onShowMagicName?: (magicName: string, isSpecial: boolean, monsterId: string) => void,
+    _onShowMagicName?: (magicName: string, isSpecial: boolean, monsterId: string) => void,
     imageTexturesRef?: React.MutableRefObject<Map<string, HTMLImageElement>>
   ) {
     this.canvas = canvas;
-    const context = canvas.getContext('2d');
+    const context = canvas.getContext('2d', { alpha: true });
     if (!context) {
       throw new Error('Canvas 2D context is not available');
     }
     this.ctx = context;
     this.width = width;
     this.height = height;
-    this.pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    this.pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio || 1, 2) : 1;
     this.defaultMonsterIcon = '';
     this.imageTexturesRef = imageTexturesRef;
     this.onMonsterDefeated = onMonsterDefeated;
-    this.onShowMagicName = onShowMagicName;
     this.configureCanvasSize(width, height);
     this.loadAssets();
     this.startLoop();
   }
 
   private loadAssets(): void {
-    // 怒りアイコンをロード
     this.angerIcon = new Image();
     this.angerIcon.src = `${import.meta.env.BASE_URL}data/anger.svg`;
-    
-    // 攻撃アイコン（音符吹き出し）をロード
     this.attackIcon = new Image();
     this.attackIcon.src = `${import.meta.env.BASE_URL}attack_icons/fukidashi_onpu_white.png`;
   }
@@ -156,11 +148,10 @@ export class FantasyPIXIInstance {
         flashUntil: existing?.flashUntil ?? 0,
         defeated: monster.currentHp <= 0,
         enraged: isEnraged,
-        enrageScale: existing?.enrageScale ?? 1,
+        enrageScale: existing?.enrageScale ?? (isEnraged ? 1.2 : 1),
         showDamageIcon: existing?.showDamageIcon ?? false,
         damageIconUntil: existing?.damageIconUntil ?? 0,
-        damageText: existing?.damageText,
-        magicText: existing?.magicText
+        damageText: existing?.damageText
       });
     });
     this.monsters = visuals;
@@ -195,43 +186,32 @@ export class FantasyPIXIInstance {
       x,
       y,
       start: performance.now(),
-      duration: success ? 300 : 400,
+      duration: 200,
       success
     });
   }
 
   triggerAttackSuccessOnMonster(
     monsterId: string,
-    chordName: string | undefined,
+    _chordName: string | undefined,
     isSpecial: boolean,
     damageDealt: number,
     defeated: boolean
   ): void {
     const visual = this.monsters.find((m) => m.id === monsterId);
     if (visual) {
-      visual.flashUntil = performance.now() + 250;
+      visual.flashUntil = performance.now() + 200;
       visual.showDamageIcon = true;
-      visual.damageIconUntil = performance.now() + 800;
+      visual.damageIconUntil = performance.now() + 600;
       
-      // ダメージテキスト追加
       visual.damageText = {
         x: visual.x,
         y: this.height * 0.25,
         value: damageDealt,
         start: performance.now(),
-        duration: 1200
+        duration: 800
       };
       
-      if (chordName) {
-        visual.magicText = {
-          value: chordName,
-          isSpecial,
-          until: performance.now() + 1500
-        };
-        this.onShowMagicName?.(chordName, isSpecial, monsterId);
-      }
-      
-      // 必殺技エフェクト
       if (isSpecial) {
         this.triggerSpecialAttackEffect();
       }
@@ -240,7 +220,7 @@ export class FantasyPIXIInstance {
         visual.defeated = true;
         setTimeout(() => {
           this.onMonsterDefeated?.();
-        }, 400);
+        }, 300);
       }
     }
   }
@@ -248,8 +228,7 @@ export class FantasyPIXIInstance {
   private triggerSpecialAttackEffect(): void {
     this.specialAttackEffect = {
       start: performance.now(),
-      duration: 2000,
-      phase: 'flash'
+      duration: 1500
     };
   }
 
@@ -260,18 +239,14 @@ export class FantasyPIXIInstance {
     }
     this.overlayText = {
       value: text,
-      until: performance.now() + 1800
+      until: performance.now() + 1500
     };
   }
 
   destroy(): void {
     this.destroyed = true;
     if (this.renderHandle !== null) {
-      if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function' && typeof this.renderHandle === 'number') {
-        window.cancelAnimationFrame(this.renderHandle);
-      } else {
-        clearTimeout(this.renderHandle as ReturnType<typeof setTimeout>);
-      }
+      cancelAnimationFrame(this.renderHandle);
     }
   }
 
@@ -284,35 +259,32 @@ export class FantasyPIXIInstance {
   }
 
   private startLoop(): void {
-    const raf =
-      typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
-        ? window.requestAnimationFrame.bind(window)
-        : (callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 1000 / 60);
-    this.renderHandle = raf(this.renderLoop);
+    this.renderHandle = requestAnimationFrame(this.renderLoop);
   }
 
-  private renderLoop = (): void => {
+  private renderLoop = (timestamp: number): void => {
     if (this.destroyed) return;
-    this.drawFrame();
-    this.startLoop();
+    
+    // 30fpsに制限
+    if (timestamp - this.lastFrameTime >= FRAME_INTERVAL) {
+      this.lastFrameTime = timestamp;
+      this.drawFrame();
+    }
+    
+    this.renderHandle = requestAnimationFrame(this.renderLoop);
   };
 
   private drawFrame(): void {
     const ctx = this.ctx;
-    ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    ctx.restore();
     ctx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
-    
-    // 背景は完全に透明（親要素の背景が見える）
     
     this.drawMonsters(ctx);
     if (this.taikoMode) {
       this.drawTaikoLane(ctx);
     }
     this.drawEffects(ctx);
-    this.drawDamageTexts(ctx);
     this.drawSpecialAttackEffect(ctx);
     this.drawOverlayText(ctx);
   }
@@ -340,50 +312,27 @@ export class FantasyPIXIInstance {
     }
     
     const now = performance.now();
-    const enragedTable = useEnemyStore.getState().enraged;
     
     this.monsters.forEach((monster) => {
       // スムーズな移動
-      monster.x += (monster.targetX - monster.x) * 0.15;
+      monster.x += (monster.targetX - monster.x) * 0.2;
       
-      // 怒り状態の更新
-      monster.enraged = enragedTable[monster.id] ?? false;
+      // 怒り時のスケールアニメーション（簡略化）
+      const targetScale = monster.enraged ? 1.2 : 1;
+      monster.enrageScale += (targetScale - monster.enrageScale) * 0.15;
       
-      // 怒り時のスケールアニメーション
-      const targetScale = monster.enraged ? 1.25 : 1;
-      monster.enrageScale += (targetScale - monster.enrageScale) * 0.1;
-      
-      // モンスターのサイズを大きく計算（画面高さの60%を使用）
-      const baseSize = Math.min(this.height * 0.6, this.width / (this.monsters.length + 1) * 0.9);
+      const baseSize = Math.min(this.height * 0.55, this.width / (this.monsters.length + 1) * 0.85);
       const monsterSize = baseSize * monster.enrageScale;
       const baseY = this.height * 0.45;
       
-      // フラッシュエフェクト（ダメージ時）
       const isFlashing = monster.flashUntil > now;
       
       ctx.save();
       ctx.translate(monster.x, baseY);
       
-      // 怒り時のパルスアニメーション
-      if (monster.enraged) {
-        const pulse = Math.sin(now * 0.008) * 0.03 + 1;
-        ctx.scale(pulse, pulse);
-      }
-      
-      // モンスター画像を描画（背景・枠なし）
+      // モンスター画像を描画
       if (monster.image && monster.image.complete) {
-        ctx.save();
-        
-        // フラッシュ時は黄色に着色
-        if (isFlashing) {
-          ctx.filter = 'brightness(1.5) sepia(0.5) saturate(2)';
-        }
-        
-        // 怒り時は赤みがかった色に
-        if (monster.enraged) {
-          ctx.filter = 'brightness(1.1) sepia(0.2) hue-rotate(-15deg)';
-        }
-        
+        // フラッシュ時は黄色オーバーレイ
         const imgSize = monsterSize;
         ctx.drawImage(
           monster.image,
@@ -392,16 +341,27 @@ export class FantasyPIXIInstance {
           imgSize,
           imgSize
         );
-        ctx.restore();
+        
+        // フラッシュ時は黄色の半透明オーバーレイ
+        if (isFlashing) {
+          ctx.fillStyle = 'rgba(255, 220, 0, 0.3)';
+          ctx.fillRect(-imgSize / 2, -imgSize / 2, imgSize, imgSize);
+        }
+        
+        // 怒り時は赤いオーバーレイ
+        if (monster.enraged) {
+          ctx.fillStyle = 'rgba(255, 80, 80, 0.2)';
+          ctx.fillRect(-imgSize / 2, -imgSize / 2, imgSize, imgSize);
+        }
       }
       
       // 怒りアイコン表示
       if (monster.enraged && this.angerIcon && this.angerIcon.complete) {
-        const iconSize = monsterSize * 0.3;
+        const iconSize = monsterSize * 0.25;
         ctx.drawImage(
           this.angerIcon,
-          monsterSize * 0.3,
-          -monsterSize * 0.4,
+          monsterSize * 0.25,
+          -monsterSize * 0.35,
           iconSize,
           iconSize
         );
@@ -409,12 +369,11 @@ export class FantasyPIXIInstance {
       
       // ダメージ時の吹き出しアイコン表示
       if (monster.showDamageIcon && monster.damageIconUntil > now && this.attackIcon && this.attackIcon.complete) {
-        const iconSize = monsterSize * 0.4;
-        const bobY = Math.sin(now * 0.01) * 3;
+        const iconSize = monsterSize * 0.35;
         ctx.drawImage(
           this.attackIcon,
-          monsterSize * 0.25,
-          -monsterSize * 0.55 + bobY,
+          monsterSize * 0.2,
+          -monsterSize * 0.45,
           iconSize,
           iconSize
         );
@@ -422,32 +381,24 @@ export class FantasyPIXIInstance {
       
       ctx.restore();
       
-      // ダメージテキスト描画（モンスターごと）
+      // ダメージテキスト描画
       if (monster.damageText) {
         const elapsed = now - monster.damageText.start;
         if (elapsed < monster.damageText.duration) {
           const progress = elapsed / monster.damageText.duration;
-          const yOffset = -progress * 60;
-          const alpha = 1 - Math.pow(progress, 2);
-          const scale = 1 + Math.sin(progress * Math.PI) * 0.3;
+          const yOffset = -progress * 50;
+          const alpha = 1 - progress;
           
           ctx.save();
-          ctx.translate(monster.x, baseY - monsterSize * 0.4 + yOffset);
-          ctx.scale(scale, scale);
           ctx.globalAlpha = alpha;
-          ctx.font = 'bold 36px "Inter", sans-serif';
+          ctx.font = 'bold 32px sans-serif';
           ctx.textAlign = 'center';
           ctx.textBaseline = 'middle';
-          
-          // 縁取り
-          ctx.strokeStyle = '#000000';
-          ctx.lineWidth = 4;
-          ctx.strokeText(String(monster.damageText.value), 0, 0);
-          
-          // テキスト（白）
-          ctx.fillStyle = '#ffffff';
-          ctx.fillText(String(monster.damageText.value), 0, 0);
-          
+          ctx.strokeStyle = '#000';
+          ctx.lineWidth = 3;
+          ctx.strokeText(String(monster.damageText.value), monster.x, baseY - monsterSize * 0.35 + yOffset);
+          ctx.fillStyle = '#fff';
+          ctx.fillText(String(monster.damageText.value), monster.x, baseY - monsterSize * 0.35 + yOffset);
           ctx.restore();
         } else {
           monster.damageText = undefined;
@@ -458,16 +409,15 @@ export class FantasyPIXIInstance {
 
   private drawTaikoLane(ctx: CanvasRenderingContext2D): void {
     const judgePos = this.getJudgeLinePosition();
-    // レーン高さを大きく
-    const laneHeight = 100;
+    const laneHeight = 90;
     
-    // レーン背景（半透明の暗い背景）
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    // レーン背景
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
     ctx.fillRect(0, judgePos.y - laneHeight / 2, this.width, laneHeight);
     
-    // 判定ライン（赤いライン）
+    // 判定ライン
     ctx.strokeStyle = '#ef4444';
-    ctx.lineWidth = 4;
+    ctx.lineWidth = 3;
     ctx.beginPath();
     ctx.moveTo(judgePos.x, judgePos.y - laneHeight / 2);
     ctx.lineTo(judgePos.x, judgePos.y + laneHeight / 2);
@@ -475,123 +425,53 @@ export class FantasyPIXIInstance {
     
     // 判定エリアの円
     ctx.strokeStyle = '#fbbf24';
-    ctx.lineWidth = 3;
+    ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.arc(judgePos.x, judgePos.y, 45, 0, Math.PI * 2);
+    ctx.arc(judgePos.x, judgePos.y, 40, 0, Math.PI * 2);
     ctx.stroke();
     
-    // ノーツを描画（大きく）
+    // ノーツを描画
+    ctx.font = 'bold 14px sans-serif';
     this.taikoNotes.forEach((note) => {
-      const radius = 35; // 大きなノーツ
+      const radius = 30;
       const isAhead = note.x >= judgePos.x;
       
-      // ノーツの円
+      // ノーツの円（単色塗り）
       ctx.beginPath();
       ctx.arc(note.x, judgePos.y, radius, 0, Math.PI * 2);
-      
-      // グラデーション塗りつぶし
-      const gradient = ctx.createRadialGradient(
-        note.x - radius * 0.3, judgePos.y - radius * 0.3, 0,
-        note.x, judgePos.y, radius
-      );
-      if (isAhead) {
-        gradient.addColorStop(0, '#fb923c');
-        gradient.addColorStop(1, '#ea580c');
-      } else {
-        gradient.addColorStop(0, '#64748b');
-        gradient.addColorStop(1, '#475569');
-      }
-      ctx.fillStyle = gradient;
+      ctx.fillStyle = isAhead ? '#f97316' : '#64748b';
       ctx.fill();
-      
-      // 縁取り
-      ctx.strokeStyle = isAhead ? '#ffffff' : '#94a3b8';
-      ctx.lineWidth = 3;
+      ctx.strokeStyle = isAhead ? '#fff' : '#94a3b8';
+      ctx.lineWidth = 2;
       ctx.stroke();
       
-      // コード名ラベル（上に表示）
-      ctx.save();
-      ctx.translate(note.x, judgePos.y - radius - 15);
-      
-      // ラベル背景
-      ctx.font = 'bold 16px "Inter", sans-serif';
-      const textWidth = ctx.measureText(note.chord).width;
-      const paddingX = 10;
-      const paddingY = 5;
-      
+      // コード名ラベル
       ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-      ctx.beginPath();
-      ctx.roundRect(-textWidth / 2 - paddingX, -12 - paddingY, textWidth + paddingX * 2, 24 + paddingY * 2, 6);
-      ctx.fill();
-      
-      // ラベルテキスト
-      ctx.fillStyle = '#ffffff';
+      const textWidth = ctx.measureText(note.chord).width;
+      ctx.fillRect(note.x - textWidth / 2 - 6, judgePos.y - radius - 28, textWidth + 12, 22);
+      ctx.fillStyle = '#fff';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(note.chord, 0, 0);
-      
-      ctx.restore();
+      ctx.fillText(note.chord, note.x, judgePos.y - radius - 17);
     });
   }
 
   private drawEffects(ctx: CanvasRenderingContext2D): void {
     const now = performance.now();
-    this.effects = this.effects.filter((effect) => now - effect.start < effect.duration);
+    this.effects = this.effects.filter((e) => now - e.start < e.duration);
+    
     this.effects.forEach((effect) => {
       const progress = (now - effect.start) / effect.duration;
       const alpha = 1 - progress;
-      const radius = 20 + progress * 40;
+      const radius = 15 + progress * 30;
       
       ctx.save();
       ctx.globalAlpha = alpha;
-      
-      // リング
       ctx.strokeStyle = effect.success ? '#22c55e' : '#ef4444';
-      ctx.lineWidth = 4;
+      ctx.lineWidth = 3;
       ctx.beginPath();
       ctx.arc(effect.x, effect.y, radius, 0, Math.PI * 2);
       ctx.stroke();
-      
-      // 内側の光
-      const innerGradient = ctx.createRadialGradient(effect.x, effect.y, 0, effect.x, effect.y, radius * 0.6);
-      innerGradient.addColorStop(0, effect.success ? 'rgba(34, 197, 94, 0.5)' : 'rgba(239, 68, 68, 0.5)');
-      innerGradient.addColorStop(1, 'transparent');
-      ctx.fillStyle = innerGradient;
-      ctx.beginPath();
-      ctx.arc(effect.x, effect.y, radius * 0.6, 0, Math.PI * 2);
-      ctx.fill();
-      
-      ctx.restore();
-    });
-  }
-
-  private drawDamageTexts(ctx: CanvasRenderingContext2D): void {
-    const now = performance.now();
-    this.damageTexts = this.damageTexts.filter((dt) => now - dt.start < dt.duration);
-    
-    this.damageTexts.forEach((dt) => {
-      const progress = (now - dt.start) / dt.duration;
-      const yOffset = -progress * 80;
-      const alpha = 1 - Math.pow(progress, 2);
-      const scale = 1 + Math.sin(progress * Math.PI) * 0.2;
-      
-      ctx.save();
-      ctx.translate(dt.x, dt.y + yOffset);
-      ctx.scale(scale, scale);
-      ctx.globalAlpha = alpha;
-      ctx.font = 'bold 42px "Inter", sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      
-      // 縁取り
-      ctx.strokeStyle = '#000000';
-      ctx.lineWidth = 5;
-      ctx.strokeText(String(dt.value), 0, 0);
-      
-      // テキスト
-      ctx.fillStyle = '#ffffff';
-      ctx.fillText(String(dt.value), 0, 0);
-      
       ctx.restore();
     });
   }
@@ -611,42 +491,24 @@ export class FantasyPIXIInstance {
     
     ctx.save();
     
-    if (progress < 0.15) {
-      // フラッシュフェーズ
-      const flashProgress = progress / 0.15;
-      ctx.fillStyle = `rgba(255, 255, 255, ${0.8 * (1 - flashProgress)})`;
+    if (progress < 0.1) {
+      // フラッシュ
+      ctx.fillStyle = `rgba(255, 255, 255, ${0.6 * (1 - progress / 0.1)})`;
       ctx.fillRect(0, 0, this.width, this.height);
     } else if (progress < 0.7) {
-      // テキスト表示フェーズ
-      const textProgress = (progress - 0.15) / 0.55;
-      const scale = 0.8 + Math.sin(textProgress * Math.PI) * 0.4;
-      const alpha = Math.min(1, textProgress * 3) * (1 - Math.max(0, (textProgress - 0.7) / 0.3));
+      // テキスト表示
+      const textProgress = (progress - 0.1) / 0.6;
+      const alpha = Math.min(1, textProgress * 2) * (1 - Math.max(0, (textProgress - 0.6) / 0.4));
       
-      ctx.translate(this.width / 2, this.height / 2);
-      ctx.scale(scale, scale);
       ctx.globalAlpha = alpha;
-      
-      ctx.font = 'bold 56px "Inter", sans-serif';
+      ctx.font = 'bold 48px sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      
-      // 金色のグラデーション
-      const gradient = ctx.createLinearGradient(-200, -30, 200, 30);
-      gradient.addColorStop(0, '#fbbf24');
-      gradient.addColorStop(0.5, '#fef08a');
-      gradient.addColorStop(1, '#fbbf24');
-      
-      // 縁取り
-      ctx.strokeStyle = '#000000';
-      ctx.lineWidth = 6;
-      ctx.strokeText('Swing! Swing! Swing!', 0, 0);
-      
-      ctx.fillStyle = gradient;
-      ctx.fillText('Swing! Swing! Swing!', 0, 0);
-    } else {
-      // フェードアウト
-      const fadeProgress = (progress - 0.7) / 0.3;
-      ctx.globalAlpha = 1 - fadeProgress;
+      ctx.strokeStyle = '#000';
+      ctx.lineWidth = 4;
+      ctx.strokeText('Swing! Swing! Swing!', this.width / 2, this.height / 2);
+      ctx.fillStyle = '#fbbf24';
+      ctx.fillText('Swing! Swing! Swing!', this.width / 2, this.height / 2);
     }
     
     ctx.restore();
@@ -658,13 +520,13 @@ export class FantasyPIXIInstance {
       this.overlayText = null;
       return;
     }
-    ctx.font = 'bold 28px "Inter", sans-serif';
-    ctx.fillStyle = '#f8fafc';
+    ctx.font = 'bold 24px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.strokeStyle = '#000000';
-    ctx.lineWidth = 3;
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 2;
     ctx.strokeText(this.overlayText.value, this.width / 2, this.height * 0.08);
+    ctx.fillStyle = '#f8fafc';
     ctx.fillText(this.overlayText.value, this.width / 2, this.height * 0.08);
   }
 
@@ -689,7 +551,6 @@ export class FantasyPIXIInstance {
     };
     img.onerror = () => {
       this.loadingImages.delete(icon);
-      // WebPでリトライ
       const webpImg = new Image();
       webpImg.decoding = 'async';
       webpImg.onload = () => {

--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import type { MonsterState } from './FantasyGameEngine';
 import { cn } from '@/utils/cn';
+import { useEnemyStore } from '@/stores/enemyStore';
 
 interface FantasyPIXIRendererProps {
   width: number;
@@ -29,33 +30,41 @@ interface ParticleEffect {
   success: boolean;
 }
 
+interface DamageTextEffect {
+  x: number;
+  y: number;
+  value: number;
+  start: number;
+  duration: number;
+}
+
+interface SpecialAttackEffect {
+  start: number;
+  duration: number;
+  phase: 'flash' | 'text' | 'fadeout';
+}
+
 interface MonsterVisual {
   id: string;
   icon: string;
   image: HTMLImageElement | null;
   hpRatio: number;
+  gauge: number;
   targetX: number;
   x: number;
   flashUntil: number;
   defeated: boolean;
+  enraged: boolean;
+  enrageScale: number;
+  showDamageIcon: boolean;
+  damageIconUntil: number;
+  damageText?: DamageTextEffect;
   magicText?: {
     value: string;
     isSpecial: boolean;
     until: number;
   };
 }
-
-const BACKGROUND_TOP = '#0f172a';
-const BACKGROUND_BOTTOM = '#020617';
-const CARD_BG = 'rgba(15,23,42,0.8)';
-const HP_BAR_BG = 'rgba(15,23,42,0.6)';
-const HP_BAR_FILL = '#ef4444';
-const ENEMY_GAUGE_BG = 'rgba(15,23,42,0.4)';
-const ENEMY_GAUGE_FILL = '#eab308';
-const OVERLAY_TEXT_COLOR = '#f8fafc';
-const TAiko_LANE_COLOR = 'rgba(255,255,255,0.2)';
-const NOTE_FILL = '#38bdf8';
-const NOTE_PREVIEW_FILL = '#64748b';
 
 export class FantasyPIXIInstance {
   private canvas: HTMLCanvasElement;
@@ -65,11 +74,12 @@ export class FantasyPIXIInstance {
   private pixelRatio: number;
   private destroyed = false;
   private renderHandle: number | ReturnType<typeof setTimeout> | null = null;
-  private enemyGauge = 0;
   private monsters: MonsterVisual[] = [];
   private taikoMode = false;
   private taikoNotes: TaikoDisplayNote[] = [];
   private effects: ParticleEffect[] = [];
+  private damageTexts: DamageTextEffect[] = [];
+  private specialAttackEffect: SpecialAttackEffect | null = null;
   private overlayText: { value: string; until: number } | null = null;
   private defaultMonsterIcon: string;
   private imageTexturesRef?: React.MutableRefObject<Map<string, HTMLImageElement>>;
@@ -77,6 +87,8 @@ export class FantasyPIXIInstance {
   private loadingImages = new Set<string>();
   private onMonsterDefeated?: () => void;
   private onShowMagicName?: (magicName: string, isSpecial: boolean, monsterId: string) => void;
+  private angerIcon: HTMLImageElement | null = null;
+  private attackIcon: HTMLImageElement | null = null;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -100,7 +112,18 @@ export class FantasyPIXIInstance {
     this.onMonsterDefeated = onMonsterDefeated;
     this.onShowMagicName = onShowMagicName;
     this.configureCanvasSize(width, height);
+    this.loadAssets();
     this.startLoop();
+  }
+
+  private loadAssets(): void {
+    // 怒りアイコンをロード
+    this.angerIcon = new Image();
+    this.angerIcon.src = `${import.meta.env.BASE_URL}data/anger.svg`;
+    
+    // 攻撃アイコン（音符吹き出し）をロード
+    this.attackIcon = new Image();
+    this.attackIcon.src = `${import.meta.env.BASE_URL}attack_icons/fukidashi_onpu_white.png`;
   }
 
   resize(width: number, height: number): void {
@@ -113,28 +136,34 @@ export class FantasyPIXIInstance {
     const sorted = [...monsters].sort((a, b) => a.position.localeCompare(b.position));
     const count = sorted.length || 1;
     const spacing = this.width / (count + 1);
+    const enragedTable = useEnemyStore.getState().enraged;
+    
     const visuals: MonsterVisual[] = [];
     sorted.forEach((monster, index) => {
       const existing = this.monsters.find((m) => m.id === monster.id);
       const image = this.ensureImage(monster.icon);
       const targetX = spacing * (index + 1);
+      const isEnraged = enragedTable[monster.id] ?? false;
+      
       visuals.push({
         id: monster.id,
         icon: monster.icon,
         image,
         hpRatio: monster.currentHp / monster.maxHp,
+        gauge: monster.gauge ?? 0,
         targetX,
         x: existing ? existing.x : targetX,
         flashUntil: existing?.flashUntil ?? 0,
         defeated: monster.currentHp <= 0,
+        enraged: isEnraged,
+        enrageScale: existing?.enrageScale ?? 1,
+        showDamageIcon: existing?.showDamageIcon ?? false,
+        damageIconUntil: existing?.damageIconUntil ?? 0,
+        damageText: existing?.damageText,
         magicText: existing?.magicText
       });
     });
     this.monsters = visuals;
-  }
-
-  setEnemyGauge(value: number): void {
-    this.enemyGauge = Math.min(100, Math.max(0, value));
   }
 
   setDefaultMonsterIcon(icon: string): void {
@@ -156,8 +185,8 @@ export class FantasyPIXIInstance {
 
   getJudgeLinePosition(): { x: number; y: number } {
     return {
-      x: this.width * 0.25,
-      y: this.height - this.height * 0.25
+      x: this.width * 0.15,
+      y: this.height * 0.75
     };
   }
 
@@ -166,15 +195,33 @@ export class FantasyPIXIInstance {
       x,
       y,
       start: performance.now(),
-      duration: success ? 250 : 400,
+      duration: success ? 300 : 400,
       success
     });
   }
 
-  triggerAttackSuccessOnMonster(monsterId: string, chordName: string | undefined, isSpecial: boolean, _damageDealt: number, defeated: boolean): void {
+  triggerAttackSuccessOnMonster(
+    monsterId: string,
+    chordName: string | undefined,
+    isSpecial: boolean,
+    damageDealt: number,
+    defeated: boolean
+  ): void {
     const visual = this.monsters.find((m) => m.id === monsterId);
     if (visual) {
-      visual.flashUntil = performance.now() + 220;
+      visual.flashUntil = performance.now() + 250;
+      visual.showDamageIcon = true;
+      visual.damageIconUntil = performance.now() + 800;
+      
+      // ダメージテキスト追加
+      visual.damageText = {
+        x: visual.x,
+        y: this.height * 0.25,
+        value: damageDealt,
+        start: performance.now(),
+        duration: 1200
+      };
+      
       if (chordName) {
         visual.magicText = {
           value: chordName,
@@ -183,6 +230,12 @@ export class FantasyPIXIInstance {
         };
         this.onShowMagicName?.(chordName, isSpecial, monsterId);
       }
+      
+      // 必殺技エフェクト
+      if (isSpecial) {
+        this.triggerSpecialAttackEffect();
+      }
+      
       if (defeated && !visual.defeated) {
         visual.defeated = true;
         setTimeout(() => {
@@ -190,6 +243,14 @@ export class FantasyPIXIInstance {
         }, 400);
       }
     }
+  }
+
+  private triggerSpecialAttackEffect(): void {
+    this.specialAttackEffect = {
+      start: performance.now(),
+      duration: 2000,
+      phase: 'flash'
+    };
   }
 
   updateOverlayText(text: string | null): void {
@@ -243,38 +304,17 @@ export class FantasyPIXIInstance {
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     ctx.restore();
     ctx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
-    this.drawBackground(ctx);
-    this.drawEnemyGauge(ctx);
+    
+    // 背景は完全に透明（親要素の背景が見える）
+    
     this.drawMonsters(ctx);
     if (this.taikoMode) {
       this.drawTaikoLane(ctx);
     }
     this.drawEffects(ctx);
+    this.drawDamageTexts(ctx);
+    this.drawSpecialAttackEffect(ctx);
     this.drawOverlayText(ctx);
-  }
-
-  private drawBackground(ctx: CanvasRenderingContext2D): void {
-    const gradient = ctx.createLinearGradient(0, 0, 0, this.height);
-    gradient.addColorStop(0, BACKGROUND_TOP);
-    gradient.addColorStop(1, BACKGROUND_BOTTOM);
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, this.width, this.height);
-  }
-
-  private drawEnemyGauge(ctx: CanvasRenderingContext2D): void {
-    const barWidth = this.width * 0.8;
-    const barHeight = 18;
-    const x = (this.width - barWidth) / 2;
-    const y = 20;
-    ctx.fillStyle = ENEMY_GAUGE_BG;
-    ctx.fillRect(x, y, barWidth, barHeight);
-    ctx.fillStyle = ENEMY_GAUGE_FILL;
-    ctx.fillRect(x, y, (barWidth * this.enemyGauge) / 100, barHeight);
-    ctx.font = '12px "Inter", sans-serif';
-    ctx.fillStyle = '#0f172a';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(`Enemy Gauge ${Math.round(this.enemyGauge)}%`, x + barWidth / 2, y + barHeight / 2);
   }
 
   private drawMonsters(ctx: CanvasRenderingContext2D): void {
@@ -286,75 +326,211 @@ export class FantasyPIXIInstance {
           icon: this.defaultMonsterIcon,
           image: this.imageCache.get(this.defaultMonsterIcon) ?? null,
           hpRatio: 1,
+          gauge: 0,
           targetX: this.width / 2,
           x: this.width / 2,
           flashUntil: 0,
-          defeated: false
+          defeated: false,
+          enraged: false,
+          enrageScale: 1,
+          showDamageIcon: false,
+          damageIconUntil: 0
         }
       ];
     }
+    
     const now = performance.now();
+    const enragedTable = useEnemyStore.getState().enraged;
+    
     this.monsters.forEach((monster) => {
-      monster.x += (monster.targetX - monster.x) * 0.1;
-      const cardWidth = Math.min(180, this.width / Math.max(3, this.monsters.length + 1));
-      const cardHeight = cardWidth * 0.8;
-      const baseY = this.height * 0.35;
+      // スムーズな移動
+      monster.x += (monster.targetX - monster.x) * 0.15;
+      
+      // 怒り状態の更新
+      monster.enraged = enragedTable[monster.id] ?? false;
+      
+      // 怒り時のスケールアニメーション
+      const targetScale = monster.enraged ? 1.25 : 1;
+      monster.enrageScale += (targetScale - monster.enrageScale) * 0.1;
+      
+      // モンスターのサイズを大きく計算（画面高さの60%を使用）
+      const baseSize = Math.min(this.height * 0.6, this.width / (this.monsters.length + 1) * 0.9);
+      const monsterSize = baseSize * monster.enrageScale;
+      const baseY = this.height * 0.45;
+      
+      // フラッシュエフェクト（ダメージ時）
+      const isFlashing = monster.flashUntil > now;
+      
       ctx.save();
-      ctx.translate(monster.x - cardWidth / 2, baseY);
-      ctx.fillStyle = CARD_BG;
-      ctx.fillRect(0, 0, cardWidth, cardHeight);
-      ctx.strokeStyle = monster.flashUntil > now ? '#fde047' : 'rgba(248,250,252,0.2)';
-      ctx.lineWidth = 2;
-      ctx.strokeRect(0, 0, cardWidth, cardHeight);
-      if (monster.image) {
-        const padding = 12;
-        ctx.drawImage(monster.image, padding, padding, cardWidth - padding * 2, cardHeight - padding * 2);
-      } else {
-        ctx.fillStyle = 'rgba(248,250,252,0.1)';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.font = '12px "Inter", sans-serif';
-        ctx.fillText('Loading...', cardWidth / 2, cardHeight / 2);
+      ctx.translate(monster.x, baseY);
+      
+      // 怒り時のパルスアニメーション
+      if (monster.enraged) {
+        const pulse = Math.sin(now * 0.008) * 0.03 + 1;
+        ctx.scale(pulse, pulse);
       }
-      // HP
-      ctx.fillStyle = HP_BAR_BG;
-      ctx.fillRect(0, cardHeight + 8, cardWidth, 10);
-      ctx.fillStyle = HP_BAR_FILL;
-      ctx.fillRect(0, cardHeight + 8, cardWidth * monster.hpRatio, 10);
-      if (monster.magicText && monster.magicText.until > now) {
-        ctx.font = monster.magicText.isSpecial ? 'bold 16px "Inter", sans-serif' : '13px "Inter", sans-serif';
-        ctx.fillStyle = monster.magicText.isSpecial ? '#fbbf24' : '#f1f5f9';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'bottom';
-        ctx.fillText(monster.magicText.value, cardWidth / 2, -6);
+      
+      // モンスター画像を描画（背景・枠なし）
+      if (monster.image && monster.image.complete) {
+        ctx.save();
+        
+        // フラッシュ時は黄色に着色
+        if (isFlashing) {
+          ctx.filter = 'brightness(1.5) sepia(0.5) saturate(2)';
+        }
+        
+        // 怒り時は赤みがかった色に
+        if (monster.enraged) {
+          ctx.filter = 'brightness(1.1) sepia(0.2) hue-rotate(-15deg)';
+        }
+        
+        const imgSize = monsterSize;
+        ctx.drawImage(
+          monster.image,
+          -imgSize / 2,
+          -imgSize / 2,
+          imgSize,
+          imgSize
+        );
+        ctx.restore();
       }
+      
+      // 怒りアイコン表示
+      if (monster.enraged && this.angerIcon && this.angerIcon.complete) {
+        const iconSize = monsterSize * 0.3;
+        ctx.drawImage(
+          this.angerIcon,
+          monsterSize * 0.3,
+          -monsterSize * 0.4,
+          iconSize,
+          iconSize
+        );
+      }
+      
+      // ダメージ時の吹き出しアイコン表示
+      if (monster.showDamageIcon && monster.damageIconUntil > now && this.attackIcon && this.attackIcon.complete) {
+        const iconSize = monsterSize * 0.4;
+        const bobY = Math.sin(now * 0.01) * 3;
+        ctx.drawImage(
+          this.attackIcon,
+          monsterSize * 0.25,
+          -monsterSize * 0.55 + bobY,
+          iconSize,
+          iconSize
+        );
+      }
+      
       ctx.restore();
+      
+      // ダメージテキスト描画（モンスターごと）
+      if (monster.damageText) {
+        const elapsed = now - monster.damageText.start;
+        if (elapsed < monster.damageText.duration) {
+          const progress = elapsed / monster.damageText.duration;
+          const yOffset = -progress * 60;
+          const alpha = 1 - Math.pow(progress, 2);
+          const scale = 1 + Math.sin(progress * Math.PI) * 0.3;
+          
+          ctx.save();
+          ctx.translate(monster.x, baseY - monsterSize * 0.4 + yOffset);
+          ctx.scale(scale, scale);
+          ctx.globalAlpha = alpha;
+          ctx.font = 'bold 36px "Inter", sans-serif';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          
+          // 縁取り
+          ctx.strokeStyle = '#000000';
+          ctx.lineWidth = 4;
+          ctx.strokeText(String(monster.damageText.value), 0, 0);
+          
+          // テキスト（白）
+          ctx.fillStyle = '#ffffff';
+          ctx.fillText(String(monster.damageText.value), 0, 0);
+          
+          ctx.restore();
+        } else {
+          monster.damageText = undefined;
+        }
+      }
     });
   }
 
   private drawTaikoLane(ctx: CanvasRenderingContext2D): void {
     const judgePos = this.getJudgeLinePosition();
-    const laneHeight = 60;
-    ctx.fillStyle = TAiko_LANE_COLOR;
+    // レーン高さを大きく
+    const laneHeight = 100;
+    
+    // レーン背景（半透明の暗い背景）
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     ctx.fillRect(0, judgePos.y - laneHeight / 2, this.width, laneHeight);
-    ctx.strokeStyle = '#f87171';
-    ctx.lineWidth = 2;
+    
+    // 判定ライン（赤いライン）
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = 4;
     ctx.beginPath();
     ctx.moveTo(judgePos.x, judgePos.y - laneHeight / 2);
     ctx.lineTo(judgePos.x, judgePos.y + laneHeight / 2);
     ctx.stroke();
+    
+    // 判定エリアの円
+    ctx.strokeStyle = '#fbbf24';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.arc(judgePos.x, judgePos.y, 45, 0, Math.PI * 2);
+    ctx.stroke();
+    
+    // ノーツを描画（大きく）
     this.taikoNotes.forEach((note) => {
-      const radius = 14;
+      const radius = 35; // 大きなノーツ
       const isAhead = note.x >= judgePos.x;
-      ctx.fillStyle = isAhead ? NOTE_FILL : NOTE_PREVIEW_FILL;
+      
+      // ノーツの円
       ctx.beginPath();
       ctx.arc(note.x, judgePos.y, radius, 0, Math.PI * 2);
+      
+      // グラデーション塗りつぶし
+      const gradient = ctx.createRadialGradient(
+        note.x - radius * 0.3, judgePos.y - radius * 0.3, 0,
+        note.x, judgePos.y, radius
+      );
+      if (isAhead) {
+        gradient.addColorStop(0, '#fb923c');
+        gradient.addColorStop(1, '#ea580c');
+      } else {
+        gradient.addColorStop(0, '#64748b');
+        gradient.addColorStop(1, '#475569');
+      }
+      ctx.fillStyle = gradient;
       ctx.fill();
-      ctx.font = '10px "Inter", sans-serif';
-      ctx.fillStyle = '#0f172a';
+      
+      // 縁取り
+      ctx.strokeStyle = isAhead ? '#ffffff' : '#94a3b8';
+      ctx.lineWidth = 3;
+      ctx.stroke();
+      
+      // コード名ラベル（上に表示）
+      ctx.save();
+      ctx.translate(note.x, judgePos.y - radius - 15);
+      
+      // ラベル背景
+      ctx.font = 'bold 16px "Inter", sans-serif';
+      const textWidth = ctx.measureText(note.chord).width;
+      const paddingX = 10;
+      const paddingY = 5;
+      
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+      ctx.beginPath();
+      ctx.roundRect(-textWidth / 2 - paddingX, -12 - paddingY, textWidth + paddingX * 2, 24 + paddingY * 2, 6);
+      ctx.fill();
+      
+      // ラベルテキスト
+      ctx.fillStyle = '#ffffff';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(note.chord, note.x, judgePos.y);
+      ctx.fillText(note.chord, 0, 0);
+      
+      ctx.restore();
     });
   }
 
@@ -364,15 +540,116 @@ export class FantasyPIXIInstance {
     this.effects.forEach((effect) => {
       const progress = (now - effect.start) / effect.duration;
       const alpha = 1 - progress;
-      const radius = 10 + progress * 25;
-      ctx.strokeStyle = effect.success ? '#4ade80' : '#ef4444';
+      const radius = 20 + progress * 40;
+      
+      ctx.save();
       ctx.globalAlpha = alpha;
-      ctx.lineWidth = 3;
+      
+      // リング
+      ctx.strokeStyle = effect.success ? '#22c55e' : '#ef4444';
+      ctx.lineWidth = 4;
       ctx.beginPath();
       ctx.arc(effect.x, effect.y, radius, 0, Math.PI * 2);
       ctx.stroke();
-      ctx.globalAlpha = 1;
+      
+      // 内側の光
+      const innerGradient = ctx.createRadialGradient(effect.x, effect.y, 0, effect.x, effect.y, radius * 0.6);
+      innerGradient.addColorStop(0, effect.success ? 'rgba(34, 197, 94, 0.5)' : 'rgba(239, 68, 68, 0.5)');
+      innerGradient.addColorStop(1, 'transparent');
+      ctx.fillStyle = innerGradient;
+      ctx.beginPath();
+      ctx.arc(effect.x, effect.y, radius * 0.6, 0, Math.PI * 2);
+      ctx.fill();
+      
+      ctx.restore();
     });
+  }
+
+  private drawDamageTexts(ctx: CanvasRenderingContext2D): void {
+    const now = performance.now();
+    this.damageTexts = this.damageTexts.filter((dt) => now - dt.start < dt.duration);
+    
+    this.damageTexts.forEach((dt) => {
+      const progress = (now - dt.start) / dt.duration;
+      const yOffset = -progress * 80;
+      const alpha = 1 - Math.pow(progress, 2);
+      const scale = 1 + Math.sin(progress * Math.PI) * 0.2;
+      
+      ctx.save();
+      ctx.translate(dt.x, dt.y + yOffset);
+      ctx.scale(scale, scale);
+      ctx.globalAlpha = alpha;
+      ctx.font = 'bold 42px "Inter", sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      
+      // 縁取り
+      ctx.strokeStyle = '#000000';
+      ctx.lineWidth = 5;
+      ctx.strokeText(String(dt.value), 0, 0);
+      
+      // テキスト
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText(String(dt.value), 0, 0);
+      
+      ctx.restore();
+    });
+  }
+
+  private drawSpecialAttackEffect(ctx: CanvasRenderingContext2D): void {
+    if (!this.specialAttackEffect) return;
+    
+    const now = performance.now();
+    const elapsed = now - this.specialAttackEffect.start;
+    
+    if (elapsed > this.specialAttackEffect.duration) {
+      this.specialAttackEffect = null;
+      return;
+    }
+    
+    const progress = elapsed / this.specialAttackEffect.duration;
+    
+    ctx.save();
+    
+    if (progress < 0.15) {
+      // フラッシュフェーズ
+      const flashProgress = progress / 0.15;
+      ctx.fillStyle = `rgba(255, 255, 255, ${0.8 * (1 - flashProgress)})`;
+      ctx.fillRect(0, 0, this.width, this.height);
+    } else if (progress < 0.7) {
+      // テキスト表示フェーズ
+      const textProgress = (progress - 0.15) / 0.55;
+      const scale = 0.8 + Math.sin(textProgress * Math.PI) * 0.4;
+      const alpha = Math.min(1, textProgress * 3) * (1 - Math.max(0, (textProgress - 0.7) / 0.3));
+      
+      ctx.translate(this.width / 2, this.height / 2);
+      ctx.scale(scale, scale);
+      ctx.globalAlpha = alpha;
+      
+      ctx.font = 'bold 56px "Inter", sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      
+      // 金色のグラデーション
+      const gradient = ctx.createLinearGradient(-200, -30, 200, 30);
+      gradient.addColorStop(0, '#fbbf24');
+      gradient.addColorStop(0.5, '#fef08a');
+      gradient.addColorStop(1, '#fbbf24');
+      
+      // 縁取り
+      ctx.strokeStyle = '#000000';
+      ctx.lineWidth = 6;
+      ctx.strokeText('Swing! Swing! Swing!', 0, 0);
+      
+      ctx.fillStyle = gradient;
+      ctx.fillText('Swing! Swing! Swing!', 0, 0);
+    } else {
+      // フェードアウト
+      const fadeProgress = (progress - 0.7) / 0.3;
+      ctx.globalAlpha = 1 - fadeProgress;
+    }
+    
+    ctx.restore();
   }
 
   private drawOverlayText(ctx: CanvasRenderingContext2D): void {
@@ -381,11 +658,14 @@ export class FantasyPIXIInstance {
       this.overlayText = null;
       return;
     }
-    ctx.font = 'bold 32px "Inter", sans-serif';
-    ctx.fillStyle = OVERLAY_TEXT_COLOR;
+    ctx.font = 'bold 28px "Inter", sans-serif';
+    ctx.fillStyle = '#f8fafc';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(this.overlayText.value, this.width / 2, this.height * 0.1);
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = 3;
+    ctx.strokeText(this.overlayText.value, this.width / 2, this.height * 0.08);
+    ctx.fillText(this.overlayText.value, this.width / 2, this.height * 0.08);
   }
 
   private ensureImage(icon: string): HTMLImageElement | null {
@@ -409,6 +689,13 @@ export class FantasyPIXIInstance {
     };
     img.onerror = () => {
       this.loadingImages.delete(icon);
+      // WebPでリトライ
+      const webpImg = new Image();
+      webpImg.decoding = 'async';
+      webpImg.onload = () => {
+        this.imageCache.set(icon, webpImg);
+      };
+      webpImg.src = `${import.meta.env.BASE_URL}monster_icons/${icon}.webp`;
     };
     img.src = `${import.meta.env.BASE_URL}monster_icons/${icon}.png`;
     return null;
@@ -419,7 +706,6 @@ export const FantasyPIXIRenderer: React.FC<FantasyPIXIRendererProps> = ({
   width,
   height,
   monsterIcon,
-  enemyGauge,
   onReady,
   onMonsterDefeated,
   onShowMagicName,
@@ -430,29 +716,29 @@ export const FantasyPIXIRenderer: React.FC<FantasyPIXIRendererProps> = ({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<FantasyPIXIInstance | null>(null);
 
-    useEffect(() => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const renderer = new FantasyPIXIInstance(
-        canvas,
-        width,
-        height,
-        onMonsterDefeated,
-        onShowMagicName,
-        imageTexturesRef
-      );
-      rendererRef.current = renderer;
-      renderer.setDefaultMonsterIcon(monsterIcon);
-      renderer.setEnemyGauge(enemyGauge);
-      if (activeMonsters) {
-        renderer.setActiveMonsters(activeMonsters);
-      }
-      onReady?.(renderer);
-      return () => {
-        renderer.destroy();
-        rendererRef.current = null;
-      };
-    }, [onReady, onMonsterDefeated, onShowMagicName, imageTexturesRef]);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const renderer = new FantasyPIXIInstance(
+      canvas,
+      width,
+      height,
+      onMonsterDefeated,
+      onShowMagicName,
+      imageTexturesRef
+    );
+    rendererRef.current = renderer;
+    renderer.setDefaultMonsterIcon(monsterIcon);
+    if (activeMonsters) {
+      renderer.setActiveMonsters(activeMonsters);
+    }
+    onReady?.(renderer);
+    return () => {
+      renderer.destroy();
+      rendererRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onReady, onMonsterDefeated, onShowMagicName, imageTexturesRef]);
 
   useEffect(() => {
     rendererRef.current?.resize(width, height);
@@ -461,10 +747,6 @@ export const FantasyPIXIRenderer: React.FC<FantasyPIXIRendererProps> = ({
   useEffect(() => {
     rendererRef.current?.setDefaultMonsterIcon(monsterIcon);
   }, [monsterIcon]);
-
-  useEffect(() => {
-    rendererRef.current?.setEnemyGauge(enemyGauge);
-  }, [enemyGauge]);
 
   useEffect(() => {
     if (activeMonsters) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance the fantasy game screen visuals by improving monster display, adding attack feedback, and refining rhythm game elements to create a more engaging experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses several visual issues in the fantasy game mode, including removing unnecessary UI elements (enemy gauge, monster card backgrounds/borders), increasing the size and clarity of rhythm game lanes and notes, making monsters more prominent, and adding dynamic feedback for player attacks (damage text, attack icons) and enemy actions (enraged state with scaling and anger icon), as well as a special attack cut-in effect. These changes aim to make the game feel more polished and intuitive.

---
<a href="https://cursor.com/background-agent?bcId=bc-4375e843-91d4-475e-9353-00091ec44caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4375e843-91d4-475e-9353-00091ec44caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

