### PR TITLE
feat(code-run): スノー登攀ステージ115と開発者テスト課題

### DIFF
--- a/public/code-run-map-editor/editor.js
+++ b/public/code-run-map-editor/editor.js
@@ -10,6 +10,10 @@ const DISPLAY_TILE = 28;
 const ENEMY_W = 38;
 const ENEMY_H = 34;
 
+const deriveWorldHeightPx = (gridRows, tileSize) => (
+  Math.max(1, Math.floor(gridRows)) * Math.max(1, Math.floor(tileSize))
+);
+
 const TOOL_COLORS = {
   ground: '#6b5344',
   brick: '#7a8499',
@@ -150,12 +154,12 @@ class CodeRunMapEditor {
       return Number.isFinite(v) && v > 0 ? v : fallback;
     };
     this.worldTilesWide = Math.min(400, Math.max(8, Math.floor(num('worldTilesWide', 64))));
-    this.gridRows = Math.min(80, Math.max(4, Math.floor(num('gridRows', 14))));
+    this.gridRows = Math.min(120, Math.max(4, Math.floor(num('gridRows', 14))));
     this.tileSize = Math.min(64, Math.max(16, Math.floor(num('tileSize', DEFAULT_TILE))));
     this.groundRow = Math.min(this.gridRows - 1, Math.max(0, Math.floor(num('groundRow', 9))));
     this.viewWidth = Math.floor(num('viewWidth', 960));
     this.viewHeight = Math.floor(num('viewHeight', 528));
-    this.worldHeight = Math.floor(num('worldHeight', 528));
+    this.worldHeight = deriveWorldHeightPx(this.gridRows, this.tileSize);
     this.goalOffsetX = num('goalOffsetX', 18);
     this.goalColumn = Math.floor(num('goalColumn', 60));
     this.resizeCanvas();
@@ -480,7 +484,7 @@ class CodeRunMapEditor {
       tileSize: this.tileSize,
       worldTilesWide: this.worldTilesWide,
       worldTilesHigh: this.gridRows,
-      worldHeight: this.worldHeight,
+      worldHeight: deriveWorldHeightPx(this.gridRows, this.tileSize),
       groundRow: this.groundRow,
       spawn: this.spawn ?? { c: 2, r: this.groundRow },
       pits: this.mergePits(),
@@ -536,7 +540,7 @@ class CodeRunMapEditor {
     this.groundRow = nonNegInt(source.groundRow, 9);
     this.viewWidth = positiveInt(source.viewWidth, 960);
     this.viewHeight = positiveInt(source.viewHeight, 528);
-    this.worldHeight = positiveInt(source.worldHeight, this.viewHeight);
+    this.worldHeight = deriveWorldHeightPx(this.gridRows, this.tileSize);
     this.goalOffsetX = nonNegNumber(source.goalOffsetX, 18);
     this.manualGround = source.manualGround === true;
     this.useGoalColumn = !source.goal;

--- a/public/code-run-map-editor/index.html
+++ b/public/code-run-map-editor/index.html
@@ -90,7 +90,7 @@
         </div>
         <div class="field">
           <label for="gridRows">編集行数</label>
-          <input id="gridRows" type="number" min="4" max="80" value="14" />
+          <input id="gridRows" type="number" min="4" max="120" value="14" />
         </div>
       </div>
       <div class="row-2">
@@ -105,8 +105,8 @@
       </div>
       <div class="row-2">
         <div class="field">
-          <label for="worldHeight">worldHeight</label>
-          <input id="worldHeight" type="number" min="96" value="528" />
+          <label for="worldHeight">worldHeight（行×タイル）</label>
+          <input id="worldHeight" type="number" readonly value="672" />
         </div>
         <div class="field">
           <label for="goalColumn">goalColumn</label>

--- a/src/components/admin/CodeRunMapEditor.tsx
+++ b/src/components/admin/CodeRunMapEditor.tsx
@@ -15,6 +15,7 @@ import {
   cellKey,
   defaultEditorSettings,
   defaultEnemyPlacement,
+  deriveWorldHeightPx,
   findEnemyIndexAt,
   parseMapLayoutJson,
 } from './codeRunMap/codeRunMapEditorLogic';
@@ -295,7 +296,13 @@ const CodeRunMapEditor: React.FC = () => {
   };
 
   const patchSettings = (patch: Partial<CodeRunEditorSettings>) => {
-    setSettings((s) => ({ ...s, ...patch }));
+    setSettings((s) => {
+      const next = { ...s, ...patch };
+      if (patch.gridRows !== undefined || patch.tileSize !== undefined) {
+        next.worldHeight = deriveWorldHeightPx(next.gridRows, next.tileSize);
+      }
+      return next;
+    });
   };
 
   const groundToolDisabled = !settings.manualGround;
@@ -397,7 +404,7 @@ const CodeRunMapEditor: React.FC = () => {
                 className="input input-bordered input-sm w-full mt-0.5"
                 type="number"
                 min={4}
-                max={80}
+                max={120}
                 value={settings.gridRows}
                 onChange={(e) => patchSettings({ gridRows: Number(e.target.value) })}
               />
@@ -421,12 +428,13 @@ const CodeRunMapEditor: React.FC = () => {
               />
             </label>
             <label className="block col-span-2">
-              <span className="text-xs text-gray-400">worldHeight</span>
+              <span className="text-xs text-gray-400">worldHeight（行×タイル）</span>
               <input
-                className="input input-bordered input-sm w-full mt-0.5"
+                className="input input-bordered input-sm w-full mt-0.5 bg-base-200"
                 type="number"
-                value={settings.worldHeight}
-                onChange={(e) => patchSettings({ worldHeight: Number(e.target.value) })}
+                readOnly
+                aria-readonly="true"
+                value={deriveWorldHeightPx(settings.gridRows, settings.tileSize)}
               />
             </label>
             <label className="block">

--- a/src/components/admin/codeRunMap/codeRunMapEditorLogic.test.ts
+++ b/src/components/admin/codeRunMap/codeRunMapEditorLogic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildMapLayoutJson,
   defaultEditorSettings,
+  deriveWorldHeightPx,
   mergePits,
   parseMapLayoutJson,
 } from './codeRunMapEditorLogic';
@@ -13,6 +14,18 @@ describe('codeRunMapEditorLogic', () => {
       { c0: 2, c1: 4 },
       { c0: 8, c1: 8 },
     ]);
+  });
+
+  it('deriveWorldHeightPx は行数×タイルサイズを返す', () => {
+    expect(deriveWorldHeightPx(65, 48)).toBe(3120);
+    expect(deriveWorldHeightPx(14, 48)).toBe(672);
+  });
+
+  it('エクスポート JSON の worldHeight は行数から導出される', () => {
+    const settings = { ...defaultEditorSettings(), gridRows: 65, tileSize: 48 };
+    const json = buildMapLayoutJson(new Map(), new Set(), [], null, null, settings);
+    expect(json.worldTilesHigh).toBe(65);
+    expect(json.worldHeight).toBe(3120);
   });
 
   it('manualGround 付き JSON を往復できる', () => {

--- a/src/components/admin/codeRunMap/codeRunMapEditorLogic.ts
+++ b/src/components/admin/codeRunMap/codeRunMapEditorLogic.ts
@@ -37,6 +37,11 @@ const isTileKind = (value: string): value is CodeRunTileKind => (
   CODE_RUN_TILE_KINDS.includes(value as CodeRunTileKind)
 );
 
+/** ランタイムの縦スクロール高さ（px）= 行数 × タイルサイズ */
+export const deriveWorldHeightPx = (gridRows: number, tileSize: number): number => (
+  Math.max(1, Math.floor(gridRows)) * Math.max(1, Math.floor(tileSize))
+);
+
 export const exportSolids = (
   cells: ReadonlyMap<string, string>,
   gridRows: number,
@@ -112,7 +117,7 @@ export const buildMapLayoutJson = (
     tileSize: settings.tileSize,
     worldTilesWide: settings.worldTilesWide,
     worldTilesHigh: settings.gridRows,
-    worldHeight: settings.worldHeight,
+    worldHeight: deriveWorldHeightPx(settings.gridRows, settings.tileSize),
     groundRow: settings.groundRow,
     spawn: spawn ?? { c: 2, r: settings.groundRow },
     pits: mergePits(pitColumns),
@@ -195,6 +200,7 @@ export const parseMapLayoutJson = (raw: string): ImportedMapState => {
     source.worldTilesHigh,
     Math.ceil(positiveInt(source.worldHeight, 528) / tileSize),
   );
+  const worldHeight = deriveWorldHeightPx(gridRows, tileSize);
 
   const settings: CodeRunEditorSettings = {
     worldTilesWide,
@@ -203,7 +209,7 @@ export const parseMapLayoutJson = (raw: string): ImportedMapState => {
     groundRow,
     viewWidth: positiveInt(source.viewWidth, 960),
     viewHeight: positiveInt(source.viewHeight, 528),
-    worldHeight: positiveInt(source.worldHeight, 528),
+    worldHeight,
     goalOffsetX: nonNegNumber(source.goalOffsetX, 18),
     manualGround: source.manualGround === true,
     useGoalColumn: !source.goal,
@@ -280,7 +286,7 @@ export const defaultEditorSettings = (): CodeRunEditorSettings => ({
   manualGround: true,
   viewWidth: 960,
   viewHeight: 528,
-  worldHeight: 528,
+  worldHeight: deriveWorldHeightPx(14, DEFAULT_TILE_SIZE),
   goalOffsetX: 18,
   useGoalColumn: true,
   goalColumn: 60,

--- a/src/components/survival/codeRun/CodeRunEngine.test.ts
+++ b/src/components/survival/codeRun/CodeRunEngine.test.ts
@@ -470,6 +470,29 @@ describe('createCodeRunMapById / createCodeRunMapFromDb', () => {
     expect(byId.goalY).toBe(direct.goalY);
   });
 
+  it('createCodeRunMapFromDb は worldTilesHigh から worldHeight を導出する', () => {
+    const fromDb = createCodeRunMapFromDb('snow_climb_run_01', {
+      layoutVersion: 1,
+      viewWidth: 960,
+      viewHeight: 528,
+      tileSize: 48,
+      worldTilesWide: 20,
+      worldTilesHigh: 65,
+      worldHeight: 500,
+      groundRow: 30,
+      manualGround: true,
+      spawn: { c: 4, r: 63 },
+      goal: { c: 0, r: 63 },
+      goalOffsetX: 18,
+      pits: [],
+      solids: [{ kind: 'platform', row: 8, c0: 14, c1: 18 }],
+      spikes: [],
+      enemies: [],
+    }, 150);
+    expect(fromDb.worldHeight).toBe(3120);
+    expect(fromDb.worldWidth).toBe(960);
+  });
+
   it('createCodeRunMapFromDb は mapId に応じたレイアウトを返す', () => {
     const nightCity = createDefaultCodeRunMap();
     const graveyard = createGraveyardRun03Map();

--- a/src/components/survival/codeRun/defaultCodeRunMap.ts
+++ b/src/components/survival/codeRun/defaultCodeRunMap.ts
@@ -103,6 +103,7 @@ interface CodeRunLayoutData {
   readonly viewHeight?: number;
   readonly tileSize?: number;
   readonly worldTilesWide?: number;
+  readonly worldTilesHigh?: number;
   readonly worldHeight?: number;
   readonly groundRow?: number;
   /** true のとき自動床（groundRow 沿い）を敷かず、solids の ground のみ使う。 */
@@ -235,7 +236,9 @@ const buildMapFromLayout = (
   const worldTilesWide = layout.worldTilesWide ?? LEVEL_TILES_W;
   const groundRow = layout.groundRow ?? GROUND_ROW;
   const worldWidth = worldTilesWide * tileSize;
-  const worldHeight = layout.worldHeight ?? viewHeight;
+  const worldHeight = layout.worldTilesHigh !== undefined
+    ? layout.worldTilesHigh * tileSize
+    : (layout.worldHeight ?? viewHeight);
   const spawnPoint = layout.spawn ?? { c: 2, r: groundRow };
   const goalPoint = layout.goal ?? { c: layout.goalColumn ?? 160, r: groundRow };
   const solids: CodeRunTileRect[] = [];
@@ -687,6 +690,7 @@ const parseCodeRunLayoutFromDb = (
     viewHeight: readPositiveNumber(source, 'viewHeight'),
     tileSize: readPositiveNumber(source, 'tileSize'),
     worldTilesWide: readPositiveNumber(source, 'worldTilesWide'),
+    worldTilesHigh: readPositiveNumber(source, 'worldTilesHigh'),
     worldHeight: readPositiveNumber(source, 'worldHeight'),
     groundRow: readNonNegativeInteger(source, 'groundRow'),
     manualGround: source.manualGround === true,

--- a/supabase/migrations/20260804230000_code_run_snow_climb_run_01_stage.sql
+++ b/supabase/migrations/20260804230000_code_run_snow_climb_run_01_stage.sql
@@ -1,0 +1,1169 @@
+-- Code Run stage 115: snow_climb_run_01 vertical tower + developer test course lesson.
+BEGIN;
+
+INSERT INTO public.survival_run_maps (id, name, map_data) VALUES (
+  'snow_climb_run_01',
+  'Snow Climb Run 01',
+  '{
+  "source": "db",
+  "variant": "snow_climb",
+  "layoutVersion": 1,
+  "viewWidth": 960,
+  "viewHeight": 528,
+  "tileSize": 48,
+  "worldTilesWide": 20,
+  "worldTilesHigh": 65,
+  "worldHeight": 3120,
+  "groundRow": 30,
+  "spawn": {
+    "c": 4,
+    "r": 63
+  },
+  "pits": [],
+  "solids": [
+    {
+      "kind": "platform",
+      "row": 8,
+      "c0": 14,
+      "c1": 18
+    },
+    {
+      "kind": "platform",
+      "row": 11,
+      "c0": 14,
+      "c1": 16
+    },
+    {
+      "kind": "platform",
+      "row": 13,
+      "c0": 10,
+      "c1": 12
+    },
+    {
+      "kind": "platform",
+      "row": 15,
+      "c0": 6,
+      "c1": 8
+    },
+    {
+      "kind": "platform",
+      "row": 17,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 19,
+      "c0": 5,
+      "c1": 7
+    },
+    {
+      "kind": "platform",
+      "row": 20,
+      "c0": 9,
+      "c1": 11
+    },
+    {
+      "kind": "platform",
+      "row": 20,
+      "c0": 13,
+      "c1": 15
+    },
+    {
+      "kind": "platform",
+      "row": 22,
+      "c0": 17,
+      "c1": 18
+    },
+    {
+      "kind": "platform",
+      "row": 27,
+      "c0": 8,
+      "c1": 10
+    },
+    {
+      "kind": "platform",
+      "row": 30,
+      "c0": 8,
+      "c1": 10
+    },
+    {
+      "kind": "platform",
+      "row": 34,
+      "c0": 2,
+      "c1": 4
+    },
+    {
+      "kind": "platform",
+      "row": 37,
+      "c0": 17,
+      "c1": 18
+    },
+    {
+      "kind": "platform",
+      "row": 39,
+      "c0": 17,
+      "c1": 18
+    },
+    {
+      "kind": "platform",
+      "row": 42,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 42,
+      "c0": 7,
+      "c1": 9
+    },
+    {
+      "kind": "platform",
+      "row": 42,
+      "c0": 11,
+      "c1": 13
+    },
+    {
+      "kind": "platform",
+      "row": 42,
+      "c0": 15,
+      "c1": 17
+    },
+    {
+      "kind": "platform",
+      "row": 44,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 46,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 48,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 50,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 52,
+      "c0": 2,
+      "c1": 5
+    },
+    {
+      "kind": "platform",
+      "row": 52,
+      "c0": 9,
+      "c1": 11
+    },
+    {
+      "kind": "platform",
+      "row": 55,
+      "c0": 10,
+      "c1": 11
+    },
+    {
+      "kind": "block",
+      "row": 0,
+      "c0": 1,
+      "c1": 19
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 1
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 2
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 3
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 3
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 4
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 4
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 5
+    },
+    {
+      "kind": "block",
+      "c": 4,
+      "r": 5
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 5
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 6
+    },
+    {
+      "kind": "block",
+      "row": 6,
+      "c0": 4,
+      "c1": 5
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 6
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 7
+    },
+    {
+      "kind": "block",
+      "row": 7,
+      "c0": 4,
+      "c1": 6
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 7
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 8
+    },
+    {
+      "kind": "block",
+      "row": 8,
+      "c0": 4,
+      "c1": 13
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 8
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 9
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 9
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 10
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 10
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 11
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 11
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 12
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 12
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 13
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 13
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 14
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 14
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 15
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 15
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 16
+    },
+    {
+      "kind": "block",
+      "row": 16,
+      "c0": 11,
+      "c1": 13
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 16
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 17
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 17
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 18
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 18
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 19
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 19
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 20
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 20
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 21
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 21
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 22
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 22
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 23
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 23
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 24
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 24
+    },
+    {
+      "kind": "block",
+      "row": 25,
+      "c0": 1,
+      "c1": 8
+    },
+    {
+      "kind": "block",
+      "row": 25,
+      "c0": 12,
+      "c1": 19
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 26
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 26
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 27
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 27
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 28
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 28
+    },
+    {
+      "kind": "block",
+      "row": 29,
+      "c0": 1,
+      "c1": 7
+    },
+    {
+      "kind": "block",
+      "row": 29,
+      "c0": 11,
+      "c1": 16
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 29
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 30
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 30
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 31
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 31
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 32
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 32
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 33
+    },
+    {
+      "kind": "block",
+      "row": 33,
+      "c0": 5,
+      "c1": 19
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 34
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 34
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 35
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 35
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "c": 5,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "c": 8,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "c": 11,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "c": 14,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 36
+    },
+    {
+      "kind": "block",
+      "row": 37,
+      "c0": 1,
+      "c1": 16
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 37
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 38
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 38
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 39
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 39
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 40
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 40
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 41
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 41
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 42
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 42
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 43
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 43
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 44
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 44
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 45
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 45
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 46
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 46
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 47
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 47
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 48
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 48
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 49
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 49
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 50
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 50
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 51
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 51
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 52
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 52
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 53
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 53
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 54
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 54
+    },
+    {
+      "kind": "block",
+      "row": 55,
+      "c0": 1,
+      "c1": 9
+    },
+    {
+      "kind": "block",
+      "row": 55,
+      "c0": 12,
+      "c1": 19
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 56
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 56
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 57
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 57
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 58
+    },
+    {
+      "kind": "block",
+      "row": 58,
+      "c0": 4,
+      "c1": 19
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 59
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 59
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 60
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 60
+    },
+    {
+      "kind": "block",
+      "row": 61,
+      "c0": 1,
+      "c1": 15
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 61
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 62
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 62
+    },
+    {
+      "kind": "block",
+      "c": 1,
+      "r": 63
+    },
+    {
+      "kind": "block",
+      "c": 19,
+      "r": 63
+    },
+    {
+      "kind": "block",
+      "row": 64,
+      "c0": 0,
+      "c1": 19
+    }
+  ],
+  "spikes": [
+    {
+      "c": 11,
+      "row": 15
+    },
+    {
+      "c": 12,
+      "row": 15
+    },
+    {
+      "c": 13,
+      "row": 15
+    },
+    {
+      "c": 17,
+      "row": 32
+    },
+    {
+      "c": 18,
+      "row": 32
+    },
+    {
+      "c": 2,
+      "row": 54
+    },
+    {
+      "c": 3,
+      "row": 54
+    },
+    {
+      "c": 4,
+      "row": 54
+    },
+    {
+      "c": 5,
+      "row": 54
+    },
+    {
+      "c": 6,
+      "row": 54
+    },
+    {
+      "c": 7,
+      "row": 54
+    },
+    {
+      "c": 8,
+      "row": 54
+    },
+    {
+      "c": 9,
+      "row": 54
+    },
+    {
+      "c": 12,
+      "row": 54
+    },
+    {
+      "c": 13,
+      "row": 54
+    },
+    {
+      "c": 14,
+      "row": 54
+    },
+    {
+      "c": 15,
+      "row": 54
+    },
+    {
+      "c": 16,
+      "row": 54
+    },
+    {
+      "c": 17,
+      "row": 54
+    },
+    {
+      "c": 18,
+      "row": 54
+    },
+    {
+      "c": 12,
+      "row": 57
+    },
+    {
+      "c": 13,
+      "row": 57
+    },
+    {
+      "c": 14,
+      "row": 57
+    },
+    {
+      "c": 15,
+      "row": 57
+    },
+    {
+      "c": 16,
+      "row": 57
+    },
+    {
+      "c": 17,
+      "row": 57
+    },
+    {
+      "c": 18,
+      "row": 57
+    }
+  ],
+  "enemies": [],
+  "goalOffsetX": 18,
+  "manualGround": true,
+  "goal": {
+    "c": 0,
+    "r": 63
+  },
+  "assets": {
+    "background": "/RUN/background.png",
+    "player": [
+      "/RUN/%E3%83%A1%E3%82%A4%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC/sprite_01.png",
+      "/RUN/%E3%83%A1%E3%82%A4%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC/sprite_02.png",
+      "/RUN/%E3%83%A1%E3%82%A4%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC/sprite_03.png",
+      "/RUN/%E3%83%A1%E3%82%A4%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC/sprite_04.png"
+    ],
+    "playerHurt": "/RUN/%E3%83%A1%E3%82%A4%E3%83%B3%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC/sprite_11.png",
+    "slime": [
+      "/RUN/kenney_new-platformer-pack-1/Sprites/Enemies/Default/slime_normal_walk_a.png",
+      "/RUN/kenney_new-platformer-pack-1/Sprites/Enemies/Default/slime_normal_walk_b.png"
+    ],
+    "tiles": {
+      "ground": "/RUN/tiles/graveyard/ground_fill.png",
+      "groundTop": "/RUN/tiles/graveyard/ground_top.png",
+      "groundTopLeft": "/RUN/tiles/graveyard/ground_top_left.png",
+      "groundTopRight": "/RUN/tiles/graveyard/ground_top_right.png",
+      "brick": "/RUN/tiles/graveyard/brick.png",
+      "platform": "/RUN/graveyardtilesetnew/png/Tiles/snowMid.png",
+      "block": "/RUN/graveyardtilesetnew/png/Objects/Crate.png",
+      "spike": "/RUN/tiles/graveyard/spike.png",
+      "flag": "/RUN/tiles/graveyard/flag.png"
+    }
+  }
+}'::jsonb
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  map_data = EXCLUDED.map_data,
+  updated_at = now();
+
+INSERT INTO public.survival_stages (
+  map_category, stage_number, stage_type, play_mode, name, name_en, difficulty,
+  chord_suffix, chord_display_name, chord_display_name_en,
+  root_pattern, root_pattern_name, root_pattern_name_en,
+  block_key, is_mixed_stage, mixed_group_key, chord_progression,
+  lesson_only, run_map_id, run_time_limit_sec, run_dialogue_script,
+  production_staff_hint_mode, production_keyboard_hint_mode
+) VALUES (
+  'basic',
+  115,
+  'progression',
+  'code_run',
+  '開発: コードラン5 スノー登攀',
+  'Dev: Code Run 5 Snow Climb',
+  'easy',
+  '',
+  'コードラン5',
+  'Code Run 5',
+  NULL,
+  '',
+  '',
+  'code_run',
+  false,
+  NULL,
+  '[
+    {"name":"Dm7(9)","voicing":[53,60,64,69],"voicing_names":["F3","C4","E4","A4"],"key_fifths":0,"voicing_staves":[2,2,1,1]},
+    {"name":"G7(9.13)","voicing":[53,57,59,64],"voicing_names":["F3","A3","B3","E4"],"key_fifths":0,"voicing_staves":[2,2,2,1]},
+    {"name":"CM7(9)","voicing":[52,55,59,62],"voicing_names":["E3","G3","B3","D4"],"key_fifths":0,"voicing_staves":[2,2,2,2]}
+  ]'::jsonb,
+  false,
+  'snow_climb_run_01',
+  150,
+  '{
+    "lines": [
+      {"at_seconds": 2, "speaker": "fai", "text": "細い塔を登って、左端の旗を目指そう。", "text_en": "Climb the narrow tower and aim for the flag on the left."},
+      {"at_seconds": 10, "speaker": "jajii", "text": "雪の足場を順に使え。落ちたら下まで戻るぞ。", "text_en": "Use the snow platforms in order. Fall and you drop all the way down."},
+      {"at_seconds": 28, "speaker": "fai", "text": "スパイク帯の上は慎重に。ゴールはスタート付近だよ。", "text_en": "Be careful over spike lanes. The goal is near where you started."}
+    ]
+  }'::jsonb,
+  'fade_15s',
+  'fade_15s'
+)
+ON CONFLICT (map_category, stage_number) DO UPDATE SET
+  stage_type = EXCLUDED.stage_type,
+  play_mode = EXCLUDED.play_mode,
+  name = EXCLUDED.name,
+  name_en = EXCLUDED.name_en,
+  difficulty = EXCLUDED.difficulty,
+  chord_suffix = EXCLUDED.chord_suffix,
+  chord_display_name = EXCLUDED.chord_display_name,
+  chord_display_name_en = EXCLUDED.chord_display_name_en,
+  root_pattern = EXCLUDED.root_pattern,
+  root_pattern_name = EXCLUDED.root_pattern_name,
+  root_pattern_name_en = EXCLUDED.root_pattern_name_en,
+  block_key = EXCLUDED.block_key,
+  is_mixed_stage = EXCLUDED.is_mixed_stage,
+  mixed_group_key = EXCLUDED.mixed_group_key,
+  chord_progression = EXCLUDED.chord_progression,
+  lesson_only = EXCLUDED.lesson_only,
+  run_map_id = EXCLUDED.run_map_id,
+  run_time_limit_sec = EXCLUDED.run_time_limit_sec,
+  run_dialogue_script = EXCLUDED.run_dialogue_script,
+  production_staff_hint_mode = EXCLUDED.production_staff_hint_mode,
+  production_keyboard_hint_mode = EXCLUDED.production_keyboard_hint_mode,
+  updated_at = now();
+
+INSERT INTO public.lessons (
+  id,
+  course_id,
+  title,
+  title_en,
+  description,
+  description_en,
+  premium_only,
+  order_index,
+  block_number,
+  block_name,
+  block_name_en,
+  nav_links,
+  assignment_description,
+  assignment_description_en
+)
+SELECT
+  uuid_generate_v5('a0000000-0000-4000-8000-000000000001'::uuid, 'dev-survival-code-run-05-snow-climb-lesson'),
+  uuid_generate_v5('a0000000-0000-4000-8000-000000000001'::uuid, 'course-developer-test'),
+  'サバイバル: コードラン5 スノー登攀（テスト）',
+  'Survival: Code Run 5 Snow Climb (test)',
+  '縦長タワーを雪の足場で登り、左端の旗に触れる開発者向けコードランのテスト課題です。',
+  'Developer test assignment for a tall vertical CodeRun tower with snow platforms.',
+  false,
+  COALESCE(mx.max_o, 0) + 1,
+  1,
+  'テスト',
+  'Test',
+  '[]'::jsonb,
+  '塔を登り、左端の旗に触れてください。足場は雪タイルです。',
+  'Climb the tower and touch the flag on the left. Platforms use snow tiles.'
+FROM (
+  SELECT MAX(order_index) AS max_o
+  FROM public.lessons
+  WHERE course_id = uuid_generate_v5('a0000000-0000-4000-8000-000000000001'::uuid, 'course-developer-test')
+) mx
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  title_en = EXCLUDED.title_en,
+  description = EXCLUDED.description,
+  description_en = EXCLUDED.description_en,
+  assignment_description = EXCLUDED.assignment_description,
+  assignment_description_en = EXCLUDED.assignment_description_en;
+
+INSERT INTO public.lesson_songs (
+  id,
+  lesson_id,
+  song_id,
+  order_index,
+  clear_conditions,
+  is_fantasy,
+  fantasy_stage_id,
+  is_survival,
+  survival_stage_number,
+  survival_map_category,
+  is_ear_training,
+  ear_training_stage_id,
+  title,
+  title_en
+) VALUES (
+  uuid_generate_v5('a0000000-0000-4000-8000-000000000001'::uuid, 'dev-survival-code-run-05-snow-climb-lsong'),
+  uuid_generate_v5('a0000000-0000-4000-8000-000000000001'::uuid, 'dev-survival-code-run-05-snow-climb-lesson'),
+  NULL,
+  0,
+  '{"count":1,"rank":"C"}'::jsonb,
+  FALSE,
+  NULL,
+  TRUE,
+  115,
+  'basic',
+  FALSE,
+  NULL,
+  '課題（コードラン5 スノー登攀）',
+  'Assignment (Code Run 5 Snow Climb)'
+)
+ON CONFLICT (id) DO UPDATE SET
+  is_survival = EXCLUDED.is_survival,
+  survival_stage_number = EXCLUDED.survival_stage_number,
+  survival_map_category = EXCLUDED.survival_map_category,
+  clear_conditions = EXCLUDED.clear_conditions,
+  title = EXCLUDED.title,
+  title_en = EXCLUDED.title_en;
+
+COMMIT;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

開発者テストコースに、縦長タワー型の Code Run ステージ「スノー登攀」を追加しました。提供レイアウトの `worldHeight: 500` は `worldTilesHigh(65) × tileSize(48) = 3120` に修正しています。

## 変更内容

- **DB**: `snow_climb_run_01` マップ、`basic` ステージ 115、開発者テスト課題（コードラン5）
- **足場スプライト**: `platform` → `/RUN/graveyardtilesetnew/png/Tiles/snowMid.png`
- **worldHeight 導出**: ランタイムは `worldTilesHigh` があれば `× tileSize` を優先。管理画面・静的エディタはエクスポート時に同式で自動設定（手入力フィールドは読み取り専用）

## 寸法メモ

| 項目 | 値 |
|------|-----|
| 横タイル | 20 → worldWidth 960px（viewWidth と一致） |
| 縦タイル | 65 → worldHeight **3120**px（旧 500 は誤り） |
| 制限時間 | 150秒 |

## チェック

- `npx tsc --noEmit` OK
- `npm run lint` OK
- `npm test`（codeRunMapEditorLogic / CodeRunEngine）40 passed
- `npx ts-prune` 新規未使用 export なし

## パフォーマンス

新規 per-frame / timer / 高頻度 React state / ホットパス割当はなし。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ca05ece-6d77-4155-a58e-abbe8c52ab3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ca05ece-6d77-4155-a58e-abbe8c52ab3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

