### PR TITLE
Sheet music mode images

### DIFF
--- a/src/components/fantasy/FantasyPIXIRenderer.tsx
+++ b/src/components/fantasy/FantasyPIXIRenderer.tsx
@@ -789,18 +789,27 @@ export class FantasyPIXIInstance {
     img.onerror = () => {
       this.loadingImages.delete(icon);
     };
-    // WebP優先、フォールバックでPNG
-    const webpPath = `${import.meta.env.BASE_URL}monster_icons/${icon}.webp`;
-    const pngPath = `${import.meta.env.BASE_URL}monster_icons/${icon}.png`;
     
-    const testImg = new Image();
-    testImg.onload = () => {
-      img.src = webpPath;
-    };
-    testImg.onerror = () => {
+    // 楽譜モード判定: 'treble_' または 'bass_' で始まる場合
+    if (icon.startsWith('treble_') || icon.startsWith('bass_')) {
+      // 楽譜モード: /notes_images/treble/ または /notes_images/bass/ から読み込み
+      const clef = icon.startsWith('treble_') ? 'treble' : 'bass';
+      const pngPath = `${import.meta.env.BASE_URL}notes_images/${clef}/${icon}.png`;
       img.src = pngPath;
-    };
-    testImg.src = webpPath;
+    } else {
+      // 通常モード: WebP優先、フォールバックでPNG
+      const webpPath = `${import.meta.env.BASE_URL}monster_icons/${icon}.webp`;
+      const pngPath = `${import.meta.env.BASE_URL}monster_icons/${icon}.png`;
+      
+      const testImg = new Image();
+      testImg.onload = () => {
+        img.src = webpPath;
+      };
+      testImg.onerror = () => {
+        img.src = pngPath;
+      };
+      testImg.src = webpPath;
+    }
     
     return null;
   }

--- a/src/platform/supabaseFantasyStages.ts
+++ b/src/platform/supabaseFantasyStages.ts
@@ -271,6 +271,10 @@ export interface UpsertFantasyStagePayload {
   stage_tier?: 'basic' | 'advanced';
   // 使用タイプ（fantasy=ファンタジーモード専用, lesson=レッスンモード専用, both=両方）
   usage_type?: FantasyStageUsageType;
+  // 楽譜モード（敵アイコンとして楽譜画像を使用）
+  sheet_music_mode?: boolean;
+  // 楽譜モード時の許可された音名リスト
+  allowed_notes?: string[];
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -545,6 +545,10 @@ export interface FantasyStage {
   stage_tier?: 'basic' | 'advanced';
   // 新規: 使用タイプ（fantasy=ファンタジーモード専用, lesson=レッスンモード専用, both=両方）
   usage_type?: FantasyStageUsageType;
+  // 新規: 楽譜モード（敵アイコンとして楽譜画像を使用）
+  sheet_music_mode?: boolean;
+  // 新規: 楽譜モード時の許可された音名リスト（例: ['treble_A#3', 'bass_C4']）
+  allowed_notes?: string[];
 }
 
 // ===== デイリーチャレンジ（日次記録） =====

--- a/supabase/migrations/20260109000000_add_sheet_music_mode_to_fantasy_stages.sql
+++ b/supabase/migrations/20260109000000_add_sheet_music_mode_to_fantasy_stages.sql
@@ -1,0 +1,17 @@
+-- 楽譜モード機能の追加
+-- 作成日: 2026-01-09
+-- 説明: ファンタジーステージに楽譜モード（敵アイコンとして楽譜画像を使用）を追加
+
+-- 楽譜モードフラグを追加
+-- true の場合、モンスターアイコンの代わりに楽譜画像（treble/bass）を表示
+ALTER TABLE fantasy_stages 
+ADD COLUMN IF NOT EXISTS sheet_music_mode BOOLEAN NOT NULL DEFAULT false;
+
+-- 許可された音名リストを追加
+-- 例: ['treble_A#3', 'treble_C4', 'bass_G2']
+ALTER TABLE fantasy_stages 
+ADD COLUMN IF NOT EXISTS allowed_notes TEXT[] DEFAULT '{}';
+
+-- コメント追加
+COMMENT ON COLUMN fantasy_stages.sheet_music_mode IS '楽譜モード: true の場合、敵アイコンとして楽譜画像を使用';
+COMMENT ON COLUMN fantasy_stages.allowed_notes IS '楽譜モード時の許可された音名リスト (例: treble_A#3, bass_C4)';


### PR DESCRIPTION
Implement "Sheet Music Mode" to allow users to practice specific musical notes using sheet music images as enemy icons in Fantasy Mode's single stage.

---
<a href="https://cursor.com/background-agent?bcId=bc-91a4e8c2-382d-4326-b7d0-436e5ad5c1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91a4e8c2-382d-4326-b7d0-436e5ad5c1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

