### PR TITLE
fix: レッスン詳細ナビのロック統一 + Swift上部ナビ + blockedReason

### DIFF
--- a/ios/Jazzify/Main/LessonJourneyView.swift
+++ b/ios/Jazzify/Main/LessonJourneyView.swift
@@ -275,7 +275,9 @@ struct LessonJourneyView: View {
             )
         ) {
             if let lesson = launchLesson {
-                LessonDetailView(lesson: lesson)
+                LessonDetailView(lesson: lesson) { nextLesson in
+                    launchLesson = nextLesson
+                }
             }
         }
         .onChange(of: launchLesson == nil) { isNil in

--- a/ios/Jazzify/Main/LessonListView.swift
+++ b/ios/Jazzify/Main/LessonListView.swift
@@ -1582,6 +1582,7 @@ struct LessonDetailView: View {
     }
 
     @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
 
     let lesson: Lesson
     var onSelectLesson: ((Lesson) -> Void)? = nil
@@ -1607,6 +1608,8 @@ struct LessonDetailView: View {
     @State private var attachmentSharePayload: AttachmentSharePayload?
     @State private var attachmentActionBusyId: UUID?
     @State private var courseIsMainQuest = false
+    @State private var navigationState: LessonNavigationState?
+    @State private var isNavigating = false
     @State private var showSubscriptionSheet = false
     @State private var survivalCatalogPrefetchTick = 0
     @State private var questCompletionSheet: QuestCompletionSheetModel?
@@ -1663,6 +1666,9 @@ struct LessonDetailView: View {
             } else if let detail {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
+                        if let navigationState {
+                            lessonNavigationBar(navigationState)
+                        }
                         summaryCard(detail)
                         if let assignment = detail.localizedAssignmentDescription(locale), !assignment.isEmpty {
                             assignmentCard(assignment)
@@ -1705,6 +1711,11 @@ struct LessonDetailView: View {
             LessonMapAudio.shared.stop()
         }
         .task { await loadLessonDetail() }
+        .onChange(of: lesson.id) { _ in
+            navigationState = nil
+            isNavigating = false
+            Task { await loadLessonDetail() }
+        }
         .onChange(of: appState.locale) { _ in
             Task { await loadLessonDetail() }
         }
@@ -2586,10 +2597,22 @@ struct LessonDetailView: View {
                         userId: userId
                     )
                     isLessonCompleted = progressRows?.first(where: { $0.lessonId == lesson.id })?.completed ?? false
+
+                    if let lessons = try? await SupabaseService.shared.fetchLessons(courseId: courseId) {
+                        let completedIds = Set((progressRows ?? []).filter(\.completed).map(\.lessonId))
+                        navigationState = LessonNavigationHelpers.computeNavigationState(
+                            currentLesson: lesson,
+                            lessons: lessons,
+                            completedIds: completedIds,
+                            isMainQuest: courseIsMainQuest,
+                            isPremium: appState.isPremium
+                        )
+                    }
                 }
             } else {
                 requirementProgress = []
                 isLessonCompleted = false
+                navigationState = nil
             }
         } catch {
             detail = nil
@@ -2827,27 +2850,141 @@ struct LessonDetailView: View {
                 userId: userId
             )
             let completedIds = Set(progressRows.filter(\.completed).map(\.lessonId))
-            let accessGraph = LessonJourneyAccessGraph.build(lessons: sorted, completedIds: completedIds)
-            let next = LessonNavigationHelpers.nextLesson(after: lesson, in: sorted)
-            let canGoNext = next.map {
-                LessonNavigationHelpers.canOpenNextLesson(nextLesson: $0, accessGraph: accessGraph)
-            } ?? false
+            let navState = LessonNavigationHelpers.computeNavigationState(
+                currentLesson: lesson,
+                lessons: lessons,
+                completedIds: completedIds,
+                isMainQuest: courseIsMainQuest,
+                isPremium: appState.isPremium
+            )
             let kind = LessonNavigationHelpers.modalKind(
                 currentLesson: lesson,
                 sortedLessons: sorted,
-                nextLesson: next,
-                canGoNext: canGoNext
+                nextLesson: navState.nextLesson,
+                canGoNext: navState.canGoNext
             )
             guard kind != .none else { return }
             await MainActor.run {
+                navigationState = navState
                 questCompletionSheet = QuestCompletionSheetModel(
                     kind: kind,
                     chapterNumber: lesson.blockNumber ?? 1,
-                    nextLesson: next
+                    nextLesson: navState.nextLesson
                 )
             }
         } catch {
             /* モーダル表示失敗は非致命的 */
+        }
+    }
+
+    @ViewBuilder
+    private func lessonNavigationBar(_ navigationState: LessonNavigationState) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                navigateToPrevious(from: navigationState)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.left")
+                    Text(locale == .ja ? "前へ" : "Back")
+                        .lineLimit(1)
+                }
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    navigationState.canGoPrevious && !isNavigating
+                        ? Color(hex: "2563eb")
+                        : Color(hex: "475569")
+                )
+                .cornerRadius(10)
+            }
+            .disabled(!navigationState.canGoPrevious || isNavigating || onSelectLesson == nil)
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "house.fill")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 40)
+                    .background(Color(hex: "475569"))
+                    .cornerRadius(10)
+            }
+            .accessibilityLabel(locale == .ja ? "クエスト一覧に戻る" : "Back to quest list")
+
+            Button {
+                navigateToNext(from: navigationState)
+            } label: {
+                HStack(spacing: 6) {
+                    Text(locale == .ja ? "次へ" : "Next")
+                        .lineLimit(1)
+                    Image(systemName: "chevron.right")
+                }
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    navigationState.canGoNext && !isNavigating
+                        ? Color(hex: "16a34a")
+                        : Color(hex: "475569")
+                )
+                .cornerRadius(10)
+            }
+            .disabled(!navigationState.canGoNext || isNavigating || onSelectLesson == nil)
+        }
+    }
+
+    private func navigateToPrevious(from navigationState: LessonNavigationState) {
+        guard !isNavigating else { return }
+        guard navigationState.canGoPrevious, let previous = navigationState.previousLesson else {
+            alertMessage = LessonNavigationHelpers.navigationBlockedMessage(
+                direction: .previous,
+                reason: navigationState.previousBlockedReason,
+                locale: locale,
+                nextLesson: navigationState.nextLesson
+            )
+            return
+        }
+        guard let onSelectLesson else {
+            alertMessage = locale == .ja ? "前のクエストへ移動できません。" : "Unable to open the previous quest."
+            return
+        }
+        isNavigating = true
+        onSelectLesson(previous)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            isNavigating = false
+        }
+    }
+
+    private func navigateToNext(from navigationState: LessonNavigationState) {
+        guard !isNavigating else { return }
+        guard navigationState.canGoNext, let next = navigationState.nextLesson else {
+            if navigationState.nextBlockedReason == .premiumRequired {
+                Task {
+                    let premium = await appState.ensureFreshBilling()
+                    if !premium {
+                        await MainActor.run { showSubscriptionSheet = true }
+                    }
+                }
+            }
+            alertMessage = LessonNavigationHelpers.navigationBlockedMessage(
+                direction: .next,
+                reason: navigationState.nextBlockedReason,
+                locale: locale,
+                nextLesson: navigationState.nextLesson
+            )
+            return
+        }
+        guard let onSelectLesson else {
+            alertMessage = locale == .ja ? "次のクエストへ移動できません。" : "Unable to open the next quest."
+            return
+        }
+        isNavigating = true
+        onSelectLesson(next)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            isNavigating = false
         }
     }
 

--- a/ios/Jazzify/Main/LessonNavigationHelpers.swift
+++ b/ios/Jazzify/Main/LessonNavigationHelpers.swift
@@ -7,6 +7,23 @@ enum QuestCompletionModalKind: Equatable {
     case none
 }
 
+enum NavigationBlockedReason: Equatable {
+    case firstLesson
+    case lastLesson
+    case sequentialLock
+    case previousBlockIncomplete
+    case premiumRequired
+}
+
+struct LessonNavigationState: Equatable {
+    let previousLesson: Lesson?
+    let nextLesson: Lesson?
+    let canGoPrevious: Bool
+    let canGoNext: Bool
+    let previousBlockedReason: NavigationBlockedReason?
+    let nextBlockedReason: NavigationBlockedReason?
+}
+
 enum LessonNavigationHelpers {
     static func sortLessonsByOrder(_ lessons: [Lesson]) -> [Lesson] {
         lessons.sorted { lhs, rhs in
@@ -14,6 +31,128 @@ enum LessonNavigationHelpers {
             let rightBlock = rhs.blockNumber ?? 1
             if leftBlock != rightBlock { return leftBlock < rightBlock }
             return lhs.orderIndex < rhs.orderIndex
+        }
+    }
+
+    static func buildAccessGraph(
+        lessons: [Lesson],
+        completedIds: Set<UUID>,
+        isMainQuest: Bool,
+        isPremium: Bool
+    ) -> LessonJourneyAccessGraph {
+        let sorted = sortLessonsByOrder(lessons)
+        var graph = LessonJourneyAccessGraph.build(
+            lessons: sorted,
+            completedIds: completedIds,
+            enforceSequentialWithinBlocks: isMainQuest
+        )
+        if isMainQuest {
+            graph = MainQuestFreeTier.applyLocks(graph: graph, lessons: sorted, isPremium: isPremium)
+        }
+        return graph
+    }
+
+    static func computeNavigationState(
+        currentLesson: Lesson,
+        lessons: [Lesson],
+        completedIds: Set<UUID>,
+        isMainQuest: Bool,
+        isPremium: Bool
+    ) -> LessonNavigationState {
+        let sorted = sortLessonsByOrder(lessons)
+        guard let currentIndex = sorted.firstIndex(where: { $0.id == currentLesson.id }) else {
+            return LessonNavigationState(
+                previousLesson: nil,
+                nextLesson: nil,
+                canGoPrevious: false,
+                canGoNext: false,
+                previousBlockedReason: nil,
+                nextBlockedReason: nil
+            )
+        }
+
+        let previousLesson = currentIndex > 0 ? sorted[currentIndex - 1] : nil
+        let nextLesson = currentIndex < sorted.count - 1 ? sorted[currentIndex + 1] : nil
+
+        let baseGraph = LessonJourneyAccessGraph.build(
+            lessons: sorted,
+            completedIds: completedIds,
+            enforceSequentialWithinBlocks: isMainQuest
+        )
+        let accessGraph = buildAccessGraph(
+            lessons: lessons,
+            completedIds: completedIds,
+            isMainQuest: isMainQuest,
+            isPremium: isPremium
+        )
+
+        let canGoPrevious = previousLesson.map { accessGraph.lessonStates[$0.id]?.isUnlocked == true } ?? false
+        let canGoNext = nextLesson.map { accessGraph.lessonStates[$0.id]?.isUnlocked == true } ?? false
+
+        return LessonNavigationState(
+            previousLesson: previousLesson,
+            nextLesson: nextLesson,
+            canGoPrevious: previousLesson != nil && canGoPrevious,
+            canGoNext: nextLesson != nil && canGoNext,
+            previousBlockedReason: resolvePreviousBlockedReason(
+                previousLesson: previousLesson,
+                canGoPrevious: previousLesson != nil && canGoPrevious
+            ),
+            nextBlockedReason: resolveNextBlockedReason(
+                currentLesson: currentLesson,
+                nextLesson: nextLesson,
+                canGoNext: nextLesson != nil && canGoNext,
+                baseGraph: baseGraph,
+                completedIds: completedIds,
+                isMainQuest: isMainQuest,
+                isPremium: isPremium
+            )
+        )
+    }
+
+    static func navigationBlockedMessage(
+        direction: NavigationDirection,
+        reason: NavigationBlockedReason?,
+        locale: AppLocale,
+        nextLesson: Lesson?
+    ) -> String {
+        let resolvedReason: NavigationBlockedReason
+        switch direction {
+        case .previous:
+            resolvedReason = reason ?? .sequentialLock
+        case .next:
+            resolvedReason = reason ?? .previousBlockIncomplete
+        }
+
+        switch resolvedReason {
+        case .firstLesson:
+            return locale == .ja
+                ? "これがコースの最初のクエストです。"
+                : "This is the first quest in the course."
+        case .lastLesson:
+            return locale == .ja
+                ? "これがコースの最後のクエストです。すべてのクエストを完了されました！"
+                : "This is the last quest. You have finished the course!"
+        case .sequentialLock:
+            return locale == .ja
+                ? "先に現在のクエストを完了してください。"
+                : "Complete the current quest before moving to the next one."
+        case .premiumRequired:
+            return locale == .ja
+                ? "メインクエスト第2チャプター以降はプレミアムが必要です。"
+                : "Main Quest chapters after Chapter 1 require Premium."
+        case .previousBlockIncomplete:
+            if let nextLesson {
+                let blockLabel = locale == .ja
+                    ? "ブロック \(nextLesson.blockNumber ?? 1)"
+                    : "Block \(nextLesson.blockNumber ?? 1)"
+                return locale == .ja
+                    ? "次のクエスト（\(blockLabel)）はまだ解放されていません。前のブロックの全クエストを完了してください。"
+                    : "The next quest (\(blockLabel)) is still locked. Complete every quest in the previous block first."
+            }
+            return locale == .ja
+                ? "次のクエストはまだ解放されていません。現在のブロックの全クエストを完了してください。"
+                : "The next quest is still locked. Complete every quest in the current block first."
         }
     }
 
@@ -64,6 +203,60 @@ enum LessonNavigationHelpers {
     ) -> Bool {
         accessGraph.lessonStates[nextLesson.id]?.isUnlocked == true
     }
+
+    private static func resolvePreviousBlockedReason(
+        previousLesson: Lesson?,
+        canGoPrevious: Bool
+    ) -> NavigationBlockedReason? {
+        if previousLesson == nil {
+            return .firstLesson
+        }
+        if canGoPrevious {
+            return nil
+        }
+        return .sequentialLock
+    }
+
+    private static func resolveNextBlockedReason(
+        currentLesson: Lesson,
+        nextLesson: Lesson?,
+        canGoNext: Bool,
+        baseGraph: LessonJourneyAccessGraph,
+        completedIds: Set<UUID>,
+        isMainQuest: Bool,
+        isPremium: Bool
+    ) -> NavigationBlockedReason? {
+        guard let nextLesson else {
+            return .lastLesson
+        }
+        if canGoNext {
+            return nil
+        }
+
+        let nextBlockNumber = nextLesson.blockNumber ?? 1
+        if isMainQuest && !MainQuestFreeTier.isBlockPlayable(isPremium: isPremium, blockNumber: nextBlockNumber) {
+            return .premiumRequired
+        }
+
+        let nextBlockUnlocked = baseGraph.blockStates[nextBlockNumber]?.isUnlocked == true
+        if !nextBlockUnlocked {
+            return .previousBlockIncomplete
+        }
+
+        let currentBlockNumber = currentLesson.blockNumber ?? 1
+        if isMainQuest
+            && currentBlockNumber == nextBlockNumber
+            && !completedIds.contains(currentLesson.id) {
+            return .sequentialLock
+        }
+
+        return .previousBlockIncomplete
+    }
+}
+
+enum NavigationDirection {
+    case previous
+    case next
 }
 
 /// メインクエスト画面の目的別コースプレビュー（uuid_generate_v5(ns, 'course-chord-run-beginner')）

--- a/ios/Jazzify/Main/TopView.swift
+++ b/ios/Jazzify/Main/TopView.swift
@@ -57,7 +57,9 @@ struct TopView: View {
                 Group {
                     if let lesson = mainQuestLessonToOpen {
                         if appState.isPremium || (lesson.blockNumber ?? 1) <= MainQuestFreeTier.maxFreeBlockNumber {
-                            LessonDetailView(lesson: lesson)
+                            LessonDetailView(lesson: lesson) { nextLesson in
+                                mainQuestLessonToOpen = nextLesson
+                            }
                         } else {
                             Color.clear
                                 .frame(width: 0, height: 0)

--- a/ios/JazzifyTests/LessonNavigationHelpersTests.swift
+++ b/ios/JazzifyTests/LessonNavigationHelpersTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Jazzify
+
+final class LessonNavigationHelpersTests: XCTestCase {
+    private let courseId = UUID()
+
+    private func makeLesson(
+        id: UUID = UUID(),
+        orderIndex: Int,
+        blockNumber: Int = 1
+    ) -> Lesson {
+        Lesson(
+            id: id,
+            courseId: courseId,
+            title: "Lesson",
+            titleEn: nil,
+            description: nil,
+            descriptionEn: nil,
+            orderIndex: orderIndex,
+            premiumOnly: nil,
+            blockNumber: blockNumber,
+            blockName: nil,
+            blockNameEn: nil,
+            blockDescription: nil,
+            blockDescriptionEn: nil,
+            manualCompletionDisabled: nil
+        )
+    }
+
+    func testMainQuestSequentialLockBlocksNextWithoutCompletion() {
+        let first = makeLesson(orderIndex: 0, blockNumber: 1)
+        let second = makeLesson(orderIndex: 1, blockNumber: 1)
+
+        let state = LessonNavigationHelpers.computeNavigationState(
+            currentLesson: first,
+            lessons: [first, second],
+            completedIds: [],
+            isMainQuest: true,
+            isPremium: true
+        )
+
+        XCTAssertEqual(state.nextLesson?.id, second.id)
+        XCTAssertFalse(state.canGoNext)
+        XCTAssertEqual(state.nextBlockedReason, .sequentialLock)
+    }
+
+    func testMainQuestAllowsNextAfterCurrentCompletion() {
+        let first = makeLesson(orderIndex: 0, blockNumber: 1)
+        let second = makeLesson(orderIndex: 1, blockNumber: 1)
+
+        let state = LessonNavigationHelpers.computeNavigationState(
+            currentLesson: first,
+            lessons: [first, second],
+            completedIds: [first.id],
+            isMainQuest: true,
+            isPremium: true
+        )
+
+        XCTAssertTrue(state.canGoNext)
+        XCTAssertNil(state.nextBlockedReason)
+    }
+
+    func testMainQuestFreeUserBlockedFromSecondChapter() {
+        let block1Last = makeLesson(orderIndex: 1, blockNumber: 1)
+        let block2First = makeLesson(orderIndex: 2, blockNumber: 2)
+        let block1First = makeLesson(orderIndex: 0, blockNumber: 1)
+
+        let state = LessonNavigationHelpers.computeNavigationState(
+            currentLesson: block1Last,
+            lessons: [block1First, block1Last, block2First],
+            completedIds: [block1First.id, block1Last.id],
+            isMainQuest: true,
+            isPremium: false
+        )
+
+        XCTAssertEqual(state.nextLesson?.id, block2First.id)
+        XCTAssertFalse(state.canGoNext)
+        XCTAssertEqual(state.nextBlockedReason, .premiumRequired)
+    }
+
+    func testPurposeCourseAllowsSkippingWithinUnlockedBlock() {
+        let first = makeLesson(orderIndex: 0, blockNumber: 1)
+        let second = makeLesson(orderIndex: 1, blockNumber: 1)
+
+        let state = LessonNavigationHelpers.computeNavigationState(
+            currentLesson: first,
+            lessons: [first, second],
+            completedIds: [],
+            isMainQuest: false,
+            isPremium: false
+        )
+
+        XCTAssertTrue(state.canGoNext)
+        XCTAssertNil(state.nextBlockedReason)
+    }
+}

--- a/src/utils/__tests__/lessonNavigation.test.ts
+++ b/src/utils/__tests__/lessonNavigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Lesson, LessonProgress } from '@/types';
 import {
   computeLessonNavigationInfo,
+  getNavigationErrorMessage,
   getQuestCompletionModalKind,
   isLastLessonInBlock,
   sortLessonsByOrder,
@@ -31,6 +32,8 @@ const navInfo = (
   nextLesson: next,
   canGoPrevious: false,
   canGoNext,
+  previousBlockedReason: null,
+  nextBlockedReason: canGoNext ? null : 'sequential_lock',
   course: {
     id: 'course-1',
     hasAccessToPrevious: false,
@@ -53,6 +56,7 @@ describe('computeLessonNavigationInfo', () => {
     );
     expect(result.nextLesson?.id).toBe('l2');
     expect(result.canGoNext).toBe(false);
+    expect(result.nextBlockedReason).toBe('sequential_lock');
   });
 
   it('メインクエスト: block1 lesson1 完了 → lesson2 へ進める', () => {
@@ -83,6 +87,7 @@ describe('computeLessonNavigationInfo', () => {
     );
     expect(result.nextLesson?.id).toBe('b2-first');
     expect(result.canGoNext).toBe(false);
+    expect(result.nextBlockedReason).toBe('premium_required');
   });
 
   it('目的別コース: 同一ブロック内は順番未完了でも次へ進める', () => {
@@ -119,6 +124,38 @@ describe('computeLessonNavigationInfo', () => {
     );
     expect(result.previousLesson).toBeNull();
     expect(result.canGoPrevious).toBe(false);
+    expect(result.previousBlockedReason).toBe('first_lesson');
+  });
+});
+
+describe('getNavigationErrorMessage', () => {
+  it('順番ロック時は専用メッセージを返す', () => {
+    const first = lesson('l1', 0, 1);
+    const second = lesson('l2', 1, 1);
+    const info = computeLessonNavigationInfo(
+      'l1',
+      'course-1',
+      [first, second],
+      {},
+      { isMainQuest: true, isPremiumMember: true },
+    );
+    expect(getNavigationErrorMessage('next', info, false)).toContain('現在のクエストを完了');
+  });
+
+  it('無料ロック時はプレミアムメッセージを返す', () => {
+    const block1Last = lesson('b1-last', 1, 1);
+    const block2First = lesson('b2-first', 2, 2);
+    const info = computeLessonNavigationInfo(
+      'b1-last',
+      'course-1',
+      [lesson('b1-first', 0, 1), block1Last, block2First],
+      {
+        'b1-first': progress('b1-first', true),
+        'b1-last': progress('b1-last', true),
+      },
+      { isMainQuest: true, isPremiumMember: false },
+    );
+    expect(getNavigationErrorMessage('next', info, false)).toContain('プレミアム');
   });
 });
 

--- a/src/utils/lessonNavigation.ts
+++ b/src/utils/lessonNavigation.ts
@@ -4,13 +4,22 @@ import { fetchLessonsByCourse } from '@/platform/supabaseLessons';
 import { fetchUserLessonProgress } from '@/platform/supabaseLessonProgress';
 import { clearCacheByPattern } from '@/platform/supabaseClient';
 import { buildLessonAccessGraph, MembershipRank } from '@/utils/lessonAccess';
-import { applyMainQuestFreeTierLocks } from '@/utils/mainQuestFreeTier';
+import { applyMainQuestFreeTierLocks, isMainQuestBlockPlayable } from '@/utils/mainQuestFreeTier';
+
+export type NavigationBlockedReason =
+  | 'first_lesson'
+  | 'last_lesson'
+  | 'sequential_lock'
+  | 'previous_block_incomplete'
+  | 'premium_required';
 
 export interface LessonNavigationInfo {
   previousLesson: Lesson | null;
   nextLesson: Lesson | null;
   canGoPrevious: boolean;
   canGoNext: boolean;
+  previousBlockedReason: NavigationBlockedReason | null;
+  nextBlockedReason: NavigationBlockedReason | null;
   course: {
     id: string;
     hasAccessToPrevious: boolean;
@@ -106,6 +115,59 @@ function buildNavigationCacheKey(
   ].join(':');
 }
 
+function resolvePreviousBlockedReason(
+  previousLesson: Lesson | null,
+  canGoPrevious: boolean,
+): NavigationBlockedReason | null {
+  if (previousLesson === null) {
+    return 'first_lesson';
+  }
+  if (canGoPrevious) {
+    return null;
+  }
+  return 'sequential_lock';
+}
+
+function resolveNextBlockedReason(
+  currentLesson: Lesson,
+  nextLesson: Lesson | null,
+  canGoNext: boolean,
+  baseAccessGraph: ReturnType<typeof buildLessonAccessGraph>,
+  completedIds: Set<string>,
+  options: { isMainQuest: boolean; isPremiumMember: boolean },
+): NavigationBlockedReason | null {
+  if (nextLesson === null) {
+    return 'last_lesson';
+  }
+  if (canGoNext) {
+    return null;
+  }
+
+  const nextBlockNumber = nextLesson.block_number ?? 1;
+  if (
+    options.isMainQuest
+    && !isMainQuestBlockPlayable(nextBlockNumber, options.isPremiumMember)
+  ) {
+    return 'premium_required';
+  }
+
+  const nextBlockUnlocked = baseAccessGraph.blockStates[nextBlockNumber]?.isUnlocked === true;
+  if (!nextBlockUnlocked) {
+    return 'previous_block_incomplete';
+  }
+
+  const currentBlockNumber = currentLesson.block_number ?? 1;
+  if (
+    options.isMainQuest
+    && currentBlockNumber === nextBlockNumber
+    && completedIds.has(currentLesson.id) !== true
+  ) {
+    return 'sequential_lock';
+  }
+
+  return 'previous_block_incomplete';
+}
+
 /**
  * レッスン一覧と進捗からナビゲーション情報を算出（純粋関数）
  */
@@ -126,12 +188,13 @@ export function computeLessonNavigationInfo(
   const previousLesson = currentIndex > 0 ? sortedLessons[currentIndex - 1] : null;
   const nextLesson = currentIndex < sortedLessons.length - 1 ? sortedLessons[currentIndex + 1] : null;
 
-  let accessGraph = buildLessonAccessGraph({
+  const baseAccessGraph = buildLessonAccessGraph({
     lessons: sortedLessons,
     progressMap,
     enforceSequentialWithinBlocks: options.isMainQuest,
   });
 
+  let accessGraph = baseAccessGraph;
   if (options.isMainQuest) {
     accessGraph = applyMainQuestFreeTierLocks(
       accessGraph,
@@ -148,11 +211,28 @@ export function computeLessonNavigationInfo(
     ? accessGraph.lessonStates[nextLesson.id]?.isUnlocked === true
     : false;
 
+  const canGoPrevious = previousLesson !== null && hasAccessToPrevious;
+  const canGoNext = nextLesson !== null && hasAccessToNext;
+  const completedIds = new Set(
+    Object.entries(progressMap)
+      .filter(([, progress]) => progress?.completed === true)
+      .map(([lessonId]) => lessonId),
+  );
+
   return {
     previousLesson,
     nextLesson,
-    canGoPrevious: previousLesson !== null && hasAccessToPrevious,
-    canGoNext: nextLesson !== null && hasAccessToNext,
+    canGoPrevious,
+    canGoNext,
+    previousBlockedReason: resolvePreviousBlockedReason(previousLesson, canGoPrevious),
+    nextBlockedReason: resolveNextBlockedReason(
+      sortedLessons[currentIndex],
+      nextLesson,
+      canGoNext,
+      baseAccessGraph,
+      completedIds,
+      options,
+    ),
     course: {
       id: courseId,
       hasAccessToPrevious,
@@ -229,29 +309,29 @@ export async function getLessonNavigationInfo(
 /**
  * レッスンナビゲーションのエラーメッセージを取得
  */
-export function getNavigationErrorMessage(
-  direction: 'previous' | 'next',
+function blockedReasonMessage(
+  reason: NavigationBlockedReason,
   navigationInfo: LessonNavigationInfo,
-  isEnglishCopy = false,
+  isEnglishCopy: boolean,
 ): string {
-  if (direction === 'previous') {
-    if (!navigationInfo.previousLesson) {
+  switch (reason) {
+    case 'first_lesson':
       return isEnglishCopy
         ? 'This is the first quest in the course.'
         : 'これがコースの最初のクエストです。';
-    }
-    if (!navigationInfo.course.hasAccessToPrevious) {
-      return isEnglishCopy
-        ? 'You cannot open the previous quest. It may still be locked.'
-        : '前のクエストにアクセスできません。クエストが解放されていない可能性があります。';
-    }
-  } else {
-    if (!navigationInfo.nextLesson) {
+    case 'last_lesson':
       return isEnglishCopy
         ? 'This is the last quest. You have finished the course!'
         : 'これがコースの最後のクエストです。すべてのクエストを完了されました！';
-    }
-    if (!navigationInfo.course.hasAccessToNext) {
+    case 'sequential_lock':
+      return isEnglishCopy
+        ? 'Complete the current quest before moving to the next one.'
+        : '先に現在のクエストを完了してください。';
+    case 'premium_required':
+      return isEnglishCopy
+        ? 'Main Quest chapters after Chapter 1 require Premium.'
+        : 'メインクエスト第2チャプター以降はプレミアムが必要です。';
+    case 'previous_block_incomplete': {
       const blockInfo = navigationInfo.nextLesson
         ? getLessonBlockInfo(navigationInfo.nextLesson, { isEnglishCopy })
         : null;
@@ -265,7 +345,26 @@ export function getNavigationErrorMessage(
         : '次のクエストはまだ解放されていません。現在のブロックの全クエストを完了してください。';
     }
   }
-  return '';
+}
+
+export function getNavigationErrorMessage(
+  direction: 'previous' | 'next',
+  navigationInfo: LessonNavigationInfo,
+  isEnglishCopy = false,
+): string {
+  if (direction === 'previous') {
+    if (navigationInfo.canGoPrevious) {
+      return '';
+    }
+    const reason = navigationInfo.previousBlockedReason ?? 'sequential_lock';
+    return blockedReasonMessage(reason, navigationInfo, isEnglishCopy);
+  }
+
+  if (navigationInfo.canGoNext) {
+    return '';
+  }
+  const reason = navigationInfo.nextBlockedReason ?? 'previous_block_incomplete';
+  return blockedReasonMessage(reason, navigationInfo, isEnglishCopy);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Web版・Swift版のレッスン詳細画面ナビゲーションを、一覧画面と同じロック判定に揃えました。Swift版には Web と同等の上部ナビ（前へ／一覧へ／次へ）を追加し、ロック理由に応じたメッセージ（`nextBlockedReason` / `previousBlockedReason`）も導入しています。

## Web 変更

- `computeLessonNavigationInfo` に `NavigationBlockedReason` を追加
- `getNavigationErrorMessage` が順番ロック・無料ロック・ブロック未完了を区別して表示
- 詳細画面ナビはメインクエストで `enforceSequentialWithinBlocks` + `applyMainQuestFreeTierLocks` を適用

## Swift 変更

- `LessonNavigationState` / `NavigationBlockedReason` を `LessonNavigationHelpers` に追加
- `LessonDetailView` 上部に前後ナビバーを追加（`summaryCard` の上）
- 詳細ロード時・完了後モーダルで一覧と同じロック判定を使用
- `LessonJourneyView` / `TopView` から `onSelectLesson` を渡し、前後遷移を可能に
- レッスン ID 変更時に詳細・ナビ状態を再読込

## テスト

**Web**
- メインクエスト順番ロック
- フリー会員の第2チャプター制限
- 目的別コースの同一ブロック内スキップ
- エラーメッセージの種別

**Swift**
- `LessonNavigationHelpersTests` を追加

## パフォーマンス影響

- 新規 per-frame ロジック: なし
- 新規 timer/interval: なし（ナビ二重タップ防止の 0.35s 遅延のみ）
- 高頻度 React/SwiftUI state 更新: なし
- hot path での新規 allocation: なし（詳細ロード・完了・ナビタップ時のみ）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c8cd99-2e29-4f4e-83ed-77d2323402e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c8cd99-2e29-4f4e-83ed-77d2323402e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

