### PR TITLE
単音カタカナドレミ

### DIFF
--- a/src/components/admin/FantasyStageManager.tsx
+++ b/src/components/admin/FantasyStageManager.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/platform/supabaseFantasyStages';
 import { fetchFantasyBgmAssets, FantasyBgmAsset } from '@/platform/supabaseFantasyBgm';
 import { FantasyStageSelector } from './FantasyStageSelector';
-import { CHORD_TEMPLATES, ChordQuality } from '@/utils/chord-templates';
+import { CHORD_TEMPLATES, ChordQuality, SINGLE_NOTE_ROOTS_SOLFEGE, solfegeToNoteName } from '@/utils/chord-templates';
 
 // モード型
 type AdminStageMode = 'single' | 'progression_order' | 'progression_random' | 'progression_timing';
@@ -815,6 +815,7 @@ const FantasyStageManager: React.FC = () => {
                   {CLICK_ADD_CHORD_TYPES.map((chordType) => (
                     <div key={chordType.label} className="space-y-1">
                       <div className="text-xs text-gray-400">{chordType.label}</div>
+                      {/* 英語音名 */}
                       <div className="flex flex-wrap gap-1">
                         {CLICK_ADD_ROOTS.map((root) => {
                           const chordName = `${root}${chordType.suffix}`;
@@ -835,6 +836,27 @@ const FantasyStageManager: React.FC = () => {
                           );
                         })}
                       </div>
+                      {/* 単音の場合はカタカナドレミ版も表示 */}
+                      {chordType.isNote && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {SINGLE_NOTE_ROOTS_SOLFEGE.map((solfege) => {
+                            const englishNote = solfegeToNoteName(solfege);
+                            return (
+                              <button
+                                key={`${chordType.label}-solfege-${solfege}`}
+                                type="button"
+                                className="btn btn-xs btn-outline hover:btn-secondary"
+                                onClick={() => {
+                                  const spec = { chord: englishNote, inversion: 0, octave: 4, type: 'note' as const };
+                                  appendAllowedChord(spec as any);
+                                }}
+                              >
+                                {solfege}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/src/components/admin/FantasyStageManager.tsx
+++ b/src/components/admin/FantasyStageManager.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/platform/supabaseFantasyStages';
 import { fetchFantasyBgmAssets, FantasyBgmAsset } from '@/platform/supabaseFantasyBgm';
 import { FantasyStageSelector } from './FantasyStageSelector';
-import { CHORD_TEMPLATES, ChordQuality, SINGLE_NOTE_ROOTS_SOLFEGE, solfegeToNoteName } from '@/utils/chord-templates';
+import { CHORD_TEMPLATES, ChordQuality, SINGLE_NOTE_ROOTS_SOLFEGE } from '@/utils/chord-templates';
 
 // モード型
 type AdminStageMode = 'single' | 'progression_order' | 'progression_random' | 'progression_timing';
@@ -840,14 +840,14 @@ const FantasyStageManager: React.FC = () => {
                       {chordType.isNote && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           {SINGLE_NOTE_ROOTS_SOLFEGE.map((solfege) => {
-                            const englishNote = solfegeToNoteName(solfege);
                             return (
                               <button
                                 key={`${chordType.label}-solfege-${solfege}`}
                                 type="button"
                                 className="btn btn-xs btn-outline hover:btn-secondary"
                                 onClick={() => {
-                                  const spec = { chord: englishNote, inversion: 0, octave: 4, type: 'note' as const };
+                                  // カタカナ音名をそのまま保存（ゲーム内でカタカナ表示される）
+                                  const spec = { chord: solfege, inversion: 0, octave: 4, type: 'note' as const };
                                   appendAllowedChord(spec as any);
                                 }}
                               >

--- a/src/components/admin/FantasyStageManager.tsx
+++ b/src/components/admin/FantasyStageManager.tsx
@@ -145,6 +145,7 @@ const formatInterval = (interval: string): string => {
 
 // コードクオリティからコード表記のサフィックスを取得
 const QUALITY_TO_SUFFIX: Record<ChordQuality, string> = {
+  'note': '', // 単音（サフィックスなし）
   'maj': '',
   'min': 'm',
   'aug': 'aug',

--- a/src/utils/chord-templates.ts
+++ b/src/utils/chord-templates.ts
@@ -7,7 +7,8 @@ export type ChordQuality =
   | 'maj' | 'min' | 'aug' | 'dim'
   | '7' | 'maj7' | 'm7' | 'mM7' | 'dim7' | 'aug7' | 'm7b5'
   | '6' | 'm6' | '9' | 'm9' | 'maj9' | '11' | 'm11' | '13' | 'm13'
-  | 'sus2' | 'sus4' | '7sus4' | 'add9' | 'madd9';
+  | 'sus2' | 'sus4' | '7sus4' | 'add9' | 'madd9'
+  | 'note'; // 単音用
 
 /**
  * 使用可能なルート音のリスト
@@ -33,6 +34,9 @@ export const VALID_ROOTS = [
  * 実音は transpose() で都度生成する
  */
 export const CHORD_TEMPLATES: Record<ChordQuality, string[]> = {
+  // 単音
+  'note':   ['1P'],  // 単音（ルート音のみ）
+  
   // トライアド
   'maj':    ['1P', '3M', '5P'],
   'min':    ['1P', '3m', '5P'],
@@ -133,3 +137,82 @@ export const FANTASY_CHORD_MAP: Record<string, { root: string; quality: ChordQua
   'C11': { root: 'C', quality: '11' },
   'C13': { root: 'C', quality: '13' }
 };
+
+/**
+ * カタカナ音名から英語音名へのマッピング
+ * 単音（type: note）入力時にカタカナドレミ表記をサポート
+ */
+export const SOLFEGE_TO_NOTE_MAP: Record<string, string> = {
+  // 基本音名（白鍵）
+  'ド': 'C',
+  'レ': 'D',
+  'ミ': 'E',
+  'ファ': 'F',
+  'ソ': 'G',
+  'ラ': 'A',
+  'シ': 'B',
+  
+  // シャープ系（♯記号）
+  'ド♯': 'C#',
+  'レ♯': 'D#',
+  'ファ♯': 'F#',
+  'ソ♯': 'G#',
+  'ラ♯': 'A#',
+  
+  // シャープ系（#記号 - ASCII入力対応）
+  'ド#': 'C#',
+  'レ#': 'D#',
+  'ファ#': 'F#',
+  'ソ#': 'G#',
+  'ラ#': 'A#',
+  
+  // フラット系（♭記号）
+  'レ♭': 'Db',
+  'ミ♭': 'Eb',
+  'ソ♭': 'Gb',
+  'ラ♭': 'Ab',
+  'シ♭': 'Bb',
+  
+  // フラット系（b記号 - ASCII入力対応）
+  'レb': 'Db',
+  'ミb': 'Eb',
+  'ソb': 'Gb',
+  'ラb': 'Ab',
+  'シb': 'Bb',
+};
+
+/**
+ * 単音用のルート音リスト（英語表記）
+ * 16種類の基本的な単音
+ */
+export const SINGLE_NOTE_ROOTS = [
+  'C', 'C#', 'Db', 'D', 'D#', 'Eb', 'E', 'F', 
+  'F#', 'Gb', 'G', 'G#', 'Ab', 'A', 'Bb', 'B'
+] as const;
+
+/**
+ * 単音用のルート音リスト（カタカナ表記）
+ * 16種類の基本的な単音（ドレミ表記）
+ */
+export const SINGLE_NOTE_ROOTS_SOLFEGE = [
+  'ド', 'ド♯', 'レ♭', 'レ', 'レ♯', 'ミ♭', 'ミ', 'ファ',
+  'ファ♯', 'ソ♭', 'ソ', 'ソ♯', 'ラ♭', 'ラ', 'シ♭', 'シ'
+] as const;
+
+/**
+ * カタカナ音名を英語音名に変換
+ * @param solfegeName カタカナ音名（例: 'ド', 'レ♯', 'ミ♭'）
+ * @returns 英語音名（例: 'C', 'D#', 'Eb'）または元の値（変換不可の場合）
+ */
+export function solfegeToNoteName(solfegeName: string): string {
+  return SOLFEGE_TO_NOTE_MAP[solfegeName] || solfegeName;
+}
+
+/**
+ * 音名がカタカナ表記かどうかを判定
+ * @param noteName 音名
+ * @returns カタカナ表記の場合true
+ */
+export function isSolfegeName(noteName: string): boolean {
+  return noteName in SOLFEGE_TO_NOTE_MAP;
+}


### PR DESCRIPTION
Add single-note Katakana Do-Re-Mi versions to chord definitions to enable handling and display of single notes using Katakana notation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3e7df5e-5fbf-4cfb-b5de-2b7675d9b850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3e7df5e-5fbf-4cfb-b5de-2b7675d9b850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

