### PR TITLE
Daily challenge performance

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -392,7 +392,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     onGameComplete: handleGameCompleteCallback,
     onEnemyAttack: handleEnemyAttack,
     displayOpts: { lang: 'en', simple: false }, // コードネーム表示は常に英語、簡易表記OFF
-    isReady
+    isReady,
+    // デイリーチャレンジは「倒しても終了しない」（終了条件はタイムリミットで制御）
+    endlessChallenge: isDailyChallenge && playMode === 'challenge'
   });
 
   // ===== 開始後のみ重い初期化を行う（デイリーチャレンジ初期表示を軽くする） =====


### PR DESCRIPTION
Fix daily challenge auto-start, enable infinite timer for practice mode, and improve daily challenge performance.

The daily challenge was automatically starting due to an `autoStart` prop, and its heavy initial load stemmed from `enemyCount=9999` causing excessive monster preloading and premature MIDI/audio system initialization. Practice mode also required an infinite timer. This PR addresses these by removing `autoStart`, optimizing enemy setup, delaying heavy initializations, and adjusting the timer logic for practice mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-624f51bc-a8cd-4c00-b7dc-48a29550a927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-624f51bc-a8cd-4c00-b7dc-48a29550a927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

