### PR TITLE
Fantasy mode display and root note octave

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -444,12 +444,21 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
           const parts = id.split('/');
           if (parts[1]) bassToPlay = parts[1];
         }
+        // 楽譜モードの場合はdisplayNameのオクターブをそのまま使用（例: A#3 → A#3）
+        if (stage?.isSheetMusicMode && chord.displayName) {
+          // displayNameにオクターブ情報が含まれている場合はそのまま使用
+          const octaveMatch = chord.displayName.match(/\d+$/);
+          if (octaveMatch) {
+            // オクターブ情報を含む完全な音名を渡す
+            bassToPlay = chord.displayName;
+          }
+        }
         await FSM?.playRootNote(bassToPlay);
       } catch (error) {
         console.error('Failed to play root note:', error);
       }
     }
-  }, [fantasyPixiInstance, stage?.playRootOnCorrect]);
+  }, [fantasyPixiInstance, stage?.playRootOnCorrect, stage?.isSheetMusicMode]);
   // ▲▲▲ ここまで ▲▲▲
   
   const handleChordIncorrect = useCallback((expectedChord: ChordDefinition, inputNotes: number[]) => {
@@ -1470,18 +1479,7 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
                         </>
                       )}
                       
-                      {/* 魔法名表示 */}
-                      {magicName && magicName.monsterId === monster.id && (
-                        <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
-                          {/* ▼▼▼ 変更点 ▼▼▼ */}
-                          <div className={`font-bold font-sans drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] opacity-75 text-sm ${
-                            magicName.isSpecial ? 'text-yellow-300' : 'text-white'
-                          }`}>
-                          {/* ▲▲▲ ここまで ▲▲▲ */}
-                            {magicName.name}
-                          </div>
-                        </div>
-                      )}
+                      {/* 魔法名表示（HPバー付近の表示は削除） */}
                       
                       {/* 行動ゲージ (singleモードのみ表示) */}
                       {!isDailyChallenge && playMode !== 'practice' && stage.mode === 'single' && (

--- a/src/utils/FantasySoundManager.ts
+++ b/src/utils/FantasySoundManager.ts
@@ -338,7 +338,13 @@ export class FantasySoundManager {
     if (!this.bassEnabled || !this.bassSampler) return;
     
     const Tone = window.Tone as unknown as typeof import('tone');
-    const n = tonalNote(rootName + '2');        // C2 付近
+    
+    // rootNameにオクターブ情報が含まれているかチェック（例: A#3, C4）
+    const hasOctave = /\d+$/.test(rootName);
+    // オクターブ情報がなければデフォルトでオクターブ2を付ける
+    const noteWithOctave = hasOctave ? rootName : rootName + '2';
+    
+    const n = tonalNote(noteWithOctave);
     if (n.midi == null) return;
     
     // Tone.js 例外対策：必ず前回より >0 の startTime


### PR DESCRIPTION
Removes the correct answer display near the enemy HP bar in Fantasy mode and plays the root note at its actual octave in Sheet Music mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0467ad3-ebba-4fbc-bc8c-49b99af8301c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0467ad3-ebba-4fbc-bc8c-49b99af8301c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

