### PR TITLE
ファンタジーモード攻撃音統一

### DIFF
--- a/src/components/fantasy/FantasyGameScreen.tsx
+++ b/src/components/fantasy/FantasyGameScreen.tsx
@@ -410,6 +410,9 @@ const FantasyGameScreen: React.FC<FantasyGameScreenProps> = ({
   const handleChordCorrect = useCallback(async (chord: ChordDefinition, isSpecial: boolean, damageDealt: number, defeated: boolean, monsterId: string) => {
     devLog.debug('✅ 正解:', { name: chord.displayName, special: isSpecial, damage: damageDealt, defeated: defeated, monsterId });
     
+    // 敵を攻撃した時に攻撃音を再生（敵の攻撃音と同じ音）
+    FantasySoundManager.playEnemyAttack();
+    
     if (fantasyPixiInstance) {
       fantasyPixiInstance.triggerAttackSuccessOnMonster(monsterId, chord.displayName, isSpecial, damageDealt, defeated);
       // 太鼓progressionモード時は判定ライン上に小さなヒットエフェクトを表示


### PR DESCRIPTION
Add enemy attack sound when the player attacks an enemy in fantasy mode.

Previously, no specific attack sound was played when the player attacked an enemy. This change ensures that the `enemy_attack.mp3` sound is played, aligning with the user's request for consistency with the enemy's attack sound.

---
<a href="https://cursor.com/background-agent?bcId=bc-92f8bc6b-acca-4afd-b864-101eff231d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92f8bc6b-acca-4afd-b864-101eff231d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

