### PR TITLE
Piano key 3d enhancement

### DIFF
--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1096,6 +1096,11 @@ export class PIXINotesRendererInstance {
       }
     });
     
+    // 白鍵でハイライトがあるものを判定
+    const hasWhiteHighlight = this.whiteKeyOrder.some((midi) => {
+      return pressedWhiteKeys.has(midi) || guideWhiteKeys.has(midi) || correctWhiteKeys.has(midi);
+    });
+    
     // 白鍵のハイライト描画（3D対応）
     for (const midi of this.whiteKeyOrder) {
       const geometry = this.keyGeometries.get(midi);
@@ -1119,16 +1124,16 @@ export class PIXINotesRendererInstance {
       }
     }
     
-    // 黒鍵のハイライト描画（3D対応）
-    for (const midi of this.blackKeyOrder) {
-      const geometry = this.keyGeometries.get(midi);
-      if (!geometry) continue;
-      
-      const isPressed = pressedBlackKeys.has(midi);
-      const isGuide = guideBlackKeys.has(midi);
-      const isCorrect = correctBlackKeys.has(midi);
-      
-      if (isPressed || isGuide || isCorrect) {
+    // 白鍵のハイライトがある場合、すべての黒鍵を再描画（白鍵の上に黒鍵を表示するため）
+    if (hasWhiteHighlight) {
+      for (const midi of this.blackKeyOrder) {
+        const geometry = this.keyGeometries.get(midi);
+        if (!geometry) continue;
+        
+        const isPressed = pressedBlackKeys.has(midi);
+        const isGuide = guideBlackKeys.has(midi);
+        const isCorrect = correctBlackKeys.has(midi);
+        
         let highlightColor: string | undefined;
         if (isPressed) {
           highlightColor = this.colors.activeKey;
@@ -1137,7 +1142,31 @@ export class PIXINotesRendererInstance {
         } else if (isGuide) {
           highlightColor = this.colors.guideKey;
         }
+        
+        // ハイライトの有無に関わらず黒鍵を再描画
         this.draw3DBlackKey(ctx, geometry, isPressed, highlightColor);
+      }
+    } else {
+      // 白鍵のハイライトがない場合は、ハイライトのある黒鍵のみ再描画
+      for (const midi of this.blackKeyOrder) {
+        const geometry = this.keyGeometries.get(midi);
+        if (!geometry) continue;
+        
+        const isPressed = pressedBlackKeys.has(midi);
+        const isGuide = guideBlackKeys.has(midi);
+        const isCorrect = correctBlackKeys.has(midi);
+        
+        if (isPressed || isGuide || isCorrect) {
+          let highlightColor: string | undefined;
+          if (isPressed) {
+            highlightColor = this.colors.activeKey;
+          } else if (isCorrect) {
+            highlightColor = this.colors.correctKey;
+          } else if (isGuide) {
+            highlightColor = this.colors.guideKey;
+          }
+          this.draw3DBlackKey(ctx, geometry, isPressed, highlightColor);
+        }
       }
     }
     

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -717,12 +717,17 @@ export class PIXINotesRendererInstance {
       ctx.fillRect(0, 0, this.width, this.height);
     }
     
+    // 鍵盤を先に描画（白鍵ハイライト → 黒鍵）
+    this.drawWhiteKeyHighlights(ctx);
+    this.drawDynamicBlackKeys(ctx);
+    
+    // ノーツを鍵盤の上に描画
     if (this.settings.showHitLine) {
       this.drawHitLine(ctx);
     }
     this.drawNotes(ctx);
-    this.drawWhiteKeyHighlights(ctx);
-    this.drawDynamicBlackKeys(ctx);
+    
+    // ラベルとオーバーレイを最後に描画
     this.drawKeyLabels(ctx);
     this.drawChordOverlay(ctx);
   }

--- a/src/components/game/PIXINotesRenderer.tsx
+++ b/src/components/game/PIXINotesRenderer.tsx
@@ -1096,10 +1096,16 @@ export class PIXINotesRendererInstance {
       }
     });
     
-    // 白鍵でハイライトがあるものを判定
-    const hasWhiteHighlight = this.whiteKeyOrder.some((midi) => {
-      return pressedWhiteKeys.has(midi) || guideWhiteKeys.has(midi) || correctWhiteKeys.has(midi);
-    });
+    // いずれかのハイライト（押下・ガイド・正解済み）があるかを判定
+    const hasAnyHighlight = this.highlightedKeys.size > 0 ||
+      this.guideHighlightedKeys.size > 0 ||
+      this.correctHighlightedKeys.size > 0;
+    
+    // ハイライトがない場合は何も描画しない（背景のみ）
+    if (!hasAnyHighlight) {
+      ctx.restore();
+      return;
+    }
     
     // 白鍵のハイライト描画（3D対応）
     for (const midi of this.whiteKeyOrder) {
@@ -1124,50 +1130,26 @@ export class PIXINotesRendererInstance {
       }
     }
     
-    // 白鍵のハイライトがある場合、すべての黒鍵を再描画（白鍵の上に黒鍵を表示するため）
-    if (hasWhiteHighlight) {
-      for (const midi of this.blackKeyOrder) {
-        const geometry = this.keyGeometries.get(midi);
-        if (!geometry) continue;
-        
-        const isPressed = pressedBlackKeys.has(midi);
-        const isGuide = guideBlackKeys.has(midi);
-        const isCorrect = correctBlackKeys.has(midi);
-        
-        let highlightColor: string | undefined;
-        if (isPressed) {
-          highlightColor = this.colors.activeKey;
-        } else if (isCorrect) {
-          highlightColor = this.colors.correctKey;
-        } else if (isGuide) {
-          highlightColor = this.colors.guideKey;
-        }
-        
-        // ハイライトの有無に関わらず黒鍵を再描画
-        this.draw3DBlackKey(ctx, geometry, isPressed, highlightColor);
+    // 常にすべての黒鍵を再描画（白鍵の上に正しく表示するため）
+    for (const midi of this.blackKeyOrder) {
+      const geometry = this.keyGeometries.get(midi);
+      if (!geometry) continue;
+      
+      const isPressed = pressedBlackKeys.has(midi);
+      const isGuide = guideBlackKeys.has(midi);
+      const isCorrect = correctBlackKeys.has(midi);
+      
+      let highlightColor: string | undefined;
+      if (isPressed) {
+        highlightColor = this.colors.activeKey;
+      } else if (isCorrect) {
+        highlightColor = this.colors.correctKey;
+      } else if (isGuide) {
+        highlightColor = this.colors.guideKey;
       }
-    } else {
-      // 白鍵のハイライトがない場合は、ハイライトのある黒鍵のみ再描画
-      for (const midi of this.blackKeyOrder) {
-        const geometry = this.keyGeometries.get(midi);
-        if (!geometry) continue;
-        
-        const isPressed = pressedBlackKeys.has(midi);
-        const isGuide = guideBlackKeys.has(midi);
-        const isCorrect = correctBlackKeys.has(midi);
-        
-        if (isPressed || isGuide || isCorrect) {
-          let highlightColor: string | undefined;
-          if (isPressed) {
-            highlightColor = this.colors.activeKey;
-          } else if (isCorrect) {
-            highlightColor = this.colors.correctKey;
-          } else if (isGuide) {
-            highlightColor = this.colors.guideKey;
-          }
-          this.draw3DBlackKey(ctx, geometry, isPressed, highlightColor);
-        }
-      }
+      
+      // ハイライトの有無に関わらず黒鍵を再描画
+      this.draw3DBlackKey(ctx, geometry, isPressed, highlightColor);
     }
     
     ctx.restore();


### PR DESCRIPTION
Make piano keys 3D with press animation and display note names to enhance visual feedback and consistency.

The previous flat key rendering lacked visual depth and feedback when keys were pressed. This change introduces a 3D effect and a sinking animation for pressed keys, making the playing experience more immersive. Additionally, displaying note names directly on the keys provides better visual cues, especially when the note name display is active for the falling notes.

---
<a href="https://cursor.com/background-agent?bcId=bc-007eb4eb-0621-405a-945b-069e38746d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-007eb4eb-0621-405a-945b-069e38746d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

