### PR TITLE
Fantasy mode practice issues

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -1000,13 +1000,17 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   }, [pixiRenderer, effectiveShowGuide, gameState.simultaneousMonsterCount, stage.mode]);
 
   // 問題が変わったタイミングでハイライトを確実にリセット
+  // progressionモードではcurrentNoteIndexの変更でコードが変わるため、明示的にchordIdも追跡
+  const resetTargetChordId = gameState.activeMonsters?.[0]?.chordTarget?.id || gameState.currentChordTarget?.id;
   useEffect(() => {
     if (!pixiRenderer) return;
     // progression/single 共通：押下中のオレンジは保持。ガイドのみクリア。
     (pixiRenderer as any).setGuideHighlightsByMidiNotes?.([]);
-  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex]);
+  }, [pixiRenderer, gameState.currentChordTarget, gameState.currentNoteIndex, resetTargetChordId]);
 
   // ガイド用ハイライト更新（showGuideが有効かつ同時出現数=1のときのみ）
+  // 依存配列にchordTarget.idを含めることで、コード変更時に確実に更新される
+  const currentTargetChordId = gameState.activeMonsters?.[0]?.chordTarget?.id || gameState.currentChordTarget?.id;
   useEffect(() => {
     if (!pixiRenderer) return;
     const canGuide = effectiveShowGuide && gameState.simultaneousMonsterCount === 1;
@@ -1026,7 +1030,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     }
     // 差分適用のみ（オレンジは残る）
     setGuideMidi(chord.notes as number[]);
-  }, [pixiRenderer, effectiveShowGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget, gameState.currentNoteIndex]);
+  }, [pixiRenderer, effectiveShowGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget, gameState.currentNoteIndex, currentTargetChordId]);
 
   // 正解済み鍵盤のハイライト更新（Singleモードのみ、赤色で保持）
   useEffect(() => {

--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -933,9 +933,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
 
           // 直前に消化したノーツはプレビューで復活させない
           if (i === lastCompletedIndex) continue;
-          // 現在判定中のノーツは次ループ分としては表示しない
-          if (i === gameState.currentNoteIndex) continue;
-          // すでに通常ノーツで表示しているものは重複させない
+          // すでに通常ノーツで表示しているものは重複させない（currentNoteIndexのスキップは不要）
           if (displayedBaseIds.has(note.id)) continue;
 
           const virtualHitTime = note.hitTime + loopDuration;
@@ -1028,7 +1026,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     }
     // 差分適用のみ（オレンジは残る）
     setGuideMidi(chord.notes as number[]);
-  }, [pixiRenderer, effectiveShowGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget]);
+  }, [pixiRenderer, effectiveShowGuide, gameState.simultaneousMonsterCount, gameState.activeMonsters, gameState.currentChordTarget, gameState.currentNoteIndex]);
 
   // 正解済み鍵盤のハイライト更新（Singleモードのみ、赤色で保持）
   useEffect(() => {


### PR DESCRIPTION
Fixes guide not updating in progression modes and enables pre-display of loop destination notes in Fantasy mode practice.

---
<a href="https://cursor.com/background-agent?bcId=bc-618c7744-5576-419e-8066-72fd47f260ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-618c7744-5576-419e-8066-72fd47f260ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

