### PR TITLE
ファンタジーモード カウント区間

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -499,13 +499,19 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
     if (!gameState.isGameActive) return;
     if (isReady) return;
 
+    // single以外のモードで、BGMにカウント区間がない場合、自動で1小節分の無音カウントを追加
+    const isProgressionMode = stage.mode !== 'single';
+    const hasNoCountIn = (stage.countInMeasures ?? 0) === 0;
+    const autoCountIn = (isProgressionMode && hasNoCountIn) ? 1 : 0;
+
     bgmManager.play(
       stage.bgmUrl ?? '/demo-1.mp3',
       stage.bpm || 120,
       stage.timeSignature || 4,
       stage.measureCount ?? 8,
       stage.countInMeasures ?? 0,
-      settings.bgmVolume ?? 0.7
+      settings.bgmVolume ?? 0.7,
+      autoCountIn  // 仮想カウント区間（初回のみ、ループ時はスキップ）
     );
 
     return () => bgmManager.stop();


### PR DESCRIPTION
Adds a virtual 1-measure silent count-in for fantasy mode (non-single) when no count-in is specified.

This ensures a consistent pre-game countdown experience for progression modes, while keeping note generation aligned with the actual music start (Measure 1) and skipping the virtual count-in on subsequent loops.

---
<a href="https://cursor.com/background-agent?bcId=bc-67845dae-58bd-410a-9a27-f561162d34fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67845dae-58bd-410a-9a27-f561162d34fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

