### PR TITLE
fix: レッスン詳細画面の前後ナビを一覧と同じロック判定に揃える

### DIFF
--- a/src/components/lesson/LessonDetailPage.tsx
+++ b/src/components/lesson/LessonDetailPage.tsx
@@ -274,6 +274,7 @@ const LessonDetailPage: React.FC = () => {
       }
 
       // 直接アクセス時のコース受講可否ガード（premium_onlyを唯一の判定）
+      let isMainQuestCourse = false;
       if (lessonData?.course_id && profile?.id) {
         const includeDevCourses = shouldIncludeDeveloperLessonCoursesForUser(profile.isAdmin);
         const [course, completedCourses] = await Promise.all([
@@ -286,6 +287,7 @@ const LessonDetailPage: React.FC = () => {
         if (course) {
           setShouldHideVideos(false);
           setCourseDifficultyTier(normalizeCourseDifficultyTier(course.difficulty_tier));
+          isMainQuestCourse = course.is_main_course === true;
           const access = canAccessCourse(course, effectiveRank, completedCourses, isEnglishCopy);
           if (!access.canAccess) {
             pushToast(
@@ -307,7 +309,7 @@ const LessonDetailPage: React.FC = () => {
             window.location.hash = '#lessons';
             return;
           }
-          setLessonCourseIsMainQuest(course.is_main_course === true);
+          setLessonCourseIsMainQuest(isMainQuestCourse);
         } else {
           setCourseDifficultyTier(null);
           setLessonCourseIsMainQuest(false);
@@ -323,7 +325,15 @@ const LessonDetailPage: React.FC = () => {
       // ナビゲーション情報を取得
       if (lessonData?.course_id) {
           try {
-            const navInfo = await getLessonNavigationInfo(targetLessonId, lessonData.course_id, effectiveRank);
+            const navInfo = await getLessonNavigationInfo(
+              targetLessonId,
+              lessonData.course_id,
+              effectiveRank,
+              {
+                isMainQuest: isMainQuestCourse,
+                isPremiumMember,
+              },
+            );
             if (!isStale()) {
               setNavigationInfo(navInfo);
             }
@@ -451,7 +461,16 @@ const LessonDetailPage: React.FC = () => {
       if (lesson.course_id) {
         try {
           clearNavigationCacheForCourse(lesson.course_id);
-          const freshNavInfo = await getLessonNavigationInfo(lessonId, lesson.course_id, effectiveRank, { forceRefresh: true });
+          const freshNavInfo = await getLessonNavigationInfo(
+            lessonId,
+            lesson.course_id,
+            effectiveRank,
+            {
+              forceRefresh: true,
+              isMainQuest: lessonCourseIsMainQuest,
+              isPremiumMember,
+            },
+          );
           setNavigationInfo(freshNavInfo);
           const courseLessons = await fetchLessonsByCourse(lesson.course_id);
           const modalKind = getQuestCompletionModalKind(

--- a/src/utils/__tests__/lessonNavigation.test.ts
+++ b/src/utils/__tests__/lessonNavigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { Lesson } from '@/types';
+import type { Lesson, LessonProgress } from '@/types';
 import {
+  computeLessonNavigationInfo,
   getQuestCompletionModalKind,
   isLastLessonInBlock,
   sortLessonsByOrder,
@@ -18,6 +19,10 @@ const lesson = (id: string, orderIndex: number, blockNumber = 1): Lesson => ({
   updated_at: '',
 });
 
+const progress = (lessonId: string, completed: boolean): Pick<LessonProgress, 'completed'> => ({
+  completed,
+});
+
 const navInfo = (
   next: Lesson | null,
   canGoNext: boolean,
@@ -31,6 +36,90 @@ const navInfo = (
     hasAccessToPrevious: false,
     hasAccessToNext: canGoNext,
   },
+});
+
+describe('computeLessonNavigationInfo', () => {
+  const l1 = lesson('l1', 0, 1);
+  const l2 = lesson('l2', 1, 1);
+  const l3 = lesson('l3', 0, 2);
+
+  it('メインクエスト: block1 lesson1 未完了 → lesson2 へ進めない', () => {
+    const result = computeLessonNavigationInfo(
+      'l1',
+      'course-1',
+      [l1, l2],
+      {},
+      { isMainQuest: true, isPremiumMember: true },
+    );
+    expect(result.nextLesson?.id).toBe('l2');
+    expect(result.canGoNext).toBe(false);
+  });
+
+  it('メインクエスト: block1 lesson1 完了 → lesson2 へ進める', () => {
+    const result = computeLessonNavigationInfo(
+      'l1',
+      'course-1',
+      [l1, l2],
+      { l1: progress('l1', true) },
+      { isMainQuest: true, isPremiumMember: true },
+    );
+    expect(result.nextLesson?.id).toBe('l2');
+    expect(result.canGoNext).toBe(true);
+  });
+
+  it('メインクエスト: フリー会員 block1 最終完了 → block2 lesson1 へ進めない', () => {
+    const block1First = lesson('b1-first', 0, 1);
+    const block1Last = lesson('b1-last', 1, 1);
+    const block2First = lesson('b2-first', 2, 2);
+    const result = computeLessonNavigationInfo(
+      'b1-last',
+      'course-1',
+      [block1First, block1Last, block2First],
+      {
+        'b1-first': progress('b1-first', true),
+        'b1-last': progress('b1-last', true),
+      },
+      { isMainQuest: true, isPremiumMember: false },
+    );
+    expect(result.nextLesson?.id).toBe('b2-first');
+    expect(result.canGoNext).toBe(false);
+  });
+
+  it('目的別コース: 同一ブロック内は順番未完了でも次へ進める', () => {
+    const result = computeLessonNavigationInfo(
+      'l1',
+      'course-1',
+      [l1, l2],
+      {},
+      { isMainQuest: false, isPremiumMember: false },
+    );
+    expect(result.nextLesson?.id).toBe('l2');
+    expect(result.canGoNext).toBe(true);
+  });
+
+  it('最後のレッスンでは canGoNext が false', () => {
+    const result = computeLessonNavigationInfo(
+      'l2',
+      'course-1',
+      [l1, l2],
+      { l1: progress('l1', true), l2: progress('l2', true) },
+      { isMainQuest: true, isPremiumMember: true },
+    );
+    expect(result.nextLesson).toBeNull();
+    expect(result.canGoNext).toBe(false);
+  });
+
+  it('最初のレッスンでは canGoPrevious が false', () => {
+    const result = computeLessonNavigationInfo(
+      'l1',
+      'course-1',
+      [l1, l2],
+      {},
+      { isMainQuest: true, isPremiumMember: true },
+    );
+    expect(result.previousLesson).toBeNull();
+    expect(result.canGoPrevious).toBe(false);
+  });
 });
 
 describe('isLastLessonInBlock', () => {

--- a/src/utils/lessonNavigation.ts
+++ b/src/utils/lessonNavigation.ts
@@ -1,9 +1,10 @@
-import { Lesson } from '@/types';
+import { Lesson, LessonProgress } from '@/types';
 import { lessonDisplayBlockName } from '@/utils/lessonCopy';
 import { fetchLessonsByCourse } from '@/platform/supabaseLessons';
 import { fetchUserLessonProgress } from '@/platform/supabaseLessonProgress';
 import { clearCacheByPattern } from '@/platform/supabaseClient';
 import { buildLessonAccessGraph, MembershipRank } from '@/utils/lessonAccess';
+import { applyMainQuestFreeTierLocks } from '@/utils/mainQuestFreeTier';
 
 export interface LessonNavigationInfo {
   previousLesson: Lesson | null;
@@ -17,12 +18,17 @@ export interface LessonNavigationInfo {
   };
 }
 
+export interface LessonNavigationOptions {
+  forceRefresh?: boolean;
+  isMainQuest?: boolean;
+  isPremiumMember?: boolean;
+}
+
 // ナビゲーション情報のキャッシュ（メモリ内）
 const navigationCache = new Map<string, {
   data: LessonNavigationInfo;
   expires: number;
   courseId: string;
-  rank: MembershipRank | null | undefined;
 }>();
 
 const NAVIGATION_CACHE_TTL = 5 * 60 * 1000; // 5分
@@ -84,6 +90,77 @@ export function cleanupLessonNavigationCache(currentLessonId: string, courseId: 
   cleanupNavigationCache();
 }
 
+function buildNavigationCacheKey(
+  courseId: string,
+  currentLessonId: string,
+  userRank: MembershipRank | null | undefined,
+  isMainQuest: boolean,
+  isPremiumMember: boolean,
+): string {
+  return [
+    courseId,
+    currentLessonId,
+    userRank ?? 'no-rank',
+    isMainQuest ? 'main' : 'course',
+    isPremiumMember ? 'premium' : 'free',
+  ].join(':');
+}
+
+/**
+ * レッスン一覧と進捗からナビゲーション情報を算出（純粋関数）
+ */
+export function computeLessonNavigationInfo(
+  currentLessonId: string,
+  courseId: string,
+  lessons: readonly Lesson[],
+  progressMap: Record<string, Pick<LessonProgress, 'completed'> | undefined>,
+  options: { isMainQuest: boolean; isPremiumMember: boolean },
+): LessonNavigationInfo {
+  const sortedLessons = sortLessonsByOrder([...lessons]);
+  const currentIndex = sortedLessons.findIndex((lesson) => lesson.id === currentLessonId);
+
+  if (currentIndex === -1) {
+    throw new Error('現在のレッスンが見つかりません');
+  }
+
+  const previousLesson = currentIndex > 0 ? sortedLessons[currentIndex - 1] : null;
+  const nextLesson = currentIndex < sortedLessons.length - 1 ? sortedLessons[currentIndex + 1] : null;
+
+  let accessGraph = buildLessonAccessGraph({
+    lessons: sortedLessons,
+    progressMap,
+    enforceSequentialWithinBlocks: options.isMainQuest,
+  });
+
+  if (options.isMainQuest) {
+    accessGraph = applyMainQuestFreeTierLocks(
+      accessGraph,
+      sortedLessons,
+      options.isPremiumMember,
+    );
+  }
+
+  const hasAccessToPrevious = previousLesson
+    ? accessGraph.lessonStates[previousLesson.id]?.isUnlocked === true
+    : false;
+
+  const hasAccessToNext = nextLesson
+    ? accessGraph.lessonStates[nextLesson.id]?.isUnlocked === true
+    : false;
+
+  return {
+    previousLesson,
+    nextLesson,
+    canGoPrevious: previousLesson !== null && hasAccessToPrevious,
+    canGoNext: nextLesson !== null && hasAccessToNext,
+    course: {
+      id: courseId,
+      hasAccessToPrevious,
+      hasAccessToNext,
+    },
+  };
+}
+
 /**
  * 現在のレッスンからナビゲーション情報を取得（キャッシュ機能付き）
  */
@@ -91,9 +168,17 @@ export async function getLessonNavigationInfo(
   currentLessonId: string,
   courseId: string,
   userRank?: MembershipRank | null,
-  options?: { forceRefresh?: boolean }
+  options?: LessonNavigationOptions,
 ): Promise<LessonNavigationInfo> {
-  const cacheKey = `${courseId}:${currentLessonId}:${userRank ?? 'no-rank'}`;
+  const isMainQuest = options?.isMainQuest === true;
+  const isPremiumMember = options?.isPremiumMember === true;
+  const cacheKey = buildNavigationCacheKey(
+    courseId,
+    currentLessonId,
+    userRank,
+    isMainQuest,
+    isPremiumMember,
+  );
   const now = Date.now();
   
   if (!options?.forceRefresh) {
@@ -109,61 +194,29 @@ export async function getLessonNavigationInfo(
   cleanupNavigationCache();
   
   try {
-    // コース内の全レッスンを取得
-    const lessons = await fetchLessonsByCourse(courseId);
-    const userProgress = await fetchUserLessonProgress(courseId, undefined, { forceRefresh: !!options?.forceRefresh });
-    
-    // レッスンを order_index でソート
-    const sortedLessons = [...lessons].sort((a, b) => a.order_index - b.order_index);
-    
-    // 現在のレッスンのインデックスを取得
-    const currentIndex = sortedLessons.findIndex(lesson => lesson.id === currentLessonId);
-    
-    if (currentIndex === -1) {
-      throw new Error('現在のレッスンが見つかりません');
-    }
+    const [lessons, userProgress] = await Promise.all([
+      fetchLessonsByCourse(courseId),
+      fetchUserLessonProgress(courseId, undefined, { forceRefresh: !!options?.forceRefresh }),
+    ]);
 
-    const previousLesson = currentIndex > 0 ? sortedLessons[currentIndex - 1] : null;
-    const nextLesson = currentIndex < sortedLessons.length - 1 ? sortedLessons[currentIndex + 1] : null;
-
-    const progressMap: Record<string, typeof userProgress[number] | undefined> = {};
+    const progressMap: Record<string, Pick<LessonProgress, 'completed'> | undefined> = {};
     userProgress.forEach((progress) => {
       progressMap[progress.lesson_id] = progress;
     });
 
-    const accessGraph = buildLessonAccessGraph({
-      lessons: sortedLessons,
+    const navigationInfo = computeLessonNavigationInfo(
+      currentLessonId,
+      courseId,
+      lessons,
       progressMap,
-      userRank,
-    });
-
-    const hasAccessToPrevious = previousLesson
-      ? accessGraph.lessonStates[previousLesson.id]?.isUnlocked === true
-      : false;
-
-    const hasAccessToNext = nextLesson
-      ? accessGraph.lessonStates[nextLesson.id]?.isUnlocked === true
-      : false;
-
-    const navigationInfo: LessonNavigationInfo = {
-      previousLesson,
-      nextLesson,
-      canGoPrevious: previousLesson !== null && hasAccessToPrevious,
-      canGoNext: nextLesson !== null && hasAccessToNext,
-      course: {
-        id: courseId,
-        hasAccessToPrevious,
-        hasAccessToNext
-      }
-    };
+      { isMainQuest, isPremiumMember },
+    );
     
-    // キャッシュに保存
-      navigationCache.set(cacheKey, {
-        data: navigationInfo,
-        expires: now + NAVIGATION_CACHE_TTL,
-        courseId,
-        rank: userRank,
-      });
+    navigationCache.set(cacheKey, {
+      data: navigationInfo,
+      expires: now + NAVIGATION_CACHE_TTL,
+      courseId,
+    });
     
     return navigationInfo;
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Web版レッスン詳細画面の「前へ／次へ」ナビゲーションで、メインクエストの順番ロックと無料プランロックが一覧画面と不一致になっていた問題を修正しました。

## 変更内容

- `computeLessonNavigationInfo` を追加し、ナビゲーション可否の算出ロジックを純粋関数として集約
- メインクエストでは `enforceSequentialWithinBlocks: true` を適用
- メインクエストでは `applyMainQuestFreeTierLocks` も適用
- キャッシュキーに `isMainQuest` / `isPremiumMember` を含めるよう変更
- `LessonDetailPage` から詳細ロード時・完了後再取得時の両方で上記オプションを渡すよう変更

## テスト

`computeLessonNavigationInfo` に以下のケースを追加:

- メインクエスト block1 lesson1 未完了 → lesson2 へ進めない
- メインクエスト block1 lesson1 完了 → lesson2 へ進める
- メインクエスト フリー会員 block1 最終完了 → block2 lesson1 へ進めない
- 目的別コース 同一ブロック内は順番未完了でも次へ進める

## パフォーマンス影響

- 新規 per-frame ロジック: なし
- 新規 timer/interval: なし
- 高頻度 React state 更新: なし
- hot path での新規 allocation: なし（詳細ロード時・完了時のイベント駆動のみ）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c8cd99-2e29-4f4e-83ed-77d2323402e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c8cd99-2e29-4f4e-83ed-77d2323402e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

