### PR TITLE
ステージデータ複製

### DIFF
--- a/scripts/duplicate_fantasy_stages.js
+++ b/scripts/duplicate_fantasy_stages.js
@@ -1,0 +1,175 @@
+/**
+ * Fantasy Stages 複製スクリプト
+ * 
+ * 使い方:
+ *   1. .env または環境変数に以下を設定:
+ *      - SUPABASE_URL (または VITE_SUPABASE_URL)
+ *      - SUPABASE_SERVICE_ROLE_KEY
+ *   2. 設定セクションで複製元・複製先を指定
+ *   3. node scripts/duplicate_fantasy_stages.js を実行
+ */
+
+// ESModuleとCommonJSの両方に対応
+const loadSupabase = async () => {
+  try {
+    // 動的インポートを試みる
+    const { createClient } = await import('@supabase/supabase-js');
+    return createClient;
+  } catch {
+    // CommonJS環境の場合
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createClient } = require('@supabase/supabase-js');
+    return createClient;
+  }
+};
+
+// dotenv読み込み（存在する場合）
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('dotenv').config();
+} catch {
+  // dotenvがない場合はスキップ
+}
+
+// ======= 設定セクション =======
+const CONFIG = {
+  sourcePrefix: '2-',      // 複製元のプレフィックス (例: '2-')
+  targetPrefix: '3-',      // 複製先のプレフィックス (例: '3-')
+  sourceTier: 'basic',     // 複製元のstage_tier ('basic' or 'advanced')
+  targetTier: 'basic',     // 複製先のstage_tier
+  startNum: 1,             // 開始ステージ番号
+  endNum: 10,              // 終了ステージ番号
+  dryRun: true,            // true: 確認のみ、false: 実際に複製
+};
+// ================================
+
+async function main() {
+  const createClient = await loadSupabase();
+  
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    console.error('Error: SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を設定してください');
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  console.log('='.repeat(50));
+  console.log('Fantasy Stages 複製スクリプト');
+  console.log('='.repeat(50));
+  console.log(`複製元: ${CONFIG.sourcePrefix}${CONFIG.startNum} 〜 ${CONFIG.sourcePrefix}${CONFIG.endNum} (tier: ${CONFIG.sourceTier})`);
+  console.log(`複製先: ${CONFIG.targetPrefix}${CONFIG.startNum} 〜 ${CONFIG.targetPrefix}${CONFIG.endNum} (tier: ${CONFIG.targetTier})`);
+  console.log(`モード: ${CONFIG.dryRun ? 'DRY RUN (確認のみ)' : '本番実行'}`);
+  console.log('='.repeat(50));
+
+  // 1. 複製元のステージを取得
+  const stageNumbers = [];
+  for (let i = CONFIG.startNum; i <= CONFIG.endNum; i++) {
+    stageNumbers.push(`${CONFIG.sourcePrefix}${i}`);
+  }
+
+  const { data: sourceStages, error: fetchError } = await supabase
+    .from('fantasy_stages')
+    .select('*')
+    .in('stage_number', stageNumbers)
+    .eq('stage_tier', CONFIG.sourceTier)
+    .order('stage_number');
+
+  if (fetchError) {
+    console.error('Error fetching source stages:', fetchError.message);
+    process.exit(1);
+  }
+
+  if (!sourceStages || sourceStages.length === 0) {
+    console.log('複製元のステージが見つかりません。');
+    process.exit(0);
+  }
+
+  console.log(`\n複製元ステージ (${sourceStages.length}件):`);
+  sourceStages.forEach(stage => {
+    console.log(`  - ${stage.stage_number}: ${stage.name} (mode: ${stage.mode})`);
+  });
+
+  // 2. 複製先の既存ステージを確認
+  const targetNumbers = stageNumbers.map(sn => 
+    sn.replace(CONFIG.sourcePrefix, CONFIG.targetPrefix)
+  );
+
+  const { data: existingTargets } = await supabase
+    .from('fantasy_stages')
+    .select('stage_number')
+    .in('stage_number', targetNumbers)
+    .eq('stage_tier', CONFIG.targetTier);
+
+  if (existingTargets && existingTargets.length > 0) {
+    console.log(`\n⚠️  警告: 複製先に既存ステージがあります:`);
+    existingTargets.forEach(s => console.log(`  - ${s.stage_number}`));
+    
+    if (!CONFIG.dryRun) {
+      console.log('\n既存ステージをスキップして続行します。');
+    }
+  }
+
+  // 3. 複製データを作成
+  const duplicatedStages = sourceStages
+    .filter(stage => {
+      const newStageNumber = stage.stage_number.replace(CONFIG.sourcePrefix, CONFIG.targetPrefix);
+      const exists = existingTargets?.some(e => e.stage_number === newStageNumber);
+      if (exists) {
+        console.log(`  スキップ: ${newStageNumber} (既存)`);
+      }
+      return !exists;
+    })
+    .map(stage => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, created_at, updated_at, ...rest } = stage;
+      return {
+        ...rest,
+        stage_number: stage.stage_number.replace(CONFIG.sourcePrefix, CONFIG.targetPrefix),
+        stage_tier: CONFIG.targetTier,
+      };
+    });
+
+  if (duplicatedStages.length === 0) {
+    console.log('\n複製するステージがありません。');
+    process.exit(0);
+  }
+
+  console.log(`\n複製予定 (${duplicatedStages.length}件):`);
+  duplicatedStages.forEach(stage => {
+    console.log(`  + ${stage.stage_number}: ${stage.name}`);
+  });
+
+  // 4. DRY RUNの場合は終了
+  if (CONFIG.dryRun) {
+    console.log('\n--- DRY RUN 終了 ---');
+    console.log('実際に複製するには CONFIG.dryRun を false に設定してください。');
+    process.exit(0);
+  }
+
+  // 5. 複製実行
+  console.log('\n複製を実行します...');
+  const { data: insertedData, error: insertError } = await supabase
+    .from('fantasy_stages')
+    .insert(duplicatedStages)
+    .select();
+
+  if (insertError) {
+    console.error('Error inserting stages:', insertError.message);
+    process.exit(1);
+  }
+
+  console.log(`\n✅ ${insertedData.length}件のステージを複製しました:`);
+  insertedData.forEach(stage => {
+    console.log(`  - ${stage.stage_number}: ${stage.name} (id: ${stage.id})`);
+  });
+}
+
+main().catch(console.error);

--- a/scripts/duplicate_fantasy_stages.sql
+++ b/scripts/duplicate_fantasy_stages.sql
@@ -1,0 +1,91 @@
+-- ========================================
+-- Fantasy Stages 複製スクリプト
+-- ステージ2-1 〜 2-10 を 3-1 〜 3-10 に複製
+-- ========================================
+-- 使い方:
+--   1. SOURCE_STAGEとTARGET_STAGEプレフィックスを変更
+--   2. Supabase SQL Editorで実行
+-- ========================================
+
+BEGIN;
+
+-- 設定: 変更するステージ番号のプレフィックス
+-- 例: '2-' を '3-' に複製
+-- stage_tierも必要に応じて変更
+
+-- 複製元: ステージ2-1 〜 2-10 (stage_tier = 'basic')
+-- 複製先: ステージ3-1 〜 3-10 (stage_tier = 'basic')
+
+INSERT INTO public.fantasy_stages (
+  -- id は自動生成されるので除外
+  stage_number,
+  name,
+  name_en,
+  description,
+  description_en,
+  max_hp,
+  question_count,
+  enemy_gauge_seconds,
+  mode,
+  allowed_chords,
+  chord_progression,
+  bgm_url,
+  show_guide,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  simultaneous_monster_count,
+  play_root_on_correct,
+  stage_tier,
+  note_interval_beats,
+  is_sheet_music_mode,
+  sheet_music_clef,
+  usage_type
+  -- created_at, updated_at は自動設定
+)
+SELECT
+  -- stage_number を '2-X' から '3-X' に変換
+  REPLACE(stage_number, '2-', '3-') AS stage_number,
+  name,
+  name_en,
+  description,
+  description_en,
+  max_hp,
+  question_count,
+  enemy_gauge_seconds,
+  mode,
+  allowed_chords,
+  chord_progression,
+  bgm_url,
+  show_guide,
+  enemy_count,
+  enemy_hp,
+  min_damage,
+  max_damage,
+  simultaneous_monster_count,
+  play_root_on_correct,
+  stage_tier,
+  note_interval_beats,
+  is_sheet_music_mode,
+  sheet_music_clef,
+  usage_type
+FROM public.fantasy_stages
+WHERE 
+  stage_number ~ '^2-\d+$'  -- '2-' で始まり数字で終わる
+  AND stage_tier = 'basic'  -- 必要に応じて変更
+ORDER BY 
+  -- stage_numberを数値順にソート
+  CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER);
+
+-- 確認クエリ (実行後、結果を確認)
+-- SELECT id, stage_number, name, stage_tier FROM fantasy_stages 
+-- WHERE stage_number ~ '^3-\d+$' ORDER BY CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER);
+
+COMMIT;
+
+-- ========================================
+-- ロールバック用 (必要な場合)
+-- ========================================
+-- DELETE FROM public.fantasy_stages 
+-- WHERE stage_number ~ '^3-\d+$' AND stage_tier = 'basic';

--- a/scripts/duplicate_fantasy_stages_generic.sql
+++ b/scripts/duplicate_fantasy_stages_generic.sql
@@ -1,0 +1,105 @@
+-- ========================================
+-- Fantasy Stages 汎用複製スクリプト
+-- ========================================
+-- 使い方:
+--   以下の変数を変更して実行
+-- ========================================
+
+-- ====== 設定 ======
+-- 以下の値を変更してください
+
+DO $$
+DECLARE
+  v_source_prefix TEXT := '2-';        -- 複製元のプレフィックス (例: '2-')
+  v_target_prefix TEXT := '3-';        -- 複製先のプレフィックス (例: '3-')
+  v_source_tier TEXT := 'basic';       -- 複製元のstage_tier ('basic' or 'advanced')
+  v_target_tier TEXT := 'basic';       -- 複製先のstage_tier (同じにする場合は同値を設定)
+  v_start_num INT := 1;                -- 開始ステージ番号 (例: 1 で '2-1'から)
+  v_end_num INT := 10;                 -- 終了ステージ番号 (例: 10 で '2-10'まで)
+  v_count INT := 0;
+BEGIN
+  -- 複製実行
+  INSERT INTO public.fantasy_stages (
+    stage_number,
+    name,
+    name_en,
+    description,
+    description_en,
+    max_hp,
+    question_count,
+    enemy_gauge_seconds,
+    mode,
+    allowed_chords,
+    chord_progression,
+    bgm_url,
+    show_guide,
+    enemy_count,
+    enemy_hp,
+    min_damage,
+    max_damage,
+    simultaneous_monster_count,
+    play_root_on_correct,
+    stage_tier,
+    note_interval_beats,
+    is_sheet_music_mode,
+    sheet_music_clef,
+    usage_type
+  )
+  SELECT
+    v_target_prefix || SPLIT_PART(stage_number, '-', 2) AS stage_number,
+    name,
+    name_en,
+    description,
+    description_en,
+    max_hp,
+    question_count,
+    enemy_gauge_seconds,
+    mode,
+    allowed_chords,
+    chord_progression,
+    bgm_url,
+    show_guide,
+    enemy_count,
+    enemy_hp,
+    min_damage,
+    max_damage,
+    simultaneous_monster_count,
+    play_root_on_correct,
+    v_target_tier AS stage_tier,  -- 複製先のtierを設定
+    note_interval_beats,
+    is_sheet_music_mode,
+    sheet_music_clef,
+    usage_type
+  FROM public.fantasy_stages
+  WHERE 
+    stage_number LIKE v_source_prefix || '%'
+    AND stage_tier = v_source_tier
+    AND CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER) >= v_start_num
+    AND CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER) <= v_end_num
+  ORDER BY 
+    CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER);
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE '% ステージを複製しました (%% -> %%)', v_count, v_source_prefix, v_target_prefix;
+END $$;
+
+-- ========================================
+-- 複製結果の確認
+-- ========================================
+SELECT 
+  id, 
+  stage_number, 
+  name, 
+  stage_tier,
+  mode,
+  question_count,
+  max_hp
+FROM public.fantasy_stages 
+WHERE stage_number LIKE '3-%'  -- 複製先のプレフィックスに変更
+ORDER BY CAST(SPLIT_PART(stage_number, '-', 2) AS INTEGER);
+
+-- ========================================
+-- ロールバック (必要な場合)
+-- ========================================
+-- DELETE FROM public.fantasy_stages 
+-- WHERE stage_number LIKE '3-%' AND stage_tier = 'basic';


### PR DESCRIPTION
Add SQL and Node.js scripts to duplicate `fantasy_stages` table data, enabling replication of stage ranges (e.g., 2-X to 3-X).

---
<a href="https://cursor.com/background-agent?bcId=bc-3175f5bb-d7c9-4fba-b1c8-755caf773274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3175f5bb-d7c9-4fba-b1c8-755caf773274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

