### PR TITLE
未解放ステージ情報表示

### DIFF
--- a/src/components/fantasy/FantasyStageSelect.tsx
+++ b/src/components/fantasy/FantasyStageSelect.tsx
@@ -549,12 +549,12 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
         
         {/* コンテンツ部分 */}
         <div className="min-w-0 flex-grow">
-          {/* ステージ名 */}
+          {/* ステージ名 - ロックされていても表示 */}
           <div className={cn(
             "text-base sm:text-lg font-medium mb-1 whitespace-normal break-words",
             unlocked ? "text-white" : "text-gray-400"
             )}>
-              {unlocked ? getLocalizedFantasyStageName(stage, profile?.rank) : "???"}
+              {getLocalizedFantasyStageName(stage, profile?.rank)}
           </div>
           
           {/* モードタグ */}
@@ -569,15 +569,19 @@ const FantasyStageSelect: React.FC<FantasyStageSelectProps> = ({
             </div>
           )}
           
-          {/* 説明文 */}
+          {/* 説明文 - ロックされていても表示 */}
           <div className={cn(
             "text-xs sm:text-sm leading-relaxed break-words",
             unlocked ? "text-gray-300" : "text-gray-500"
             )}>
-              {unlocked ? getLocalizedFantasyStageDescription(stage, profile?.rank) : (
-                isFreeOrGuest && stage.stageNumber && stage.stageNumber >= '1-4' 
-                  ? (isEnglishCopy ? 'Available on the Standard plan or higher.' : 'スタンダードプラン以上で利用可能です') 
-                  : (isEnglishCopy ? 'This stage is still locked.' : 'このステージはまだロックされています')
+              {getLocalizedFantasyStageDescription(stage, profile?.rank)}
+              {!unlocked && (
+                <span className="block mt-1 text-orange-400/80">
+                  {isFreeOrGuest && stage.stageNumber && stage.stageNumber >= '1-4' 
+                    ? (isEnglishCopy ? '(Available on the Standard plan or higher)' : '（スタンダードプラン以上で利用可能）') 
+                    : (isEnglishCopy ? '(Clear the previous stage to unlock)' : '（前のステージをクリアすると解放）')
+                  }
+                </span>
               )}
           </div>
         </div>

--- a/src/components/lesson/LessonPage.tsx
+++ b/src/components/lesson/LessonPage.tsx
@@ -631,6 +631,15 @@ const LessonPage: React.FC = () => {
                                               </div>
                                             </div>
                                           )}
+
+                                          {/* 説明文 - ロックされていても表示 */}
+                                          {lesson.description && (
+                                            <p className={`text-xs sm:text-sm line-clamp-2 ${
+                                              unlocked ? 'text-gray-300' : 'text-gray-500'
+                                            }`}>
+                                              {lesson.description}
+                                            </p>
+                                          )}
                                         </div>
                                       </div>
                                     );


### PR DESCRIPTION
Display titles and descriptions for locked stages and lessons to allow users to preview content.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ca6cd5f-e250-4862-97a4-119825c6a213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ca6cd5f-e250-4862-97a4-119825c6a213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

