### PR TITLE
fix(admin): コードランエディタで床セル上にトゲを配置可能に

### DIFF
--- a/src/components/admin/CodeRunMapEditor.tsx
+++ b/src/components/admin/CodeRunMapEditor.tsx
@@ -48,6 +48,7 @@ const CodeRunMapEditor: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [settings, setSettings] = useState<CodeRunEditorSettings>(defaultEditorSettings);
   const [cells, setCells] = useState<Map<string, string>>(() => new Map());
+  const [spikeCells, setSpikeCells] = useState<Set<string>>(() => new Set());
   const [pitColumns, setPitColumns] = useState<Set<number>>(() => new Set());
   const [enemies, setEnemies] = useState<CodeRunEnemyPlacement[]>([]);
   const [spawn, setSpawn] = useState<CodeRunGridPoint | null>({ c: 2, r: 9 });
@@ -63,8 +64,8 @@ const CodeRunMapEditor: React.FC = () => {
   const displayTile = Math.round(DISPLAY_TILE_BASE * zoom);
 
   const layoutJson = useMemo(
-    () => buildMapLayoutJson(cells, pitColumns, enemies, spawn, goal, settings),
-    [cells, pitColumns, enemies, spawn, goal, settings],
+    () => buildMapLayoutJson(cells, spikeCells, pitColumns, enemies, spawn, goal, settings),
+    [cells, spikeCells, pitColumns, enemies, spawn, goal, settings],
   );
 
   const syncJson = useCallback(() => {
@@ -82,6 +83,7 @@ const CodeRunMapEditor: React.FC = () => {
     if (!ctx) return;
     drawCodeRunMapCanvas(ctx, canvas.width, canvas.height, {
       cells,
+      spikeCells,
       pitColumns,
       enemies,
       spawn,
@@ -90,7 +92,7 @@ const CodeRunMapEditor: React.FC = () => {
       displayTile,
       selectedEnemyIndex,
     });
-  }, [cells, pitColumns, enemies, spawn, goal, settings, displayTile, selectedEnemyIndex]);
+  }, [cells, spikeCells, pitColumns, enemies, spawn, goal, settings, displayTile, selectedEnemyIndex]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -141,6 +143,11 @@ const CodeRunMapEditor: React.FC = () => {
           next.delete(cellKey(c, r));
           return next;
         });
+        setSpikeCells((prev) => {
+          const next = new Set(prev);
+          next.delete(cellKey(c, r));
+          return next;
+        });
         break;
       case 'pit':
         setPitColumns((prev) => {
@@ -151,10 +158,10 @@ const CodeRunMapEditor: React.FC = () => {
         });
         break;
       case 'spike':
-        setCells((prev) => {
-          const next = new Map(prev);
+        setSpikeCells((prev) => {
+          const next = new Set(prev);
           if (erase) next.delete(cellKey(c, r));
-          else next.set(cellKey(c, r), 'spike');
+          else next.add(cellKey(c, r));
           return next;
         });
         break;
@@ -262,6 +269,7 @@ const CodeRunMapEditor: React.FC = () => {
   const clearAll = () => {
     if (!window.confirm('マップをすべて消去しますか？')) return;
     setCells(new Map());
+    setSpikeCells(new Set());
     setPitColumns(new Set());
     setEnemies([]);
     setSpawn({ c: 2, r: settings.groundRow });
@@ -274,6 +282,7 @@ const CodeRunMapEditor: React.FC = () => {
       const imported = parseMapLayoutJson(jsonText);
       setSettings(imported.settings);
       setCells(imported.cells);
+      setSpikeCells(imported.spikeCells);
       setPitColumns(imported.pitColumns);
       setEnemies(imported.enemies);
       setSpawn(imported.spawn);

--- a/src/components/admin/codeRunMap/codeRunMapEditorCanvas.ts
+++ b/src/components/admin/codeRunMap/codeRunMapEditorCanvas.ts
@@ -91,6 +91,7 @@ const drawEnemy = (
 
 export interface CodeRunEditorDrawParams {
   cells: ReadonlyMap<string, string>;
+  spikeCells: ReadonlySet<string>;
   pitColumns: ReadonlySet<number>;
   enemies: readonly CodeRunEnemyPlacement[];
   spawn: CodeRunGridPoint | null;
@@ -116,6 +117,7 @@ export const drawCodeRunMapCanvas = (
 ): void => {
   const {
     cells,
+    spikeCells,
     pitColumns,
     enemies,
     spawn,
@@ -141,12 +143,20 @@ export const drawCodeRunMapCanvas = (
   }
 
   for (const [key, kind] of cells) {
-    if (!isTileKind(kind) && kind !== 'spike') continue;
+    if (!isTileKind(kind)) continue;
     const [cs, rs] = key.split(',');
     const c = Number(cs);
     const row = Number(rs);
     if (!Number.isFinite(c) || !Number.isFinite(row)) continue;
     drawTile(ctx, c, row, kind, ts);
+  }
+
+  for (const key of spikeCells) {
+    const [cs, rs] = key.split(',');
+    const c = Number(cs);
+    const row = Number(rs);
+    if (!Number.isFinite(c) || !Number.isFinite(row)) continue;
+    drawTile(ctx, c, row, 'spike', ts);
   }
 
   if (!settings.manualGround) {

--- a/src/components/admin/codeRunMap/codeRunMapEditorLogic.test.ts
+++ b/src/components/admin/codeRunMap/codeRunMapEditorLogic.test.ts
@@ -22,12 +22,36 @@ describe('codeRunMapEditorLogic', () => {
       [cellKey(3, 5), 'ground'],
       [cellKey(4, 5), 'ground'],
     ]);
-    const json = buildMapLayoutJson(cells, new Set(), [], { c: 1, r: 5 }, null, settings);
+    const json = buildMapLayoutJson(cells, new Set(), new Set(), [], { c: 1, r: 5 }, null, settings);
     expect(json.manualGround).toBe(true);
     expect(json.solids).toEqual([{ kind: 'ground', row: 5, c0: 2, c1: 4 }]);
 
     const imported = parseMapLayoutJson(JSON.stringify(json));
     expect(imported.settings.manualGround).toBe(true);
     expect(imported.cells.get(cellKey(2, 5))).toBe('ground');
+  });
+
+  it('床セル上にトゲを重ねても床は残る', () => {
+    const settings = { ...defaultEditorSettings(), manualGround: true, groundRow: 9 };
+    const cells = new Map<string, string>([
+      [cellKey(4, 9), 'ground'],
+      [cellKey(4, 10), 'ground'],
+    ]);
+    const spikeCells = new Set([cellKey(4, 9), cellKey(5, 9)]);
+    const json = buildMapLayoutJson(cells, spikeCells, new Set(), [], null, null, settings);
+
+    expect(json.solids).toEqual([
+      { kind: 'ground', c: 4, r: 9 },
+      { kind: 'ground', c: 4, r: 10 },
+    ]);
+    expect(json.spikes).toEqual([
+      { c: 4, row: 9 },
+      { c: 5, row: 9 },
+    ]);
+
+    const imported = parseMapLayoutJson(JSON.stringify(json));
+    expect(imported.cells.get(cellKey(4, 9))).toBe('ground');
+    expect(imported.spikeCells.has(cellKey(4, 9))).toBe(true);
+    expect(imported.spikeCells.has(cellKey(5, 9))).toBe(true);
   });
 });

--- a/src/components/admin/codeRunMap/codeRunMapEditorLogic.ts
+++ b/src/components/admin/codeRunMap/codeRunMapEditorLogic.ts
@@ -65,19 +65,23 @@ export const exportSolids = (
   return solids;
 };
 
-export const exportSpikes = (
-  cells: ReadonlyMap<string, string>,
-  gridRows: number,
-  worldTilesWide: number,
-  groundRow: number,
-): Record<string, unknown>[] => {
+export const exportSpikes = (spikeCells: ReadonlySet<string>): Record<string, unknown>[] => {
   const spikes: Record<string, unknown>[] = [];
-  for (let r = 0; r < gridRows; r += 1) {
-    for (let c = 0; c < worldTilesWide; c += 1) {
-      if (cells.get(cellKey(c, r)) === 'spike') spikes.push({ c, row: r });
-    }
+  for (const key of spikeCells) {
+    const [cs, rs] = key.split(',');
+    const c = Number(cs);
+    const r = Number(rs);
+    if (!Number.isFinite(c) || !Number.isFinite(r)) continue;
+    spikes.push({ c, row: r });
   }
-  return spikes;
+  return spikes.sort((a, b) => {
+    const rowA = typeof a.row === 'number' ? a.row : 0;
+    const rowB = typeof b.row === 'number' ? b.row : 0;
+    if (rowA !== rowB) return rowA - rowB;
+    const colA = typeof a.c === 'number' ? a.c : 0;
+    const colB = typeof b.c === 'number' ? b.c : 0;
+    return colA - colB;
+  });
 };
 
 export const exportEnemies = (
@@ -99,6 +103,7 @@ export const findEnemyIndexAt = (
 
 export const buildMapLayoutJson = (
   cells: ReadonlyMap<string, string>,
+  spikeCells: ReadonlySet<string>,
   pitColumns: ReadonlySet<number>,
   enemies: readonly CodeRunEnemyPlacement[],
   spawn: CodeRunGridPoint | null,
@@ -117,7 +122,7 @@ export const buildMapLayoutJson = (
     spawn: spawn ?? { c: 2, r: settings.groundRow },
     pits: mergePits(pitColumns),
     solids: exportSolids(cells, settings.gridRows, settings.worldTilesWide),
-    spikes: exportSpikes(cells, settings.gridRows, settings.worldTilesWide, settings.groundRow),
+    spikes: exportSpikes(spikeCells),
     enemies: exportEnemies(enemies, settings.groundRow),
     goalOffsetX: settings.goalOffsetX,
   };
@@ -142,6 +147,7 @@ const nonNegNumber = (v: unknown, fallback: number): number => (
 export interface ImportedMapState {
   settings: CodeRunEditorSettings;
   cells: Map<string, string>;
+  spikeCells: Set<string>;
   pitColumns: Set<number>;
   enemies: CodeRunEnemyPlacement[];
   spawn: CodeRunGridPoint | null;
@@ -225,13 +231,14 @@ export const parseMapLayoutJson = (raw: string): ImportedMapState => {
     if (typeof s === 'object' && s !== null) applySolidPlacement(cells, s as Record<string, unknown>);
   }
 
+  const spikeCells = new Set<string>();
   const spikes = Array.isArray(source.spikes) ? source.spikes : [];
   for (const sp of spikes) {
     if (typeof sp !== 'object' || sp === null) continue;
     const row = sp as Record<string, unknown>;
     if (typeof row.c !== 'number') continue;
     const r = typeof row.row === 'number' ? row.row : groundRow;
-    cells.set(cellKey(row.c, r), 'spike');
+    spikeCells.add(cellKey(row.c, r));
   }
 
   let spawn: CodeRunGridPoint | null = null;
@@ -263,7 +270,7 @@ export const parseMapLayoutJson = (raw: string): ImportedMapState => {
 
   if (!settings.manualGround) applyAutoGroundPreview(cells, pitColumns, settings);
 
-  return { settings, cells, pitColumns, enemies, spawn, goal };
+  return { settings, cells, spikeCells, pitColumns, enemies, spawn, goal };
 };
 
 export const defaultEnemyPlacement = (c: number, r: number): CodeRunEnemyPlacement => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

コードラン管理画面のマップエディタで、床タイルがあるセルにトゲを置くと床が消えてしまい、「床の上／隣にトゲを置けない」ように見える不具合を修正しました。

## 原因

エディタが `cells` Map 1つに床・レンガ・トゲなどすべてを格納していたため、同一グリッドセルに床とトゲを共存できませんでした。ゲーム本体は `solids` と `spikes` を別配列で持つ設計です。

## 対応

- トゲ専用の `spikeCells`（`Set<string>`）を追加
- 配置・消去・描画・JSON 入出力を `spikeCells` 経由に変更
- 床の上にトゲを重ねても `solids` の床はエクスポートに残る

## テスト

- `床セル上にトゲを重ねても床は残る` を追加
- `npm test`（対象テスト）、`tsc --noEmit`、`npm run lint` 通過

## パフォーマンス

ゲームランタイムへの変更なし（管理画面の状態管理のみ）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b8a3368-9006-4cc5-990c-96c6be1d0dd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b8a3368-9006-4cc5-990c-96c6be1d0dd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

