### PR TITLE
Profile table admin deletion

### DIFF
--- a/supabase/migrations/20251220090000_fix_fantasy_bgm_assets_on_delete.sql
+++ b/supabase/migrations/20251220090000_fix_fantasy_bgm_assets_on_delete.sql
@@ -1,18 +1,29 @@
--- fantasy_bgm_assets テーブルの外部キー制約を ON DELETE SET NULL に変更
--- これにより、プロファイル削除時にBGMアセットは残り、created_by がNULLになる
+-- プロファイル削除時の外部キー制約を修正
+-- ON DELETE SET NULL が正しく動作するよう NOT NULL 制約を削除
 
--- 1. created_by カラムの NOT NULL 制約を削除
+-- =============================================
+-- 1. fantasy_bgm_assets テーブル
+-- =============================================
+-- created_by カラムの NOT NULL 制約を削除
 ALTER TABLE public.fantasy_bgm_assets 
   ALTER COLUMN created_by DROP NOT NULL;
 
--- 2. 既存の外部キー制約を削除
+-- 既存の外部キー制約を削除
 ALTER TABLE public.fantasy_bgm_assets 
   DROP CONSTRAINT IF EXISTS fantasy_bgm_assets_created_by_fkey;
 
--- 3. ON DELETE SET NULL で新しい外部キー制約を追加
+-- ON DELETE SET NULL で新しい外部キー制約を追加
 ALTER TABLE public.fantasy_bgm_assets 
   ADD CONSTRAINT fantasy_bgm_assets_created_by_fkey 
     FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
 
--- コメント更新
 COMMENT ON COLUMN public.fantasy_bgm_assets.created_by IS '作成者のプロファイルID（ユーザー削除時はNULLになる）';
+
+-- =============================================
+-- 2. guilds テーブル
+-- =============================================
+-- leader_id カラムの NOT NULL 制約を削除（ON DELETE SET NULL と競合するため）
+ALTER TABLE public.guilds 
+  ALTER COLUMN leader_id DROP NOT NULL;
+
+COMMENT ON COLUMN public.guilds.leader_id IS 'ギルドリーダーのプロファイルID（リーダー削除時はNULLになる）';

--- a/supabase/migrations/20251220090000_fix_fantasy_bgm_assets_on_delete.sql
+++ b/supabase/migrations/20251220090000_fix_fantasy_bgm_assets_on_delete.sql
@@ -1,0 +1,18 @@
+-- fantasy_bgm_assets テーブルの外部キー制約を ON DELETE SET NULL に変更
+-- これにより、プロファイル削除時にBGMアセットは残り、created_by がNULLになる
+
+-- 1. created_by カラムの NOT NULL 制約を削除
+ALTER TABLE public.fantasy_bgm_assets 
+  ALTER COLUMN created_by DROP NOT NULL;
+
+-- 2. 既存の外部キー制約を削除
+ALTER TABLE public.fantasy_bgm_assets 
+  DROP CONSTRAINT IF EXISTS fantasy_bgm_assets_created_by_fkey;
+
+-- 3. ON DELETE SET NULL で新しい外部キー制約を追加
+ALTER TABLE public.fantasy_bgm_assets 
+  ADD CONSTRAINT fantasy_bgm_assets_created_by_fkey 
+    FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- コメント更新
+COMMENT ON COLUMN public.fantasy_bgm_assets.created_by IS '作成者のプロファイルID（ユーザー削除時はNULLになる）';


### PR DESCRIPTION
Modify `fantasy_bgm_assets` foreign key to `ON DELETE SET NULL` to allow profile deletion without losing associated BGM assets.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0adeaf8-37a7-408e-a729-bcb11460e1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0adeaf8-37a7-408e-a729-bcb11460e1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

